### PR TITLE
fix:  production deployment postgress error

### DIFF
--- a/infra/production/docker-compose.prod.yml
+++ b/infra/production/docker-compose.prod.yml
@@ -49,7 +49,7 @@ services:
       POSTGRES_PASSWORD: ${PROD_DB_PASSWORD}
       POSTGRES_DB: ${PROD_DB_NAME}
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
     networks:
       - app_network
     healthcheck:


### PR DESCRIPTION
## Description
Fixes the startup error caused by mounting the wrong PostgreSQL data directory in version 18+.

## Changes
- Updated volume mount from `/var/lib/postgresql/data` to `/var/lib/postgresql`

## Result
PostgreSQL 18 now starts correctly without data directory conflicts.