### PR TITLE
ci: fix Dependabot PR permissions for preview comments

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, closed]
 
+# Explicit permissions needed for Dependabot and fork PRs to post comments
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
 jobs:
   preview:
     if: github.event.action != 'closed'
@@ -12,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Check Docker availability
         run: |
@@ -95,7 +101,7 @@ jobs:
     environment: preview
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Generate env files (composite action)
         uses: ./.github/actions/generate-preview-env


### PR DESCRIPTION

  Fixes #65

  Dependabot PRs were failing because they couldn't post preview comments due to token permissions.

  Added explicit permissions so Dependabot (and forks) can post comments on PRs. Also bumped checkout to v4 while we're at it.

  Changes:
  - `permissions: contents: read, pull-requests: write, issues: write`
  - `actions/checkout@v3` → `v4`