### PR TITLE
feat: Implementing Halls, Spaces endpoints

### DIFF
--- a/backend/database/src/repos/hall.rs
+++ b/backend/database/src/repos/hall.rs
@@ -32,4 +32,17 @@ impl<'a> HallRepo<'a> {
     pub async fn insert(&self, hall: HallCreate) -> Result<Hall, DatabaseError> {
         Ok(hall.insert(self.db).await?)
     }
+
+    pub async fn update(&self, hall: Hall) -> Result<Hall, DatabaseError> {
+        Ok(hall.update_all_fields(self.db).await?)
+    }
+
+    pub async fn delete(&self, id: Uuid) -> Result<(), DatabaseError> {
+        sqlx::query("DELETE FROM halls WHERE id = $1")
+            .bind(id)
+            .execute(self.db)
+            .await?;
+
+        Ok(())
+    }
 }

--- a/backend/database/src/repos/location.rs
+++ b/backend/database/src/repos/location.rs
@@ -41,4 +41,17 @@ impl<'a> LocationRepo<'a> {
             .await?
             .ok_or(DatabaseError::NotFound)
     }
+
+    pub async fn update(&self, location: Location) -> Result<Location, DatabaseError> {
+        Ok(location.update_all_fields(self.db).await?)
+    }
+
+    pub async fn delete(&self, id: Uuid) -> Result<(), DatabaseError> {
+        sqlx::query("DELETE FROM locations WHERE id = $1")
+            .bind(id)
+            .execute(self.db)
+            .await?;
+
+        Ok(())
+    }
 }

--- a/backend/database/src/repos/space.rs
+++ b/backend/database/src/repos/space.rs
@@ -40,4 +40,17 @@ impl<'a> SpaceRepo<'a> {
             .fetch_optional(self.db)
             .await?)
     }
+
+    pub async fn update(&self, space: Space) -> Result<Space, DatabaseError> {
+        Ok(space.update_all_fields(self.db).await?)
+    }
+
+    pub async fn delete(&self, id: Uuid) -> Result<(), DatabaseError> {
+        sqlx::query("DELETE FROM spaces WHERE id = $1")
+            .bind(id)
+            .execute(self.db)
+            .await?;
+
+        Ok(())
+    }
 }

--- a/backend/migrations/20260312141953_cascade_delete_spaces_and_locations.down.sql
+++ b/backend/migrations/20260312141953_cascade_delete_spaces_and_locations.down.sql
@@ -1,0 +1,17 @@
+-- revert halls -> spaces
+ALTER TABLE halls
+DROP CONSTRAINT IF EXISTS halls_space_id_fkey;
+
+ALTER TABLE halls
+ADD CONSTRAINT halls_space_id_fkey
+FOREIGN KEY (space_id)
+REFERENCES spaces(id);
+
+-- revert spaces -> locations
+ALTER TABLE spaces
+DROP CONSTRAINT IF EXISTS spaces_location_id_fkey;
+
+ALTER TABLE spaces
+ADD CONSTRAINT spaces_location_id_fkey
+FOREIGN KEY (location_id)
+REFERENCES locations(id);

--- a/backend/migrations/20260312141953_cascade_delete_spaces_and_locations.up.sql
+++ b/backend/migrations/20260312141953_cascade_delete_spaces_and_locations.up.sql
@@ -1,0 +1,19 @@
+-- halls -> spaces
+ALTER TABLE halls
+DROP CONSTRAINT IF EXISTS halls_space_id_fkey;
+
+ALTER TABLE halls
+ADD CONSTRAINT halls_space_id_fkey
+FOREIGN KEY (space_id)
+REFERENCES spaces(id)
+ON DELETE CASCADE;
+
+-- spaces -> locations
+ALTER TABLE spaces
+DROP CONSTRAINT IF EXISTS spaces_location_id_fkey;
+
+ALTER TABLE spaces
+ADD CONSTRAINT spaces_location_id_fkey
+FOREIGN KEY (location_id)
+REFERENCES locations(id)
+ON DELETE CASCADE;

--- a/backend/src/dto/hall.rs
+++ b/backend/src/dto/hall.rs
@@ -1,0 +1,75 @@
+use database::{
+    Database,
+    models::hall::{Hall, HallCreate},
+};
+use o2o::o2o;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use crate::error::AppError;
+
+impl HallPayload {
+    pub async fn all(db: &Database, limit: usize) -> Result<Vec<Self>, AppError> {
+        Ok(db
+            .halls()
+            .all(limit)
+            .await?
+            .into_iter()
+            .map(Self::from)
+            .collect())
+    }
+
+    pub async fn by_id(db: &Database, id: Uuid) -> Result<Self, AppError> {
+        Ok(db.halls().by_id(id).await?.into())
+    }
+
+    pub async fn update(self, db: &Database) -> Result<Self, AppError> {
+        Ok(db.halls().update(self.into()).await?.into())
+    }
+
+    pub async fn delete(db: &Database, id: Uuid) -> Result<(), AppError> {
+        Ok(db.halls().delete(id).await?)
+    }
+}
+
+impl HallPostPayload {
+    pub async fn create(self, db: &Database) -> Result<HallPayload, AppError> {
+        Ok(db.halls().insert(self.into()).await?.into())
+    }
+}
+
+#[derive(o2o, Serialize, Deserialize, ToSchema)]
+#[map_owned(Hall)]
+pub struct HallPayload {
+    pub id: Uuid,
+
+    pub source_id: Option<i32>,
+
+    pub vendor_id: Option<String>,
+    pub box_office_id: Option<String>,
+    pub seat_selection: Option<bool>,
+    pub open_seating: Option<bool>,
+    pub name: String,
+    pub remark: Option<String>,
+    pub slug: String,
+
+    pub space_id: Option<Uuid>,
+}
+
+#[derive(o2o, Deserialize, ToSchema)]
+#[owned_into(HallCreate)]
+pub struct HallPostPayload {
+    pub source_id: Option<i32>,
+    pub slug: String,
+
+    pub vendor_id: Option<String>,
+    pub box_office_id: Option<String>,
+    pub seat_selection: Option<bool>,
+    pub open_seating: Option<bool>,
+    pub name: String,
+    pub remark: Option<String>,
+
+    // reference to space
+    pub space_id: Option<Uuid>,
+}

--- a/backend/src/dto/location.rs
+++ b/backend/src/dto/location.rs
@@ -1,16 +1,36 @@
 use database::{Database, models::location::Location};
 use o2o::o2o;
-use serde::Serialize;
+use serde::{Serialize, Deserialize};
 use utoipa::ToSchema;
 use uuid::Uuid;
 
+use database::models::location::LocationCreate;
+
 use crate::error::AppError;
 
-#[derive(o2o, Serialize, ToSchema)]
-#[from_owned(Location)]
+#[derive(o2o, Serialize, Deserialize, ToSchema)]
+#[map_owned(Location)]
 pub struct LocationPayload {
     pub id: Uuid,
 
+    pub source_id: Option<i32>,
+
+    pub name: Option<String>,
+    pub code: Option<String>,
+    pub street: Option<String>,
+    pub number: Option<String>,
+    pub postal_code: Option<String>,
+    pub city: Option<String>,
+    pub country: Option<String>,
+    pub phone_1: Option<String>,
+    pub phone_2: Option<String>,
+    pub is_owned_by_viernulvier: Option<bool>,
+    pub uitdatabank_id: Option<String>,
+}
+
+#[derive(o2o, Deserialize, ToSchema)]
+#[owned_into(LocationCreate)]
+pub struct LocationPostPayload {
     pub source_id: Option<i32>,
 
     pub name: Option<String>,
@@ -42,5 +62,19 @@ impl LocationPayload {
                 .by_id(id)
                 .await?
         ))
+    }
+
+    pub async fn update(self, db: &Database) -> Result<Self, AppError> {
+        Ok(db.locations().update(self.into()).await?.into())
+    }
+
+    pub async fn delete(db: &Database, id: Uuid) -> Result<(), AppError> {
+        Ok(db.locations().delete(id).await?)
+    }
+}
+
+impl LocationPostPayload {
+    pub async fn create(self, db: &Database) -> Result<LocationPayload, AppError> {
+        Ok(db.locations().insert(self.into()).await?.into())
     }
 }

--- a/backend/src/dto/mod.rs
+++ b/backend/src/dto/mod.rs
@@ -1,3 +1,4 @@
 pub mod hall;
 pub mod location;
 pub mod production;
+pub mod space;

--- a/backend/src/dto/mod.rs
+++ b/backend/src/dto/mod.rs
@@ -1,2 +1,3 @@
-pub mod production;
+pub mod hall;
 pub mod location;
+pub mod production;

--- a/backend/src/dto/space.rs
+++ b/backend/src/dto/space.rs
@@ -1,0 +1,59 @@
+use database::{
+    Database,
+    models::space::{Space, SpaceCreate},
+};
+use o2o::o2o;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use crate::error::AppError;
+
+impl SpacePayload {
+    pub async fn all(db: &Database, limit: usize) -> Result<Vec<Self>, AppError> {
+        Ok(db
+            .spaces()
+            .all(limit)
+            .await?
+            .into_iter()
+            .map(Self::from)
+            .collect())
+    }
+
+    pub async fn by_id(db: &Database, id: Uuid) -> Result<Self, AppError> {
+        Ok(db.spaces().by_id(id).await?.into())
+    }
+
+    pub async fn update(self, db: &Database) -> Result<Self, AppError> {
+        Ok(db.spaces().update(self.into()).await?.into())
+    }
+
+    pub async fn delete(db: &Database, id: Uuid) -> Result<(), AppError> {
+        Ok(db.spaces().delete(id).await?)
+    }
+}
+
+impl SpacePostPayload {
+    pub async fn create(self, db: &Database) -> Result<SpacePayload, AppError> {
+        Ok(db.spaces().insert(self.into()).await?.into())
+    }
+}
+
+#[derive(o2o, Serialize, Deserialize, ToSchema)]
+#[map_owned(Space)]
+pub struct SpacePayload {
+    pub id: Uuid,
+
+    pub source_id: Option<i32>,
+    pub name_nl: String,
+    pub location_id: Uuid,
+}
+
+#[derive(o2o, Deserialize, ToSchema)]
+#[owned_into(SpaceCreate)]
+pub struct SpacePostPayload {
+    pub source_id: Option<i32>,
+    pub name_nl: String,
+    pub location_id: Uuid,
+}
+

--- a/backend/src/handlers/admin.rs
+++ b/backend/src/handlers/admin.rs
@@ -12,6 +12,7 @@ pub struct AdminResponse {
 #[utoipa::path(
     method(get),
     path = "/admin/me",
+    operation_id = "get_admin_info",
     tag = "Admin",
     description = "Receive admin info of the logged in user",
     responses(

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -96,6 +96,7 @@ fn refresh_cookie(token: String, expiry_days: i8) -> Cookie<'static> {
     method(post),
     path = "/auth/login",
     tag = "Auth",
+    operation_id = "auth_login",
     description = "Login to the API",
     request_body = LoginRequest,
     responses(
@@ -164,6 +165,7 @@ pub async fn login(
     method(post),
     path = "/auth/refresh",
     tag = "Auth",
+    operation_id = "refresh_access_token",
     description = "Refresh the access token using the refresh cookie",
     responses(
         (status = 200, description = "Success", body = AuthResponse),
@@ -225,6 +227,7 @@ pub async fn refresh(
     method(post),
     path = "/auth/logout",
     tag = "Auth",
+    operation_id = "logout_and_invalidate_sessions",
     description = "Logout and invalidate sessions",
     responses(
         (status = 200, description = "Logged out successfully", body = AuthResponse)

--- a/backend/src/handlers/hall.rs
+++ b/backend/src/handlers/hall.rs
@@ -1,0 +1,83 @@
+use axum::{Json, extract::Path, http::StatusCode};
+use database::Database;
+use uuid::Uuid;
+
+use crate::{
+    dto::hall::{HallPayload, HallPostPayload},
+    handlers::{IntoApiResponse, JsonResponse, JsonStatusResponse, StatusResponse},
+};
+
+#[utoipa::path(
+    method(get),
+    path = "/halls",
+    tag = "Halls",
+    description = "Create a hall",
+    responses(
+        (status = 201, description = "Created", body = [HallPayload])
+    )
+)]
+pub async fn get_all(db: Database) -> JsonResponse<Vec<HallPayload>> {
+    HallPayload::all(&db, 10).await?.json()
+}
+
+#[utoipa::path(
+    method(get),
+    path = "/halls/{id}",
+    tag = "Halls",
+    description = "Get a hall by id",
+    params(
+        ("id" = Uuid, Path, description = "Hall UUID")
+    ),
+    responses(
+        (status = 200, description = "Success", body = HallPayload)
+    )
+)]
+pub async fn get_one(db: Database, Path(id): Path<Uuid>) -> JsonResponse<HallPayload> {
+    HallPayload::by_id(&db, id).await?.json()
+}
+
+#[utoipa::path(
+    method(post),
+    path = "/halls",
+    tag = "Halls",
+    description = "Create a hall",
+    responses(
+        (status = 201, description = "Created", body = HallPayload)
+    )
+)]
+pub async fn post(
+    db: Database,
+    Json(hall): Json<HallPostPayload>,
+) -> JsonStatusResponse<HallPayload> {
+    hall.create(&db).await?.json_created()
+}
+
+#[utoipa::path(
+    method(delete),
+    path = "/halls/{id}",
+    tag = "Halls",
+    description = "Delete a hall",
+    params(
+            ("id" = Uuid, Path, description = "Hall UUID")
+        ),
+    responses(
+        (status = 204, description = "No Content")
+    )
+)]
+pub async fn delete(db: Database, Path(id): Path<Uuid>) -> StatusResponse {
+    HallPayload::delete(&db, id).await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+#[utoipa::path(
+    method(put),
+    path = "/halls",
+    tag = "Halls",
+    description = "Update the fields of a hall",
+    responses(
+        (status = 200, description = "Success", body = HallPayload)
+    )
+)]
+pub async fn put(db: Database, Json(hall): Json<HallPayload>) -> JsonResponse<HallPayload> {
+    Ok(Json(hall.update(&db).await?))
+}

--- a/backend/src/handlers/hall.rs
+++ b/backend/src/handlers/hall.rs
@@ -11,9 +11,9 @@ use crate::{
     method(get),
     path = "/halls",
     tag = "Halls",
-    description = "Create a hall",
+    description = "Get all halls",
     responses(
-        (status = 201, description = "Created", body = [HallPayload])
+        (status = 201, description = "Success", body = [HallPayload])
     )
 )]
 pub async fn get_all(db: Database) -> JsonResponse<Vec<HallPayload>> {
@@ -29,7 +29,8 @@ pub async fn get_all(db: Database) -> JsonResponse<Vec<HallPayload>> {
         ("id" = Uuid, Path, description = "Hall UUID")
     ),
     responses(
-        (status = 200, description = "Success", body = HallPayload)
+        (status = 200, description = "Success", body = HallPayload),
+        (status = 404, description = "Not found")
     )
 )]
 pub async fn get_one(db: Database, Path(id): Path<Uuid>) -> JsonResponse<HallPayload> {
@@ -61,7 +62,8 @@ pub async fn post(
             ("id" = Uuid, Path, description = "Hall UUID")
         ),
     responses(
-        (status = 204, description = "No Content")
+        (status = 204, description = "No Content"),
+        (status = 404, description = "Not found")
     )
 )]
 pub async fn delete(db: Database, Path(id): Path<Uuid>) -> StatusResponse {
@@ -75,7 +77,8 @@ pub async fn delete(db: Database, Path(id): Path<Uuid>) -> StatusResponse {
     tag = "Halls",
     description = "Update the fields of a hall",
     responses(
-        (status = 200, description = "Success", body = HallPayload)
+        (status = 200, description = "Success", body = HallPayload),
+        (status = 404, description = "Not found")
     )
 )]
 pub async fn put(db: Database, Json(hall): Json<HallPayload>) -> JsonResponse<HallPayload> {

--- a/backend/src/handlers/hall.rs
+++ b/backend/src/handlers/hall.rs
@@ -11,6 +11,7 @@ use crate::{
     method(get),
     path = "/halls",
     tag = "Halls",
+    operation_id = "get_all_halls",
     description = "Get all halls",
     responses(
         (status = 200, description = "Success", body = [HallPayload])
@@ -24,6 +25,7 @@ pub async fn get_all(db: Database) -> JsonResponse<Vec<HallPayload>> {
     method(get),
     path = "/halls/{id}",
     tag = "Halls",
+    operation_id = "get_one_hall",
     description = "Get a hall by id",
     params(
         ("id" = Uuid, Path, description = "Hall UUID")
@@ -41,6 +43,7 @@ pub async fn get_one(db: Database, Path(id): Path<Uuid>) -> JsonResponse<HallPay
     method(post),
     path = "/halls",
     tag = "Halls",
+    operation_id = "create_hall",
     description = "Create a hall",
     responses(
         (status = 201, description = "Created", body = HallPayload)
@@ -57,6 +60,7 @@ pub async fn post(
     method(delete),
     path = "/halls/{id}",
     tag = "Halls",
+    operation_id = "delete_hall",
     description = "Delete a hall",
     params(
             ("id" = Uuid, Path, description = "Hall UUID")
@@ -75,6 +79,7 @@ pub async fn delete(db: Database, Path(id): Path<Uuid>) -> StatusResponse {
     method(put),
     path = "/halls",
     tag = "Halls",
+    operation_id = "update_hall",
     description = "Update the fields of a hall",
     responses(
         (status = 200, description = "Success", body = HallPayload),

--- a/backend/src/handlers/hall.rs
+++ b/backend/src/handlers/hall.rs
@@ -13,7 +13,7 @@ use crate::{
     tag = "Halls",
     description = "Get all halls",
     responses(
-        (status = 201, description = "Success", body = [HallPayload])
+        (status = 200, description = "Success", body = [HallPayload])
     )
 )]
 pub async fn get_all(db: Database) -> JsonResponse<Vec<HallPayload>> {

--- a/backend/src/handlers/location.rs
+++ b/backend/src/handlers/location.rs
@@ -11,6 +11,7 @@ use crate::{
     method(get),
     path = "/locations",
     tag = "Locations",
+    operation_id = "get_all_locations",
     description = "Get all locations",
     responses(
         (status = 200, description = "Success", body = [LocationPayload])
@@ -24,6 +25,7 @@ pub async fn get_all(db: Database) -> JsonResponse<Vec<LocationPayload>> {
     method(get),
     path = "/locations/{id}",
     tag = "Locations",
+    operation_id = "get_one_location",
     description = "Get location by id",
     params(
         ("id" = Uuid, Path, description = "Location UUID")
@@ -41,6 +43,7 @@ pub async fn get_one(db: Database, Path(id): Path<Uuid>) -> JsonResponse<Locatio
     method(post),
     path = "/locations",
     tag = "Locations",
+    operation_id = "create_location",
     description = "Create a location",
     responses(
         (status = 201, description = "Created", body = LocationPayload)
@@ -57,6 +60,7 @@ pub async fn post(
     method(delete),
     path = "/locations/{id}",
     tag = "Locations",
+    operation_id = "delete_location",
     description = "Delete a location",
     params(
             ("id" = Uuid, Path, description = "Location UUID")
@@ -75,6 +79,7 @@ pub async fn delete(db: Database, Path(id): Path<Uuid>) -> StatusResponse {
     method(put),
     path = "/locations",
     tag = "Locations",
+    operation_id = "update_location",
     description = "Update the fields of a location",
     responses(
         (status = 200, description = "Success", body = LocationPayload),

--- a/backend/src/handlers/location.rs
+++ b/backend/src/handlers/location.rs
@@ -1,10 +1,10 @@
-use axum::extract::Path;
+use axum::{Json, extract::Path, http::StatusCode};
 use database::Database;
 use uuid::Uuid;
 
 use crate::{
-    dto::location::LocationPayload,
-    handlers::{IntoApiResponse, JsonResponse},
+    dto::location::{LocationPayload, LocationPostPayload},
+    handlers::{IntoApiResponse, JsonResponse, JsonStatusResponse, StatusResponse},
 };
 
 #[utoipa::path(
@@ -16,7 +16,7 @@ use crate::{
         (status = 200, description = "Success", body = [LocationPayload])
     )
 )]
-pub async fn all(db: Database) -> JsonResponse<Vec<LocationPayload>> {
+pub async fn get_all(db: Database) -> JsonResponse<Vec<LocationPayload>> {
     LocationPayload::all(&db, 10).await?.json()
 }
 
@@ -33,6 +33,54 @@ pub async fn all(db: Database) -> JsonResponse<Vec<LocationPayload>> {
         (status = 404, description = "Not found")
     )
 )]
-pub async fn by_id(db: Database, Path(id): Path<Uuid>) -> JsonResponse<LocationPayload> {
+pub async fn get_one(db: Database, Path(id): Path<Uuid>) -> JsonResponse<LocationPayload> {
     LocationPayload::by_id(&db, id).await?.json()
+}
+
+#[utoipa::path(
+    method(post),
+    path = "/locations",
+    tag = "Locations",
+    description = "Create a location",
+    responses(
+        (status = 201, description = "Created", body = LocationPayload)
+    )
+)]
+pub async fn post(
+    db: Database,
+    Json(location): Json<LocationPostPayload>,
+) -> JsonStatusResponse<LocationPayload> {
+    location.create(&db).await?.json_created()
+}
+
+#[utoipa::path(
+    method(delete),
+    path = "/locations/{id}",
+    tag = "Locations",
+    description = "Delete a location",
+    params(
+            ("id" = Uuid, Path, description = "Location UUID")
+        ),
+    responses(
+        (status = 204, description = "No Content"),
+        (status = 404, description = "Not found")
+    )
+)]
+pub async fn delete(db: Database, Path(id): Path<Uuid>) -> StatusResponse {
+    LocationPayload::delete(&db, id).await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+#[utoipa::path(
+    method(put),
+    path = "/locations",
+    tag = "Locations",
+    description = "Update the fields of a location",
+    responses(
+        (status = 200, description = "Success", body = LocationPayload),
+        (status = 404, description = "Not found")
+    )
+)]
+pub async fn put(db: Database, Json(location): Json<LocationPayload>) -> JsonResponse<LocationPayload> {
+    Ok(Json(location.update(&db).await?))
 }

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -7,6 +7,7 @@ pub mod admin;
 pub mod auth;
 pub mod location;
 pub mod production;
+pub mod hall;
 pub mod version;
 
 pub type JsonResponse<T> = Result<Json<T>, AppError>;

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -8,6 +8,7 @@ pub mod auth;
 pub mod location;
 pub mod production;
 pub mod hall;
+pub mod space;
 pub mod version;
 
 pub type JsonResponse<T> = Result<Json<T>, AppError>;

--- a/backend/src/handlers/production.rs
+++ b/backend/src/handlers/production.rs
@@ -11,6 +11,7 @@ use crate::{
     method(get),
     path = "/productions",
     tag = "Productions",
+    operation_id = "get_all_productions",
     description = "Get all productions",
     responses(
         (status = 200, description = "Success", body = [ProductionPayload])
@@ -24,6 +25,7 @@ pub async fn get_all(db: Database) -> JsonResponse<Vec<ProductionPayload>> {
     method(get),
     path = "/productions/{id}",
     tag = "Productions",
+    operation_id = "get_one_production",
     description = "Get a production by id",
     params(
         ("id" = Uuid, Path, description = "Production UUID")
@@ -41,6 +43,7 @@ pub async fn get_one(db: Database, Path(id): Path<Uuid>) -> JsonResponse<Product
     method(post),
     path = "/productions",
     tag = "Productions",
+    operation_id = "create_production",
     description = "Create a production",
     responses(
         (status = 201, description = "Created", body = ProductionPayload)
@@ -57,6 +60,7 @@ pub async fn post(
     method(delete),
     path = "/productions/{id}",
     tag = "Productions",
+    operation_id = "delete_production",
     description = "Delete a production",
     params(
             ("id" = Uuid, Path, description = "Production UUID")
@@ -75,6 +79,7 @@ pub async fn delete(db: Database, Path(id): Path<Uuid>) -> StatusResponse {
     method(put),
     path = "/productions",
     tag = "Productions",
+    operation_id = "update_production",
     description = "Update the fields of a production",
     responses(
         (status = 200, description = "Success", body = ProductionPayload),

--- a/backend/src/handlers/space.rs
+++ b/backend/src/handlers/space.rs
@@ -12,6 +12,7 @@ use crate::{
     method(get),
     path = "/spaces",
     tag = "Spaces",
+    operation_id = "get_all_spaces",
     description = "Get all spaces",
     responses(
         (status = 200, description = "Success", body = [SpacePayload])
@@ -25,6 +26,7 @@ pub async fn get_all(db: Database) -> JsonResponse<Vec<SpacePayload>> {
     method(get),
     path = "/spaces/{id}",
     tag = "Spaces",
+    operation_id = "get_one_space",
     description = "Get a space by id",
     params(
         ("id" = Uuid, Path, description = "Space UUID")
@@ -42,6 +44,7 @@ pub async fn get_one(db: Database, Path(id): Path<Uuid>) -> JsonResponse<SpacePa
     method(post),
     path = "/spaces",
     tag = "Spaces",
+    operation_id = "create_space",
     description = "Create a space",
     responses(
         (status = 201, description = "Created", body = SpacePayload)
@@ -58,6 +61,7 @@ pub async fn post(
     method(delete),
     path = "/spaces/{id}",
     tag = "Spaces",
+    operation_id = "delete_space",
     description = "Delete a space",
     params(
             ("id" = Uuid, Path, description = "Space UUID")
@@ -76,6 +80,7 @@ pub async fn delete(db: Database, Path(id): Path<Uuid>) -> StatusResponse {
     method(put),
     path = "/spaces",
     tag = "Spaces",
+    operation_id = "update_space",
     description = "Update the fields of a space",
     responses(
         (status = 200, description = "Success", body = SpacePayload),

--- a/backend/src/handlers/space.rs
+++ b/backend/src/handlers/space.rs
@@ -1,0 +1,85 @@
+
+use axum::{Json, extract::Path, http::StatusCode};
+use database::Database;
+use uuid::Uuid;
+
+use crate::{
+    dto::space::{SpacePayload, SpacePostPayload},
+    handlers::{IntoApiResponse, JsonResponse, JsonStatusResponse, StatusResponse},
+};
+
+#[utoipa::path(
+    method(get),
+    path = "/spaces",
+    tag = "Spaces",
+    description = "Create a space",
+    responses(
+        (status = 201, description = "Created", body = [SpacePayload])
+    )
+)]
+pub async fn get_all(db: Database) -> JsonResponse<Vec<SpacePayload>> {
+    SpacePayload::all(&db, 10).await?.json()
+}
+
+#[utoipa::path(
+    method(get),
+    path = "/spaces/{id}",
+    tag = "Spaces",
+    description = "Get a space by id",
+    params(
+        ("id" = Uuid, Path, description = "Space UUID")
+    ),
+    responses(
+        (status = 200, description = "Success", body = SpacePayload)
+    )
+)]
+pub async fn get_one(db: Database, Path(id): Path<Uuid>) -> JsonResponse<SpacePayload> {
+    SpacePayload::by_id(&db, id).await?.json()
+}
+
+#[utoipa::path(
+    method(post),
+    path = "/spaces",
+    tag = "Spaces",
+    description = "Create a space",
+    responses(
+        (status = 201, description = "Created", body = SpacePayload)
+    )
+)]
+pub async fn post(
+    db: Database,
+    Json(space): Json<SpacePostPayload>,
+) -> JsonStatusResponse<SpacePayload> {
+    space.create(&db).await?.json_created()
+}
+
+#[utoipa::path(
+    method(delete),
+    path = "/spaces/{id}",
+    tag = "Spaces",
+    description = "Delete a space",
+    params(
+            ("id" = Uuid, Path, description = "Space UUID")
+        ),
+    responses(
+        (status = 204, description = "No Content")
+    )
+)]
+pub async fn delete(db: Database, Path(id): Path<Uuid>) -> StatusResponse {
+    SpacePayload::delete(&db, id).await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+#[utoipa::path(
+    method(put),
+    path = "/spaces",
+    tag = "Spaces",
+    description = "Update the fields of a space",
+    responses(
+        (status = 200, description = "Success", body = SpacePayload)
+    )
+)]
+pub async fn put(db: Database, Json(space): Json<SpacePayload>) -> JsonResponse<SpacePayload> {
+    Ok(Json(space.update(&db).await?))
+}
+

--- a/backend/src/handlers/space.rs
+++ b/backend/src/handlers/space.rs
@@ -12,9 +12,9 @@ use crate::{
     method(get),
     path = "/spaces",
     tag = "Spaces",
-    description = "Create a space",
+    description = "Get all spaces",
     responses(
-        (status = 201, description = "Created", body = [SpacePayload])
+        (status = 201, description = "Success", body = [SpacePayload])
     )
 )]
 pub async fn get_all(db: Database) -> JsonResponse<Vec<SpacePayload>> {
@@ -30,7 +30,8 @@ pub async fn get_all(db: Database) -> JsonResponse<Vec<SpacePayload>> {
         ("id" = Uuid, Path, description = "Space UUID")
     ),
     responses(
-        (status = 200, description = "Success", body = SpacePayload)
+        (status = 200, description = "Success", body = SpacePayload),
+        (status = 404, description = "Not found")
     )
 )]
 pub async fn get_one(db: Database, Path(id): Path<Uuid>) -> JsonResponse<SpacePayload> {
@@ -62,7 +63,8 @@ pub async fn post(
             ("id" = Uuid, Path, description = "Space UUID")
         ),
     responses(
-        (status = 204, description = "No Content")
+        (status = 204, description = "No Content"),
+        (status = 404, description = "Not found")
     )
 )]
 pub async fn delete(db: Database, Path(id): Path<Uuid>) -> StatusResponse {
@@ -76,7 +78,8 @@ pub async fn delete(db: Database, Path(id): Path<Uuid>) -> StatusResponse {
     tag = "Spaces",
     description = "Update the fields of a space",
     responses(
-        (status = 200, description = "Success", body = SpacePayload)
+        (status = 200, description = "Success", body = SpacePayload),
+        (status = 404, description = "Not found")
     )
 )]
 pub async fn put(db: Database, Json(space): Json<SpacePayload>) -> JsonResponse<SpacePayload> {

--- a/backend/src/handlers/space.rs
+++ b/backend/src/handlers/space.rs
@@ -14,7 +14,7 @@ use crate::{
     tag = "Spaces",
     description = "Get all spaces",
     responses(
-        (status = 201, description = "Success", body = [SpacePayload])
+        (status = 200, description = "Success", body = [SpacePayload])
     )
 )]
 pub async fn get_all(db: Database) -> JsonResponse<Vec<SpacePayload>> {

--- a/backend/src/handlers/version.rs
+++ b/backend/src/handlers/version.rs
@@ -2,6 +2,7 @@
     method(get),
     path = "/version",
     tag = "System",
+    operation_id = "get_build_version",
     description = "Get server build version",
     responses(
         (status = 200, description = "Success", body = String)

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -16,7 +16,7 @@ use utoipa_swagger_ui::SwaggerUi;
 
 use crate::config::AppConfig;
 use crate::error::AppError;
-use crate::handlers::{admin, auth, location, production, version};
+use crate::handlers::{admin, auth, hall, location, production, version};
 
 pub mod config;
 pub mod dto;
@@ -126,6 +126,11 @@ fn open_routes() -> OpenApiRouter<AppState> {
         .routes(routes!(auth::refresh))
         .routes(routes!(auth::logout))
         .routes(routes!(admin::admin))
+        .routes(routes!(hall::get_all))
+        .routes(routes!(hall::get_one))
+        .routes(routes!(hall::post))
+        .routes(routes!(hall::delete))
+        .routes(routes!(hall::put))
 }
 
 #[allow(clippy::expect_used)]

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -16,7 +16,7 @@ use utoipa_swagger_ui::SwaggerUi;
 
 use crate::config::AppConfig;
 use crate::error::AppError;
-use crate::handlers::{admin, auth, hall, location, production, version};
+use crate::handlers::{admin, auth, hall, location, production, space, version};
 
 pub mod config;
 pub mod dto;
@@ -131,6 +131,11 @@ fn open_routes() -> OpenApiRouter<AppState> {
         .routes(routes!(hall::post))
         .routes(routes!(hall::delete))
         .routes(routes!(hall::put))
+        .routes(routes!(space::get_all))
+        .routes(routes!(space::get_one))
+        .routes(routes!(space::post))
+        .routes(routes!(space::delete))
+        .routes(routes!(space::put))
 }
 
 #[allow(clippy::expect_used)]

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -114,23 +114,32 @@ pub fn router() -> Router<AppState> {
 
 fn open_routes() -> OpenApiRouter<AppState> {
     OpenApiRouter::new()
+        // version
         .routes(routes!(version::get))
-        .routes(routes!(location::all))
+        // locations
+        .routes(routes!(location::get_all))
+        .routes(routes!(location::get_one))
+        .routes(routes!(location::post))
+        .routes(routes!(location::delete))
+        .routes(routes!(location::put))
+        // productions
         .routes(routes!(production::get_all))
         .routes(routes!(production::get_one))
         .routes(routes!(production::post))
         .routes(routes!(production::delete))
         .routes(routes!(production::put))
-        .routes(routes!(location::by_id))
+        // auth
         .routes(routes!(auth::login))
         .routes(routes!(auth::refresh))
         .routes(routes!(auth::logout))
         .routes(routes!(admin::admin))
+        // halls
         .routes(routes!(hall::get_all))
         .routes(routes!(hall::get_one))
         .routes(routes!(hall::post))
         .routes(routes!(hall::delete))
         .routes(routes!(hall::put))
+        // spaces
         .routes(routes!(space::get_all))
         .routes(routes!(space::get_one))
         .routes(routes!(space::post))


### PR DESCRIPTION
This PR closes #56, implementing the last endpoints needed for Milestone 1.

I implemented ```get_all```, ```get_by_id```, ```create```, ```update```, ```delete``` for ```halls``` and ```spaces```. Also added support for ```create```, ```update``` and ```delete``` for ```locations```.

Added a [new migration](backend/migrations/20260312141953_cascade_delete_spaces_and_locations.up.sql). This makes it so deleting a ```space``` also removes its ```halls```, and deleting a ```location``` also removes its ```spaces``` and ```halls```. We can discuss later if this is the intended behaviour.

Tried testing the getters and deletes locally, and they seemed to work fine.

After writing the migrations and starting the API locally, I stumbled upon this error: [importer_error.txt](https://github.com/user-attachments/files/25938956/importer_error.txt). The importer seems to be complaining about a duplicate slug. Not sure if it was my commits that caused this error, or if this is just the default behaviour for now.

TODO:

- [x] ```halls```
- [x] ```halls/id```
- [x] ```spaces```
- [x] ```spaces/id```
- [x] add error messages
