### PR TITLE
fix(docker): add restart policies to preview and traefik services

### DIFF
--- a/infra/preview/docker-compose.preview.yml
+++ b/infra/preview/docker-compose.preview.yml
@@ -21,6 +21,7 @@ services:
     networks:
       - traefik
       - internal
+    restart: unless-stopped
 
   api:
     build:
@@ -42,6 +43,7 @@ services:
     networks:
       - traefik
       - internal
+    restart: unless-stopped
 
   db:
     image: postgres:18
@@ -54,6 +56,7 @@ services:
       - db_data:/var/lib/postgresql
     networks:
       - internal
+    restart: unless-stopped
 
 volumes:
   db_data:

--- a/infra/traefik/docker-compose.yml
+++ b/infra/traefik/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - traefik-certs:/letsencrypt
-    restart: unless-stopped
+    restart: always
     networks:
       - traefik
 


### PR DESCRIPTION
- Preview services: `restart: unless-stopped`
- Traefik: `restart: always` (was `unless-stopped`)
- Prod had al `restart: always`
