### PR TITLE
fix(repo): remove unneeded template items

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,7 @@
-# Title of PR
 **Description**
 
 **Related Issue**
 Fixes #
-
-**Type of change**
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that causes existing functionality to change)
-- [ ] ♻Refactor / Chore / Documentation
 
 **How Has This Been Tested?**
 - [ ] Local manual testing


### PR DESCRIPTION
- remove title from body. The title of the pr is enough title.
- removed checkboxes for type. Labels and type from github should cover this. 
- conventional commit '!' semantic covers breaking change

**removed:**
<img width="778" height="206" alt="image" src="https://github.com/user-attachments/assets/79589d96-43bf-4331-9816-830d93bc2195" />
