### PR TITLE
fix(traefik): Fixed previews not working

### DIFF
--- a/infra/preview/docker-compose.preview.yml
+++ b/infra/preview/docker-compose.preview.yml
@@ -16,8 +16,8 @@ services:
       - "traefik.http.routers.${PREVIEW_NAME}.rule=Host(`${PREVIEW_HOST}`) && PathPrefix(`/${PREVIEW_NAME}`) && !PathPrefix(`/${PREVIEW_NAME}/docs`) && !PathPrefix(`/${PREVIEW_NAME}/api`)"
       - "traefik.http.routers.${PREVIEW_NAME}.entrypoints=websecure"
       - "traefik.http.services.${PREVIEW_NAME}.loadbalancer.server.port=3000"
-      #- "traefik.http.routers.${PREVIEW_NAME}.priority=1"
       - "traefik.http.routers.${PREVIEW_NAME}.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.${PREVIEW_NAME}.priority=200"
       - "traefik.http.middlewares.${PREVIEW_NAME}-prefix.headers.customrequestheaders.X-Forwarded-Prefix=/${PREVIEW_NAME}"
       - "traefik.http.routers.${PREVIEW_NAME}.middlewares=${PREVIEW_NAME}-prefix"
     networks:
@@ -40,8 +40,8 @@ services:
       - "traefik.http.routers.${PREVIEW_NAME}-docs.rule=Host(`${PREVIEW_HOST}`) && PathPrefix(`/${PREVIEW_NAME}/docs`)"
       - "traefik.http.routers.${PREVIEW_NAME}-docs.entrypoints=websecure"
       - "traefik.http.services.${PREVIEW_NAME}-docs.loadbalancer.server.port=3002"
-      #- "traefik.http.routers.${PREVIEW_NAME}-docs.priority=2"
       - "traefik.http.routers.${PREVIEW_NAME}-docs.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.${PREVIEW_NAME}-docs.priority=200"
       - "traefik.http.middlewares.${PREVIEW_NAME}-prefix-docs.headers.customrequestheaders.X-Forwarded-Prefix=/${PREVIEW_NAME}/docs"
       - "traefik.http.routers.${PREVIEW_NAME}-docs.middlewares=${PREVIEW_NAME}-prefix-docs"
     networks:
@@ -74,7 +74,7 @@ services:
       - "traefik.http.routers.${PREVIEW_NAME}-api.entrypoints=websecure"
       - "traefik.http.services.${PREVIEW_NAME}-api.loadbalancer.server.port=3001"
       - "traefik.http.routers.${PREVIEW_NAME}-api.tls.certresolver=letsencrypt"
-      #- "traefik.http.routers.${PREVIEW_NAME}-docs.priority=3"
+      - "traefik.http.routers.${PREVIEW_NAME}-api.priority=200"
     networks:
       - traefik
       - internal
@@ -139,9 +139,9 @@ services:
         # Copy garage binary from garage container
         cp /proc/1/root/garage /usr/local/bin/garage
         chmod +x /usr/local/bin/garage
-        
+
         G="garage -c /etc/garage.toml"
-        
+
         # Wait for garage to generate node key first
         echo "Waiting for garage node key..."
         for i in $$(seq 1 60); do
@@ -149,20 +149,20 @@ services:
           echo "Waiting for node key... ($$i/60)"
           sleep 2
         done
-        
+
         [ -f /var/lib/garage/meta/node_key ] || { echo "Node key not found"; exit 1; }
-        
+
         # Get node ID and configure layout
         NODE_ID=$$($$G node id -q)
         echo "Node ID: $$NODE_ID"
-        
+
         # Check if layout needs to be configured
         if $$G status 2>&1 | grep -q "NO ROLE ASSIGNED"; then
           echo "Configuring layout..."
           $$G layout assign "$$NODE_ID" -z "$$GARAGE_ZONE" -c "$$GARAGE_CAPACITY"
           $$G layout apply --version 1
         fi
-        
+
         # Now wait for healthy status
         echo "Waiting for garage to be healthy..."
         for i in $$(seq 1 30); do
@@ -170,18 +170,18 @@ services:
           echo "Waiting... ($$i/30)"
           sleep 2
         done
-        
+
         $$G status | grep -q "HEALTHY" || { echo "Garage not healthy"; exit 1; }
-        
+
         echo "Creating key..."
         $$G key info "$$GARAGE_S3_ACCESS_KEY" 2>/dev/null || \
           $$G key import "$$GARAGE_S3_ACCESS_KEY" "$$GARAGE_S3_SECRET_KEY" -n app-key --yes
-        
+
         echo "Creating bucket..."
         $$G bucket info "$$GARAGE_S3_BUCKET" 2>/dev/null || \
           $$G bucket create "$$GARAGE_S3_BUCKET"
         $$G bucket allow "$$GARAGE_S3_BUCKET" --key "$$GARAGE_S3_ACCESS_KEY" --read --write || true
-        
+
         echo "Init complete!"
 
 volumes:

--- a/infra/production/docker-compose.prod.yml
+++ b/infra/production/docker-compose.prod.yml
@@ -27,8 +27,8 @@ services:
       #- "traefik.http.routers.main-api.middlewares=api-strip"
       - "traefik.http.routers.main-api.entrypoints=websecure"
       - "traefik.http.services.main-api.loadbalancer.server.port=3001"
-      #- "traefik.http.routers.main-api.priority=20"
       - "traefik.http.routers.main-api.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.main-api.priority=100"
 
   frontend:
     image: kayasem/${COMPOSE_PROJECT_NAME}-frontend:latest
@@ -45,8 +45,8 @@ services:
       - "traefik.http.routers.main.rule=Host(`${PROD_HOST}`) && PathPrefix(`/`) && !PathPrefix(`/docs`) && !PathPrefix(`/api`)"
       - "traefik.http.routers.main.entrypoints=websecure"
       - "traefik.http.services.main.loadbalancer.server.port=3000"
-      #- "traefik.http.routers.main.priority=10"
       - "traefik.http.routers.main.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.main.priority=100"
 
   docs:
     image: kayasem/${COMPOSE_PROJECT_NAME}-docs:latest
@@ -59,8 +59,8 @@ services:
       - "traefik.http.routers.main-docs.rule=Host(`${PROD_HOST}`) && PathPrefix(`/docs`)"
       - "traefik.http.routers.main-docs.entrypoints=websecure"
       - "traefik.http.services.main-docs.loadbalancer.server.port=3002"
-      #- "traefik.http.routers.main-docs.priority=20"
       - "traefik.http.routers.main-docs.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.main-docs.priority=100"
       - "traefik.http.middlewares.prefix-docs.headers.customrequestheaders.X-Forwarded-Prefix=/docs"
       - "traefik.http.routers.main-docs.middlewares=prefix-docs"
 
@@ -122,9 +122,9 @@ services:
         # Copy garage binary from garage container
         cp /proc/1/root/garage /usr/local/bin/garage
         chmod +x /usr/local/bin/garage
-        
+
         G="garage -c /etc/garage.toml"
-        
+
         # Wait for garage to generate node key first
         echo "Waiting for garage node key..."
         for i in $$(seq 1 60); do
@@ -132,20 +132,20 @@ services:
           echo "Waiting for node key... ($$i/60)"
           sleep 2
         done
-        
+
         [ -f /var/lib/garage/meta/node_key ] || { echo "Node key not found"; exit 1; }
-        
+
         # Get node ID and configure layout
         NODE_ID=$$($$G node id -q)
         echo "Node ID: $$NODE_ID"
-        
+
         # Check if layout needs to be configured
         if $$G status 2>&1 | grep -q "NO ROLE ASSIGNED"; then
           echo "Configuring layout..."
           $$G layout assign "$$NODE_ID" -z "$$GARAGE_ZONE" -c "$$GARAGE_CAPACITY"
           $$G layout apply --version 1
         fi
-        
+
         # Now wait for healthy status
         echo "Waiting for garage to be healthy..."
         for i in $$(seq 1 30); do
@@ -153,18 +153,18 @@ services:
           echo "Waiting... ($$i/30)"
           sleep 2
         done
-        
+
         $$G status | grep -q "HEALTHY" || { echo "Garage not healthy"; exit 1; }
-        
+
         echo "Creating key..."
         $$G key info "$$GARAGE_S3_ACCESS_KEY" 2>/dev/null || \
           $$G key import "$$GARAGE_S3_ACCESS_KEY" "$$GARAGE_S3_SECRET_KEY" -n app-key --yes
-        
+
         echo "Creating bucket..."
         $$G bucket info "$$GARAGE_S3_BUCKET" 2>/dev/null || \
           $$G bucket create "$$GARAGE_S3_BUCKET"
         $$G bucket allow "$$GARAGE_S3_BUCKET" --key "$$GARAGE_S3_ACCESS_KEY" --read --write || true
-        
+
         echo "Init complete!"
 
 volumes:


### PR DESCRIPTION
This PR adds the priority back as currently preview builds are being taken over by the production version. 

For example: https://sel2-6.ugent.be/pr-150/api is redirecting to https://sel2-6.ugent.be/nl/pr-150/api