### PR TITLE
fix: facet test get_filtered_by_unknown_entity_type

### DIFF
--- a/backend/src/dto/facet.rs
+++ b/backend/src/dto/facet.rs
@@ -2,19 +2,19 @@ use database::{
     Database,
     models::{entity_type::EntityType, tag::TaxonomyTag},
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 use crate::error::AppError;
 
-#[derive(Serialize, ToSchema)]
+#[derive(Serialize, Deserialize, ToSchema)]
 pub struct TagResponse {
     pub slug: String,
     pub label: String,
     pub sort_order: i32,
 }
 
-#[derive(Serialize, ToSchema)]
+#[derive(Serialize, Deserialize, ToSchema)]
 pub struct FacetResponse {
     pub slug: String,
     pub label: String,

--- a/backend/tests/taxonomy.rs
+++ b/backend/tests/taxonomy.rs
@@ -1,6 +1,7 @@
+#![allow(clippy::indexing_slicing)]
 use axum::http::StatusCode;
 use sqlx::PgPool;
-use viernulvier_api::dto::facet::FacetDto;
+use viernulvier_api::dto::facet::FacetResponse;
 
 use crate::common::{into_struct::IntoStruct, router::TestRouter};
 
@@ -14,7 +15,7 @@ async fn get_all(db: PgPool) {
 
     assert_eq!(response.status(), StatusCode::OK);
 
-    let data: Vec<FacetDto> = response.into_struct().await;
+    let data: Vec<FacetResponse> = response.into_struct().await;
     assert_eq!(data.len(), 4);
 
     assert_eq!(data[0].slug, "discipline");
@@ -39,7 +40,7 @@ async fn get_filtered_by_production(db: PgPool) {
 
     assert_eq!(response.status(), StatusCode::OK);
 
-    let data: Vec<FacetDto> = response.into_struct().await;
+    let data: Vec<FacetResponse> = response.into_struct().await;
     assert_eq!(data.len(), 4);
     assert_eq!(data[0].slug, "discipline");
     assert_eq!(data[3].slug, "audience");
@@ -53,7 +54,7 @@ async fn get_filtered_by_artist(db: PgPool) {
 
     assert_eq!(response.status(), StatusCode::OK);
 
-    let data: Vec<FacetDto> = response.into_struct().await;
+    let data: Vec<FacetResponse> = response.into_struct().await;
     assert_eq!(data.len(), 1);
     assert_eq!(data[0].slug, "discipline");
     assert_eq!(data[0].tags.len(), 8);
@@ -67,6 +68,6 @@ async fn get_filtered_by_unknown_entity_type(db: PgPool) {
 
     assert_eq!(response.status(), StatusCode::OK);
 
-    let data: Vec<FacetDto> = response.into_struct().await;
+    let data: Vec<FacetResponse> = response.into_struct().await;
     assert_eq!(data.len(), 0);
 }

--- a/backend/tests/taxonomy.rs
+++ b/backend/tests/taxonomy.rs
@@ -66,8 +66,5 @@ async fn get_filtered_by_unknown_entity_type(db: PgPool) {
     let app = TestRouter::new(db);
     let response = app.get("/taxonomy/facets?entity_type=nonexistent").await;
 
-    assert_eq!(response.status(), StatusCode::OK);
-
-    let data: Vec<FacetResponse> = response.into_struct().await;
-    assert_eq!(data.len(), 0);
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 }


### PR DESCRIPTION
**Description**
fixes the facet test `get_filtered_by_unknown_entity_type` as it was broken by using enums instead of a string

**Related Issue**
Fixes #

**How Has This Been Tested?**
- [x] Local manual testing
- [x[ Added/updated unit or integration tests
- [ ] Tested in the staging environment

**Developer Checklist:**
- [x] I have performed a self-review of my own code.
- [ ] I have left comments in hard-to-understand areas of my code.
- [x] My changes generate no new warnings or console errors.

