### PR TITLE
fix(test): fixed secrets for test workflow in production

### DIFF
--- a/.github/workflows/build-push-deploy.yml
+++ b/.github/workflows/build-push-deploy.yml
@@ -7,12 +7,12 @@ on:
 
 jobs:
   run_backend_tests:
-    if: github.event.action != 'closed'
     uses: ./.github/workflows/backend-tests.yml
+    secrets: inherit
 
   run_frontend_tests:
-    if: github.event.action != 'closed'
     uses: ./.github/workflows/frontend-tests.yml
+    secrets: inherit
 
   build-push:
     runs-on: self-hosted


### PR DESCRIPTION
**Description**
The tests in the production (`main` branch) did not have access to the needed secrets to upload reports to codecov. This small fix should fix it. Overlooked in previous PR (#158)