### PR TITLE
chore: format backend, add a macro to process translations

### DIFF
--- a/backend/api/src/lib.rs
+++ b/backend/api/src/lib.rs
@@ -10,7 +10,10 @@ use tracing::{info, warn};
 use crate::helper::extract_source_id;
 use crate::models::space::ApiSpace;
 use crate::models::{
-    collection::ApiCollection, event::ApiEvent, hall::ApiHall, location::ApiLocation,
+    collection::ApiCollection,
+    event::ApiEvent,
+    hall::ApiHall,
+    location::ApiLocation,
     production::{ApiProduction, ProductionImportData},
 };
 

--- a/backend/api/src/models/production.rs
+++ b/backend/api/src/models/production.rs
@@ -99,108 +99,59 @@ impl From<ApiProduction> for ProductionImportData {
             uitdatabank_type: api.uitdatabank_type,
         };
 
-        let translations =
-            build_translations(api.supertitle, api.title, api.artist, api.meta_title, api.meta_description, api.tagline, api.teaser, api.description, api.description_extra, api.description_2, api.quote, api.quote_source, api.programme, api.info, api.description_short);
+        macro_rules! extract_translations {
+            // kind of like a regex
+            // $field:ident matches identifiers (variables) and puts them in $field
+            // + is at least once
+            // $(,)? allows a trailing comma
+            ( $( $field:ident ),+ $(,)? ) => {{
+                // write this line for every field
+                $( let $field = flatten_loc(api.$field); )+
+
+                let mut out = Vec::with_capacity(2);
+
+                // nl
+                // expands into supertitle.0.is_some() || title.0.is_some() ...
+                if $( $field.0.is_some() )||+ {
+                    out.push(ProductionTranslationData {
+                        language_code: "nl".into(),
+                        $( $field: $field.0 ),+
+                    });
+                }
+
+                // en
+                if $( $field.1.is_some() )||+ {
+                    out.push(ProductionTranslationData {
+                        language_code: "en".into(),
+                        $( $field: $field.1 ),+
+                    });
+                }
+
+                out
+            }};
+        }
+
+        let translations = extract_translations!(
+            supertitle,
+            title,
+            artist,
+            meta_title,
+            meta_description,
+            tagline,
+            teaser,
+            description,
+            description_extra,
+            description_2,
+            quote,
+            quote_source,
+            programme,
+            info,
+            description_short
+        );
 
         Self {
             production,
             translations,
         }
     }
-}
-
-fn build_translations(
-    supertitle: Option<ApiLocalizedText>,
-    title: Option<ApiLocalizedText>,
-    artist: Option<ApiLocalizedText>,
-    meta_title: Option<ApiLocalizedText>,
-    meta_description: Option<ApiLocalizedText>,
-    tagline: Option<ApiLocalizedText>,
-    teaser: Option<ApiLocalizedText>,
-    description: Option<ApiLocalizedText>,
-    description_extra: Option<ApiLocalizedText>,
-    description_2: Option<ApiLocalizedText>,
-    quote: Option<ApiLocalizedText>,
-    quote_source: Option<ApiLocalizedText>,
-    programme: Option<ApiLocalizedText>,
-    info: Option<ApiLocalizedText>,
-    description_short: Option<ApiLocalizedText>,
-) -> Vec<ProductionTranslationData> {
-    let (supertitle_nl, supertitle_en) = flatten_loc(supertitle);
-    let (title_nl, title_en) = flatten_loc(title);
-    let (artist_nl, artist_en) = flatten_loc(artist);
-    let (meta_title_nl, meta_title_en) = flatten_loc(meta_title);
-    let (meta_description_nl, meta_description_en) = flatten_loc(meta_description);
-    let (tagline_nl, tagline_en) = flatten_loc(tagline);
-    let (teaser_nl, teaser_en) = flatten_loc(teaser);
-    let (description_nl, description_en) = flatten_loc(description);
-    let (description_extra_nl, description_extra_en) = flatten_loc(description_extra);
-    let (description_2_nl, description_2_en) = flatten_loc(description_2);
-    let (quote_nl, quote_en) = flatten_loc(quote);
-    let (quote_source_nl, quote_source_en) = flatten_loc(quote_source);
-    let (programme_nl, programme_en) = flatten_loc(programme);
-    let (info_nl, info_en) = flatten_loc(info);
-    let (description_short_nl, description_short_en) = flatten_loc(description_short);
-
-    let mut out = Vec::with_capacity(2);
-
-    let nl_any = [
-        &supertitle_nl, &title_nl, &artist_nl, &meta_title_nl, &meta_description_nl,
-        &tagline_nl, &teaser_nl, &description_nl, &description_extra_nl, &description_2_nl,
-        &quote_nl, &quote_source_nl, &programme_nl, &info_nl, &description_short_nl,
-    ]
-    .iter()
-    .any(|f| f.is_some());
-
-    if nl_any {
-        out.push(ProductionTranslationData {
-            language_code: "nl".into(),
-            supertitle: supertitle_nl,
-            title: title_nl,
-            artist: artist_nl,
-            meta_title: meta_title_nl,
-            meta_description: meta_description_nl,
-            tagline: tagline_nl,
-            teaser: teaser_nl,
-            description: description_nl,
-            description_extra: description_extra_nl,
-            description_2: description_2_nl,
-            quote: quote_nl,
-            quote_source: quote_source_nl,
-            programme: programme_nl,
-            info: info_nl,
-            description_short: description_short_nl,
-        });
-    }
-
-    let en_any = [
-        &supertitle_en, &title_en, &artist_en, &meta_title_en, &meta_description_en,
-        &tagline_en, &teaser_en, &description_en, &description_extra_en, &description_2_en,
-        &quote_en, &quote_source_en, &programme_en, &info_en, &description_short_en,
-    ]
-    .iter()
-    .any(|f| f.is_some());
-
-    if en_any {
-        out.push(ProductionTranslationData {
-            language_code: "en".into(),
-            supertitle: supertitle_en,
-            title: title_en,
-            artist: artist_en,
-            meta_title: meta_title_en,
-            meta_description: meta_description_en,
-            tagline: tagline_en,
-            teaser: teaser_en,
-            description: description_en,
-            description_extra: description_extra_en,
-            description_2: description_2_en,
-            quote: quote_en,
-            quote_source: quote_source_en,
-            programme: programme_en,
-            info: info_en,
-            description_short: description_short_en,
-        });
-    }
-
-    out
 }

--- a/backend/database/src/repos/collection.rs
+++ b/backend/database/src/repos/collection.rs
@@ -27,11 +27,10 @@ impl<'a> CollectionRepo<'a> {
     }
 
     pub async fn all(&self) -> Result<Vec<CollectionWithTranslations>, DatabaseError> {
-        let collections = sqlx::query_as::<_, Collection>(
-            "SELECT * FROM collections ORDER BY created_at DESC",
-        )
-        .fetch_all(self.db)
-        .await?;
+        let collections =
+            sqlx::query_as::<_, Collection>("SELECT * FROM collections ORDER BY created_at DESC")
+                .fetch_all(self.db)
+                .await?;
 
         if collections.is_empty() {
             return Ok(vec![]);
@@ -62,13 +61,15 @@ impl<'a> CollectionRepo<'a> {
             .collect())
     }
 
-    pub async fn by_id(&self, id: Uuid) -> Result<Option<CollectionWithTranslations>, DatabaseError> {
-        let Some(collection) = sqlx::query_as::<_, Collection>(
-            "SELECT * FROM collections WHERE id = $1",
-        )
-        .bind(id)
-        .fetch_optional(self.db)
-        .await?
+    pub async fn by_id(
+        &self,
+        id: Uuid,
+    ) -> Result<Option<CollectionWithTranslations>, DatabaseError> {
+        let Some(collection) =
+            sqlx::query_as::<_, Collection>("SELECT * FROM collections WHERE id = $1")
+                .bind(id)
+                .fetch_optional(self.db)
+                .await?
         else {
             return Ok(None);
         };
@@ -93,7 +94,8 @@ impl<'a> CollectionRepo<'a> {
         .fetch_one(self.db)
         .await?;
 
-        self.upsert_translations(collection.id, &translations).await?;
+        self.upsert_translations(collection.id, &translations)
+            .await?;
         let translations = self.fetch_translations_for(collection.id).await?;
 
         Ok(CollectionWithTranslations {
@@ -119,7 +121,8 @@ impl<'a> CollectionRepo<'a> {
             return Ok(None);
         };
 
-        self.upsert_translations(collection.id, &translations).await?;
+        self.upsert_translations(collection.id, &translations)
+            .await?;
         let translations = self.fetch_translations_for(collection.id).await?;
 
         Ok(Some(CollectionWithTranslations {
@@ -141,7 +144,10 @@ impl<'a> CollectionRepo<'a> {
         Ok(Some(()))
     }
 
-    pub async fn items_for(&self, collection_id: Uuid) -> Result<Vec<CollectionItemWithTranslations>, DatabaseError> {
+    pub async fn items_for(
+        &self,
+        collection_id: Uuid,
+    ) -> Result<Vec<CollectionItemWithTranslations>, DatabaseError> {
         let items = sqlx::query_as::<_, CollectionItem>(
             "SELECT * FROM collection_items WHERE collection_id = $1 ORDER BY position ASC",
         )
@@ -152,7 +158,10 @@ impl<'a> CollectionRepo<'a> {
         self.attach_item_translations(items).await
     }
 
-    pub async fn items_for_collections(&self, collection_ids: &[Uuid]) -> Result<Vec<CollectionItemWithTranslations>, DatabaseError> {
+    pub async fn items_for_collections(
+        &self,
+        collection_ids: &[Uuid],
+    ) -> Result<Vec<CollectionItemWithTranslations>, DatabaseError> {
         let items = sqlx::query_as::<_, CollectionItem>(
             "SELECT * FROM collection_items WHERE collection_id = ANY($1) ORDER BY position ASC",
         )
@@ -163,7 +172,10 @@ impl<'a> CollectionRepo<'a> {
         self.attach_item_translations(items).await
     }
 
-    pub async fn add_item(&self, item: CollectionItemCreate) -> Result<CollectionItemWithTranslations, DatabaseError> {
+    pub async fn add_item(
+        &self,
+        item: CollectionItemCreate,
+    ) -> Result<CollectionItemWithTranslations, DatabaseError> {
         let new_item = sqlx::query_as::<_, CollectionItem>(
             "INSERT INTO collection_items (collection_id, content_id, content_type, position) VALUES ($1, $2, $3, $4) RETURNING *",
         )
@@ -174,7 +186,8 @@ impl<'a> CollectionRepo<'a> {
         .fetch_one(self.db)
         .await?;
 
-        self.upsert_item_translations(new_item.id, &item.translations).await?;
+        self.upsert_item_translations(new_item.id, &item.translations)
+            .await?;
         let translations = self.fetch_item_translations_for(new_item.id).await?;
 
         Ok(CollectionItemWithTranslations {
@@ -188,12 +201,11 @@ impl<'a> CollectionRepo<'a> {
         collection_id: Uuid,
         item_id: Uuid,
     ) -> Result<Option<()>, DatabaseError> {
-        let res =
-            sqlx::query("DELETE FROM collection_items WHERE id = $1 AND collection_id = $2")
-                .bind(item_id)
-                .bind(collection_id)
-                .execute(self.db)
-                .await?;
+        let res = sqlx::query("DELETE FROM collection_items WHERE id = $1 AND collection_id = $2")
+            .bind(item_id)
+            .bind(collection_id)
+            .execute(self.db)
+            .await?;
 
         if res.rows_affected() == 0 {
             return Ok(None);
@@ -202,7 +214,10 @@ impl<'a> CollectionRepo<'a> {
         Ok(Some(()))
     }
 
-    async fn fetch_translations_for(&self, collection_id: Uuid) -> Result<Vec<CollectionTranslation>, DatabaseError> {
+    async fn fetch_translations_for(
+        &self,
+        collection_id: Uuid,
+    ) -> Result<Vec<CollectionTranslation>, DatabaseError> {
         Ok(sqlx::query_as::<_, CollectionTranslation>(
             "SELECT * FROM collection_translations WHERE collection_id = $1",
         )
@@ -220,9 +235,15 @@ impl<'a> CollectionRepo<'a> {
             return Ok(());
         }
 
-        let language_codes: Vec<&str> = translations.iter().map(|t| t.language_code.as_str()).collect();
+        let language_codes: Vec<&str> = translations
+            .iter()
+            .map(|t| t.language_code.as_str())
+            .collect();
         let titles: Vec<&str> = translations.iter().map(|t| t.title.as_str()).collect();
-        let descriptions: Vec<&str> = translations.iter().map(|t| t.description.as_str()).collect();
+        let descriptions: Vec<&str> = translations
+            .iter()
+            .map(|t| t.description.as_str())
+            .collect();
 
         sqlx::query(
             "INSERT INTO collection_translations (collection_id, language_code, title, description)
@@ -259,7 +280,10 @@ impl<'a> CollectionRepo<'a> {
 
         let mut translation_map: HashMap<Uuid, Vec<CollectionItemTranslation>> = HashMap::new();
         for t in all_translations {
-            translation_map.entry(t.collection_item_id).or_default().push(t);
+            translation_map
+                .entry(t.collection_item_id)
+                .or_default()
+                .push(t);
         }
 
         Ok(items
@@ -274,7 +298,10 @@ impl<'a> CollectionRepo<'a> {
             .collect())
     }
 
-    async fn fetch_item_translations_for(&self, item_id: Uuid) -> Result<Vec<CollectionItemTranslation>, DatabaseError> {
+    async fn fetch_item_translations_for(
+        &self,
+        item_id: Uuid,
+    ) -> Result<Vec<CollectionItemTranslation>, DatabaseError> {
         Ok(sqlx::query_as::<_, CollectionItemTranslation>(
             "SELECT * FROM collection_item_translations WHERE collection_item_id = $1",
         )
@@ -292,8 +319,12 @@ impl<'a> CollectionRepo<'a> {
             return Ok(());
         }
 
-        let language_codes: Vec<&str> = translations.iter().map(|t| t.language_code.as_str()).collect();
-        let comments: Vec<Option<&str>> = translations.iter().map(|t| t.comment.as_deref()).collect();
+        let language_codes: Vec<&str> = translations
+            .iter()
+            .map(|t| t.language_code.as_str())
+            .collect();
+        let comments: Vec<Option<&str>> =
+            translations.iter().map(|t| t.comment.as_deref()).collect();
 
         sqlx::query(
             "INSERT INTO collection_item_translations (collection_item_id, language_code, comment)

--- a/backend/database/src/repos/production.rs
+++ b/backend/database/src/repos/production.rs
@@ -37,45 +37,45 @@ impl<'a> ProductionRepo<'a> {
         })
     }
 
-pub async fn all(
-    &self,
-    limit: usize,
-    id_cursor: Option<Uuid>,
-) -> Result<Vec<ProductionWithTranslations>, DatabaseError> {
-    let mut select = Production::select().limit(limit).order_desc("id");
-    if let Some(id_cursor) = id_cursor {
-        select = select.where_("id < $1").bind(id_cursor);
+    pub async fn all(
+        &self,
+        limit: usize,
+        id_cursor: Option<Uuid>,
+    ) -> Result<Vec<ProductionWithTranslations>, DatabaseError> {
+        let mut select = Production::select().limit(limit).order_desc("id");
+        if let Some(id_cursor) = id_cursor {
+            select = select.where_("id < $1").bind(id_cursor);
+        }
+        let productions = select.fetch_all(self.db).await?;
+
+        if productions.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let ids: Vec<Uuid> = productions.iter().map(|p| p.id).collect();
+        let all_translations = sqlx::query_as::<_, ProductionTranslation>(
+            "SELECT * FROM production_translations WHERE production_id = ANY($1)",
+        )
+        .bind(&ids[..])
+        .fetch_all(self.db)
+        .await?;
+
+        let mut translation_map: HashMap<Uuid, Vec<ProductionTranslation>> = HashMap::new();
+        for t in all_translations {
+            translation_map.entry(t.production_id).or_default().push(t);
+        }
+
+        Ok(productions
+            .into_iter()
+            .map(|p| {
+                let translations = translation_map.remove(&p.id).unwrap_or_default();
+                ProductionWithTranslations {
+                    production: p,
+                    translations,
+                }
+            })
+            .collect())
     }
-    let productions = select.fetch_all(self.db).await?;
-
-    if productions.is_empty() {
-        return Ok(vec![]);
-    }
-
-    let ids: Vec<Uuid> = productions.iter().map(|p| p.id).collect();
-    let all_translations = sqlx::query_as::<_, ProductionTranslation>(
-        "SELECT * FROM production_translations WHERE production_id = ANY($1)",
-    )
-    .bind(&ids[..])
-    .fetch_all(self.db)
-    .await?;
-
-    let mut translation_map: HashMap<Uuid, Vec<ProductionTranslation>> = HashMap::new();
-    for t in all_translations {
-        translation_map.entry(t.production_id).or_default().push(t);
-    }
-
-    Ok(productions
-        .into_iter()
-        .map(|p| {
-            let translations = translation_map.remove(&p.id).unwrap_or_default();
-            ProductionWithTranslations {
-                production: p,
-                translations,
-            }
-        })
-        .collect())
-}
 
     pub async fn insert(
         &self,
@@ -83,7 +83,8 @@ pub async fn all(
         translations: Vec<ProductionTranslationData>,
     ) -> Result<ProductionWithTranslations, DatabaseError> {
         let production = production.insert(self.db).await?;
-        self.upsert_translations(production.id, &translations).await?;
+        self.upsert_translations(production.id, &translations)
+            .await?;
         let translation_rows = self.fetch_translations_for(production.id).await?;
 
         Ok(ProductionWithTranslations {
@@ -98,7 +99,8 @@ pub async fn all(
         translations: Vec<ProductionTranslationData>,
     ) -> Result<ProductionWithTranslations, DatabaseError> {
         let production = production.update_all_fields(self.db).await?;
-        self.upsert_translations(production.id, &translations).await?;
+        self.upsert_translations(production.id, &translations)
+            .await?;
         let translation_rows = self.fetch_translations_for(production.id).await?;
 
         Ok(ProductionWithTranslations {
@@ -162,22 +164,53 @@ pub async fn all(
             return Ok(());
         }
 
-        let language_codes: Vec<&str> = translations.iter().map(|t| t.language_code.as_str()).collect();
-        let supertitles: Vec<Option<&str>> = translations.iter().map(|t| t.supertitle.as_deref()).collect();
+        let language_codes: Vec<&str> = translations
+            .iter()
+            .map(|t| t.language_code.as_str())
+            .collect();
+        let supertitles: Vec<Option<&str>> = translations
+            .iter()
+            .map(|t| t.supertitle.as_deref())
+            .collect();
         let titles: Vec<Option<&str>> = translations.iter().map(|t| t.title.as_deref()).collect();
         let artists: Vec<Option<&str>> = translations.iter().map(|t| t.artist.as_deref()).collect();
-        let meta_titles: Vec<Option<&str>> = translations.iter().map(|t| t.meta_title.as_deref()).collect();
-        let meta_descriptions: Vec<Option<&str>> = translations.iter().map(|t| t.meta_description.as_deref()).collect();
-        let taglines: Vec<Option<&str>> = translations.iter().map(|t| t.tagline.as_deref()).collect();
+        let meta_titles: Vec<Option<&str>> = translations
+            .iter()
+            .map(|t| t.meta_title.as_deref())
+            .collect();
+        let meta_descriptions: Vec<Option<&str>> = translations
+            .iter()
+            .map(|t| t.meta_description.as_deref())
+            .collect();
+        let taglines: Vec<Option<&str>> =
+            translations.iter().map(|t| t.tagline.as_deref()).collect();
         let teasers: Vec<Option<&str>> = translations.iter().map(|t| t.teaser.as_deref()).collect();
-        let descriptions: Vec<Option<&str>> = translations.iter().map(|t| t.description.as_deref()).collect();
-        let description_extras: Vec<Option<&str>> = translations.iter().map(|t| t.description_extra.as_deref()).collect();
-        let description_2s: Vec<Option<&str>> = translations.iter().map(|t| t.description_2.as_deref()).collect();
+        let descriptions: Vec<Option<&str>> = translations
+            .iter()
+            .map(|t| t.description.as_deref())
+            .collect();
+        let description_extras: Vec<Option<&str>> = translations
+            .iter()
+            .map(|t| t.description_extra.as_deref())
+            .collect();
+        let description_2s: Vec<Option<&str>> = translations
+            .iter()
+            .map(|t| t.description_2.as_deref())
+            .collect();
         let quotes: Vec<Option<&str>> = translations.iter().map(|t| t.quote.as_deref()).collect();
-        let quote_sources: Vec<Option<&str>> = translations.iter().map(|t| t.quote_source.as_deref()).collect();
-        let programmes: Vec<Option<&str>> = translations.iter().map(|t| t.programme.as_deref()).collect();
+        let quote_sources: Vec<Option<&str>> = translations
+            .iter()
+            .map(|t| t.quote_source.as_deref())
+            .collect();
+        let programmes: Vec<Option<&str>> = translations
+            .iter()
+            .map(|t| t.programme.as_deref())
+            .collect();
         let infos: Vec<Option<&str>> = translations.iter().map(|t| t.info.as_deref()).collect();
-        let description_shorts: Vec<Option<&str>> = translations.iter().map(|t| t.description_short.as_deref()).collect();
+        let description_shorts: Vec<Option<&str>> = translations
+            .iter()
+            .map(|t| t.description_short.as_deref())
+            .collect();
 
         sqlx::query(
             "INSERT INTO production_translations (

--- a/backend/src/dto/collection.rs
+++ b/backend/src/dto/collection.rs
@@ -124,7 +124,9 @@ fn build_payload(
     }
 }
 
-fn item_translations_to_data(translations: &[CollectionItemTranslationPayload]) -> Vec<CollectionItemTranslationData> {
+fn item_translations_to_data(
+    translations: &[CollectionItemTranslationPayload],
+) -> Vec<CollectionItemTranslationData> {
     translations
         .iter()
         .map(|t| CollectionItemTranslationData {
@@ -134,7 +136,9 @@ fn item_translations_to_data(translations: &[CollectionItemTranslationPayload]) 
         .collect()
 }
 
-fn collection_translations_to_data(translations: &[CollectionTranslationPayload]) -> Vec<CollectionTranslationData> {
+fn collection_translations_to_data(
+    translations: &[CollectionTranslationPayload],
+) -> Vec<CollectionTranslationData> {
     translations
         .iter()
         .map(|t| CollectionTranslationData {
@@ -153,7 +157,10 @@ impl CollectionPayload {
 
         let mut items_map: HashMap<Uuid, Vec<CollectionItemWithTranslations>> = HashMap::new();
         for item in all_items {
-            items_map.entry(item.item.collection_id).or_default().push(item);
+            items_map
+                .entry(item.item.collection_id)
+                .or_default()
+                .push(item);
         }
 
         Ok(collections
@@ -166,7 +173,11 @@ impl CollectionPayload {
     }
 
     pub async fn by_id(db: &Database, id: Uuid) -> Result<Self, AppError> {
-        let cwt = db.collections().by_id(id).await?.ok_or(AppError::NotFound)?;
+        let cwt = db
+            .collections()
+            .by_id(id)
+            .await?
+            .ok_or(AppError::NotFound)?;
         let items = db.collections().items_for(id).await?;
         Ok(build_payload(cwt, items))
     }
@@ -199,7 +210,11 @@ impl CollectionPostPayload {
 }
 
 impl CollectionItemPostPayload {
-    pub async fn add_to(self, db: &Database, collection_id: Uuid) -> Result<CollectionItemPayload, AppError> {
+    pub async fn add_to(
+        self,
+        db: &Database,
+        collection_id: Uuid,
+    ) -> Result<CollectionItemPayload, AppError> {
         let translations = item_translations_to_data(&self.translations);
         Ok(db
             .collections()

--- a/backend/src/dto/facet.rs
+++ b/backend/src/dto/facet.rs
@@ -47,6 +47,7 @@ impl FacetResponse {
     }
 }
 
+#[allow(clippy::single_match_else)]
 fn group_into_facets(rows: Vec<TaxonomyRow>) -> Vec<FacetResponse> {
     let mut facets: Vec<FacetResponse> = Vec::new();
 
@@ -64,7 +65,11 @@ fn group_into_facets(rows: Vec<TaxonomyRow>) -> Vec<FacetResponse> {
         };
 
         // Only the first occurrence per language wins
-        if !facet.translations.iter().any(|t| t.language_code == row.language_code) {
+        if !facet
+            .translations
+            .iter()
+            .any(|t| t.language_code == row.language_code)
+        {
             facet.translations.push(FacetTranslationPayload {
                 language_code: row.language_code.clone(),
                 label: row.facet_label.clone(),

--- a/backend/src/dto/production.rs
+++ b/backend/src/dto/production.rs
@@ -49,7 +49,11 @@ impl ProductionPayload {
     pub async fn update(self, db: &Database) -> Result<Self, AppError> {
         let translations = translations_to_data(&self.translations);
         let production: Production = self.into();
-        Ok(db.productions().update(production, translations).await?.into())
+        Ok(db
+            .productions()
+            .update(production, translations)
+            .await?
+            .into())
     }
 
     pub async fn delete(db: &Database, id: Uuid) -> Result<(), AppError> {
@@ -61,11 +65,17 @@ impl ProductionPostPayload {
     pub async fn create(self, db: &Database) -> Result<ProductionPayload, AppError> {
         let translations = translations_to_data(&self.translations);
         let production_create: ProductionCreate = self.into();
-        Ok(db.productions().insert(production_create, translations).await?.into())
+        Ok(db
+            .productions()
+            .insert(production_create, translations)
+            .await?
+            .into())
     }
 }
 
-fn translations_to_data(translations: &[ProductionTranslationPayload]) -> Vec<ProductionTranslationData> {
+fn translations_to_data(
+    translations: &[ProductionTranslationPayload],
+) -> Vec<ProductionTranslationData> {
     translations
         .iter()
         .map(|t| ProductionTranslationData {

--- a/backend/src/handlers/collection.rs
+++ b/backend/src/handlers/collection.rs
@@ -156,6 +156,9 @@ pub async fn delete_item(
     db: Database,
     Path((collection_id, item_id)): Path<(Uuid, Uuid)>,
 ) -> StatusResponse {
-    db.collections().delete_item(collection_id, item_id).await?.ok_or(AppError::NotFound)?;
+    db.collections()
+        .delete_item(collection_id, item_id)
+        .await?
+        .ok_or(AppError::NotFound)?;
     Ok(StatusCode::NO_CONTENT)
 }

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -5,8 +5,8 @@ use utoipa::IntoParams;
 use crate::error::AppError;
 
 pub mod admin;
-pub mod collection;
 pub mod auth;
+pub mod collection;
 pub mod event;
 pub mod hall;
 pub mod location;

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -20,7 +20,9 @@ use utoipa_swagger_ui::{Config, SwaggerUi};
 
 use crate::config::AppConfig;
 use crate::error::AppError;
-use crate::handlers::{admin, auth, collection, event, hall, location, production, space, taxonomy, version};
+use crate::handlers::{
+    admin, auth, collection, event, hall, location, production, space, taxonomy, version,
+};
 
 pub mod config;
 pub mod dto;

--- a/backend/tests/collection.rs
+++ b/backend/tests/collection.rs
@@ -36,7 +36,11 @@ async fn get_one_success(db: PgPool) {
     assert_eq!(data.id, target_id);
     assert_eq!(data.slug, "zomerselectie");
 
-    let nl = data.translations.iter().find(|t| t.language_code == "nl").expect("Dutch translation not found");
+    let nl = data
+        .translations
+        .iter()
+        .find(|t| t.language_code == "nl")
+        .expect("Dutch translation not found");
     assert_eq!(nl.title, "Zomerselectie");
 
     assert_eq!(data.items.len(), 2);
@@ -70,8 +74,16 @@ async fn post_success(db: PgPool) {
     let data: CollectionPayload = response.into_struct().await;
     assert_eq!(data.slug, "test-selectie");
 
-    let nl = data.translations.iter().find(|t| t.language_code == "nl").expect("Dutch translation not found");
-    let en = data.translations.iter().find(|t| t.language_code == "en").expect("English translation not found");
+    let nl = data
+        .translations
+        .iter()
+        .find(|t| t.language_code == "nl")
+        .expect("Dutch translation not found");
+    let en = data
+        .translations
+        .iter()
+        .find(|t| t.language_code == "en")
+        .expect("English translation not found");
     assert_eq!(nl.title, "Test Selectie");
     assert_eq!(en.title, "Test Selection");
     assert_eq!(nl.description, "");
@@ -122,7 +134,11 @@ async fn put_success(db: PgPool) {
     assert_eq!(data.id, target_id);
     assert_eq!(data.slug, "dans-2025-bijgewerkt");
 
-    let nl = data.translations.iter().find(|t| t.language_code == "nl").expect("Dutch translation not found");
+    let nl = data
+        .translations
+        .iter()
+        .find(|t| t.language_code == "nl")
+        .expect("Dutch translation not found");
     assert_eq!(nl.title, "Dans 2025 (bijgewerkt)");
 }
 
@@ -181,9 +197,7 @@ async fn delete_success(db: PgPool) {
 async fn delete_not_found(db: PgPool) {
     let app = TestRouter::as_editor(db).await;
 
-    let response = app
-        .delete(&format!("/collections/{}", Uuid::nil()))
-        .await;
+    let response = app.delete(&format!("/collections/{}", Uuid::nil())).await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
@@ -202,14 +216,20 @@ async fn post_item_success(db: PgPool) {
     .expect("Failed to deserialize CollectionItemPostPayload");
 
     let unauthenticated_response = unauthenticated_app
-        .post(&format!("/collections/{collection_id}/items"), &item_payload)
+        .post(
+            &format!("/collections/{collection_id}/items"),
+            &item_payload,
+        )
         .await;
     assert_eq!(unauthenticated_response.status(), StatusCode::UNAUTHORIZED);
 
     let app = TestRouter::as_editor(db).await;
 
     let response = app
-        .post(&format!("/collections/{collection_id}/items"), &item_payload)
+        .post(
+            &format!("/collections/{collection_id}/items"),
+            &item_payload,
+        )
         .await;
     assert_eq!(response.status(), StatusCode::CREATED);
 
@@ -250,7 +270,10 @@ async fn delete_item_not_found(db: PgPool) {
     let app = TestRouter::as_editor(db).await;
 
     let response = app
-        .delete(&format!("/collections/{collection_id}/items/{}", Uuid::nil()))
+        .delete(&format!(
+            "/collections/{collection_id}/items/{}",
+            Uuid::nil()
+        ))
         .await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }

--- a/backend/tests/production.rs
+++ b/backend/tests/production.rs
@@ -101,7 +101,11 @@ async fn post_success(db: PgPool) {
 
     let data: ProductionPayload = response.into_struct().await;
     assert_eq!(data.slug, "test-post-production");
-    let nl = data.translations.iter().find(|t| t.language_code == "nl").unwrap();
+    let nl = data
+        .translations
+        .iter()
+        .find(|t| t.language_code == "nl")
+        .unwrap();
     assert_eq!(nl.title.as_deref(), Some("Nieuwe Test Productie"));
     assert!(!data.id.is_nil());
 }
@@ -130,7 +134,11 @@ async fn put_success(db: PgPool) {
 
     let data: ProductionPayload = response.into_struct().await;
     assert_eq!(data.id, target_id);
-    let nl = data.translations.iter().find(|t| t.language_code == "nl").unwrap();
+    let nl = data
+        .translations
+        .iter()
+        .find(|t| t.language_code == "nl")
+        .unwrap();
     assert_eq!(nl.title.as_deref(), Some("Aangepaste Titel"));
 }
 


### PR DESCRIPTION
**Description**
Format the backend.
Add a macro to make processing the productions translations cleaner. (and fix the lint error)

**FOR REVIEWS**
The only files that have had actual changes (and not `cargo fmt`) are
[api/src/models/production.rs](https://github.com/SELab-2/viernulvier-6/pull/204/changes#diff-b0eaa1ba3942e13e75c89f60d6350523ba8ed3fb0ad58ab8d28ee7c08fdeb2a2)
[src/dto/facet.rs LINE 50](https://github.com/SELab-2/viernulvier-6/pull/204/changes#diff-41a45d41a6caf6e2925996c175f26edb4a209bb556315782f2acc4edad93425bR50)

**Related Issue**
Fixes #

**How Has This Been Tested?**
- [x] Local manual testing
- [ ] Added/updated unit or integration tests
- [ ] Tested in the staging environment

**Developer Checklist:**
- [x] I have performed a self-review of my own code.
- [x] I have left comments in hard-to-understand areas of my code.
- [x] My changes generate no new warnings or console errors.
- [ ] I have updated the documentation (if applicable).

**Screenshots / Video (if UI/UX changed):**
