### PR TITLE
chore: small aesthetics tweaks

### DIFF
--- a/frontend/src/app/[locale]/(app)/page.tsx
+++ b/frontend/src/app/[locale]/(app)/page.tsx
@@ -132,9 +132,6 @@ export default function HomePage() {
                 <p className="text-muted-foreground font-body max-w-[480px] text-sm leading-relaxed">
                     {t("about.text")}
                 </p>
-                <span className="text-muted-foreground font-mono text-[9px] tracking-[1.4px] uppercase sm:text-[10px]">
-                    {t("about.address")}
-                </span>
             </section>
         </>
     );

--- a/frontend/src/app/[locale]/(app)/page.tsx
+++ b/frontend/src/app/[locale]/(app)/page.tsx
@@ -69,7 +69,7 @@ export default function HomePage() {
             />
 
             {/* Hero */}
-            <section className="border-muted/30 flex flex-col items-center gap-6 border-b px-4 py-16 text-center sm:px-10 sm:py-24">
+            <section className="flex flex-col items-center gap-6 px-4 py-16 text-center sm:px-10 sm:py-24">
                 <h1 className="font-display text-foreground text-[40px] leading-[1.05] font-bold tracking-[-0.03em] sm:text-[64px] md:text-[72px]">
                     {t("hero.title")}
                 </h1>

--- a/frontend/src/components/homepage/featured-section/FeaturedSection.tsx
+++ b/frontend/src/components/homepage/featured-section/FeaturedSection.tsx
@@ -41,13 +41,13 @@ export function FeaturedSection() {
     const t = useTranslations("Featured");
 
     return (
-        <div className="border-foreground border-b-2">
+        <div>
             <div className="text-muted-foreground mb-3 flex items-center gap-2.5 font-mono text-[9px] font-medium tracking-[2px] uppercase">
                 {t("label")}
                 <span className="bg-muted/40 h-px flex-1" />
             </div>
 
-            <div className="bg-muted border-muted -mx-4 grid grid-cols-1 gap-px border sm:-mx-[30px] sm:grid-cols-[1.6fr_1fr_1fr]">
+            <div className="bg-muted border-foreground -mx-4 grid grid-cols-1 gap-px border-x border-b-2 sm:-mx-[30px] sm:grid-cols-[1.6fr_1fr_1fr]">
                 {FEATURED_ITEMS.map((item, index) => (
                     <FeaturedCard key={item.title} item={item} isFirst={index === 0} />
                 ))}

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -89,8 +89,8 @@
     "Home": {
         "loading": "Loading archive...",
         "hero": {
-            "title": "The story of De Vooruit",
-            "subtitle": "Over a century of theatre, dance, music and nightlife in the heart of Ghent.",
+            "title": "The VIERNULVIER archive",
+            "subtitle": "Over 40 years of theatre, dance, music and nightlife in Ghent.",
             "searchPlaceholder": "Search the archive\u2026"
         },
         "tags": {
@@ -101,8 +101,7 @@
         },
         "about": {
             "title": "Arts Centre VIERNULVIER",
-            "text": "Since 1883, De Vooruit has been a breeding ground for art, culture and society. From revolutionary parties to contemporary performance \u2014 the archive preserves it all.",
-            "address": "Sint-Pietersnieuwstraat 23 \u00b7 9000 Ghent"
+            "text": "Since 1883, De Vooruit has been a breeding ground for art, culture and society. From revolutionary parties to contemporary performance. The archive preserves it all."
         },
         "latest": {
             "label": "Latest productions",

--- a/frontend/src/messages/nl.json
+++ b/frontend/src/messages/nl.json
@@ -89,8 +89,8 @@
     "Home": {
         "loading": "Archief laden...",
         "hero": {
-            "title": "Het verhaal van De Vooruit",
-            "subtitle": "Meer dan een eeuw theater, dans, muziek en nachtleven in het hart van Gent.",
+            "title": "Het archief van VIERNULVIER",
+            "subtitle": "Meer dan 40 jaar theater, dans, muziek en nachtleven in Gent.",
             "searchPlaceholder": "Zoek in het archief\u2026"
         },
         "tags": {
@@ -101,8 +101,7 @@
         },
         "about": {
             "title": "Kunstencentrum VIERNULVIER",
-            "text": "Sinds 1883 is De Vooruit een broedplaats voor kunst, cultuur en samenleving. Van revolutionaire feesten tot hedendaagse performance \u2014 het archief bewaart het allemaal.",
-            "address": "Sint-Pietersnieuwstraat 23 \u00b7 9000 Gent"
+            "text": "Sinds 1883 is De Vooruit een broedplaats voor kunst, cultuur en samenleving. Van revolutionaire feesten tot hedendaagse performance. Het archief bewaart het allemaal."
         },
         "latest": {
             "label": "Laatste producties",

--- a/frontend/src/types/api/generated.ts
+++ b/frontend/src/types/api/generated.ts
@@ -66,7 +66,7 @@ export interface paths {
         get: operations["get_all_collections"];
         /** @description Update the metadata (slug, titles, descriptions) of an existing collection. Requires editor authentication. Does not affect items — use the items sub-resource for that. */
         put: operations["update_collection"];
-        /** @description Create a new collection. Requires editor authentication. Supply a human-readable slug that will appear in the shareable URL (e.g. `videodroom-candidates-2026`), bilingual titles, and optional bilingual descriptions. Items are added separately via POST /collections/{id}/items. */
+        /** @description Create a new collection. Requires editor authentication. Supply a human-readable slug that will appear in the shareable URL (e.g. `videodroom-candidates-2026`) and per-language translations (title required, description required but may be empty). Items are added separately via POST /collections/{id}/items. */
         post: operations["create_collection"];
         delete?: never;
         options?: never;
@@ -426,7 +426,7 @@ export interface components {
             id: string;
             /**
              * Format: int32
-             * @description Zero-based display order within the collection.
+             * @description Display order within the collection (1-based).
              */
             position: number;
             /** @description Per-language curator annotation for this item. */
@@ -442,11 +442,11 @@ export interface components {
             content_type: components["schemas"]["CollectionContentType"];
             /**
              * Format: int32
-             * @description Zero-based display order within the collection.
+             * @description Display order within the collection (1-based).
              */
             position: number;
             /** @description Per-language curator annotation for this item. */
-            translations: components["schemas"]["CollectionItemTranslationPayload"][];
+            translations?: components["schemas"]["CollectionItemTranslationPayload"][];
         };
         CollectionItemTranslationPayload: {
             comment?: string | null;


### PR DESCRIPTION
Removes the bottom border from the hero section and moves the heavy border to the featured section's sides and bottom, cleaning up visual separation between sections.

Updates homepage copy: renames "De Vooruit" to "VIERNULVIER archive" in both NL and EN, adjusts the subtitle timeframe from "a century" to "40 years", and removes the duplicate address line from the About section (already shown in the footer).

Also includes regenerated API types from recent backend collection changes (position is now 1-based, item translations are optional).