### PR TITLE
fix(auth): restore middleware.ts for auth redirects

### DIFF
--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -4,7 +4,7 @@ import { routing } from "@/i18n/routing";
 
 const intlMiddleware = createIntlMiddleware(routing);
 
-export function proxy(request: NextRequest) {
+export function middleware(request: NextRequest) {
     const token = request.cookies.get("access_token")?.value;
     const pathname = request.nextUrl.pathname;
 


### PR DESCRIPTION
**Description**
Restore middleware.ts convention for auth redirects. Next.js 16's proxy.ts has issues with cookie reading/execution order, causing login redirects to fail silently. Using middleware.ts (still supported) fixes this.

This issue seems to only take place in safari (tested in macOS Tahoe 26.2)

**Related Issue**
login redirect not working, remained on login page after login 200 Ok

**How Has This Been Tested?**
- [x] Local manual testing (Safari & chrome)
- [ ] Added/updated unit or integration tests
- [ ] Tested in the staging environment

**Developer Checklist:**
- [x] I have performed a self-review of my own code.
- [ ] I have left comments in hard-to-understand areas of my code.
- [x] My changes generate no new warnings or console errors.
- [ ] I have updated the documentation (if applicable).