### PR TITLE
feat(backend): improve importer error handling

### DIFF
--- a/backend/api/Cargo.toml
+++ b/backend/api/Cargo.toml
@@ -22,7 +22,7 @@ ai-normalization = ["dep:scraper"]
 [dependencies]
 database = { path = "../database" }
 tracing = { workspace = true }
-tokio = { workspace = true, features = ["fs", "io-util", "rt", "rt-multi-thread", "macros"] }
+tokio = { workspace = true, features = ["fs", "io-util", "rt", "rt-multi-thread", "macros", "time"] }
 tracing-subscriber = { version = "=0.3", default-features = false, features = ["env-filter", "fmt", "ansi"] }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/backend/api/src/error.rs
+++ b/backend/api/src/error.rs
@@ -1,5 +1,186 @@
+use database::{error::DatabaseError, models::import_error::ImportErrorCreate};
 use thiserror::Error;
+use uuid::Uuid;
 
+// ImportEntity, ImportField and ImportRelation are small enums that allow
+// for stuff like ImportEntity::Event, removing strings from the picture
+
+/// Speciefies what entity we are importing
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImportEntity {
+    Event,
+    EventPrice,
+    Gallery,
+    Hall,
+    Location,
+    Media,
+    MediaVariant,
+    Price,
+    PriceRank,
+    Production,
+    Space,
+}
+
+impl ImportEntity {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Event => "event",
+            Self::EventPrice => "event_price",
+            Self::Gallery => "gallery",
+            Self::Hall => "hall",
+            Self::Location => "location",
+            Self::Media => "media",
+            Self::MediaVariant => "media_variant",
+            Self::Price => "price",
+            Self::PriceRank => "price_rank",
+            Self::Production => "production",
+            Self::Space => "space",
+        }
+    }
+}
+
+impl From<&'static str> for ImportEntity {
+    fn from(value: &'static str) -> Self {
+        match value {
+            "event" => Self::Event,
+            "event_price" => Self::EventPrice,
+            "gallery" => Self::Gallery,
+            "hall" => Self::Hall,
+            "location" => Self::Location,
+            "media" => Self::Media,
+            "media_variant" => Self::MediaVariant,
+            "price" => Self::Price,
+            "price_rank" => Self::PriceRank,
+            "production" => Self::Production,
+            "space" => Self::Space,
+            other => panic!("unknown import entity: {other}"),
+        }
+    }
+}
+
+/// Specifies what field causes problems
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImportField {
+    Amount,
+    CdnUrl,
+    Crop,
+    Event,
+    Format,
+    GalleryUrl,
+    Location,
+    MaxTicketsPerOrder,
+    Name,
+    OpenSeating,
+    Price,
+    Production,
+    Rank,
+    SeatSelection,
+    SourceId,
+    SourceUri,
+}
+
+impl ImportField {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Amount => "amount",
+            Self::CdnUrl => "cdn_url",
+            Self::Crop => "crop",
+            Self::Event => "event",
+            Self::Format => "format",
+            Self::GalleryUrl => "gallery_url",
+            Self::Location => "location",
+            Self::MaxTicketsPerOrder => "max_tickets_per_order",
+            Self::Name => "name",
+            Self::OpenSeating => "open_seating",
+            Self::Price => "price",
+            Self::Production => "production",
+            Self::Rank => "rank",
+            Self::SeatSelection => "seat_selection",
+            Self::SourceId => "source_id",
+            Self::SourceUri => "source_uri",
+        }
+    }
+}
+
+impl From<&'static str> for ImportField {
+    fn from(value: &'static str) -> Self {
+        match value {
+            "amount" => Self::Amount,
+            "cdn_url" => Self::CdnUrl,
+            "crop" => Self::Crop,
+            "event" => Self::Event,
+            "format" => Self::Format,
+            "gallery_url" => Self::GalleryUrl,
+            "location" => Self::Location,
+            "max_tickets_per_order" => Self::MaxTicketsPerOrder,
+            "name" => Self::Name,
+            "open_seating" => Self::OpenSeating,
+            "price" => Self::Price,
+            "production" => Self::Production,
+            "rank" => Self::Rank,
+            "seat_selection" => Self::SeatSelection,
+            "source_id" => Self::SourceId,
+            "source_uri" => Self::SourceUri,
+            other => panic!("unknown import field: {other}"),
+        }
+    }
+}
+
+/// Specifies which linked entity is involved
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImportRelation {
+    Event,
+    EventPrice,
+    Gallery,
+    Hall,
+    Location,
+    Media,
+    MediaVariant,
+    Price,
+    PriceRank,
+    Production,
+    Space,
+}
+
+impl ImportRelation {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Event => "event",
+            Self::EventPrice => "event_price",
+            Self::Gallery => "gallery",
+            Self::Hall => "hall",
+            Self::Location => "location",
+            Self::Media => "media",
+            Self::MediaVariant => "media_variant",
+            Self::Price => "price",
+            Self::PriceRank => "price_rank",
+            Self::Production => "production",
+            Self::Space => "space",
+        }
+    }
+}
+
+impl From<&'static str> for ImportRelation {
+    fn from(value: &'static str) -> Self {
+        match value {
+            "event" => Self::Event,
+            "event_price" => Self::EventPrice,
+            "gallery" => Self::Gallery,
+            "hall" => Self::Hall,
+            "location" => Self::Location,
+            "media" => Self::Media,
+            "media_variant" => Self::MediaVariant,
+            "price" => Self::Price,
+            "price_rank" => Self::PriceRank,
+            "production" => Self::Production,
+            "space" => Self::Space,
+            other => panic!("unknown import relation: {other}"),
+        }
+    }
+}
+
+/// Enum for importer-level failures, like S3 or IO issues, or network issues.
+/// These are run-ending failures.
 #[derive(Debug, Error)]
 pub enum ImporterError {
     #[error("Reqwest error: {0}")]
@@ -10,4 +191,597 @@ pub enum ImporterError {
 
     #[error("S3 error: {0}")]
     S3(String),
+}
+
+/// Errors are modeled as explicit enums so we don't end up matching on hardcoded
+/// strings when reporting them.
+#[derive(Debug)]
+pub struct ItemConversion<T> {
+    pub value: T,
+    pub warnings: Vec<ImportItemWarning>,
+}
+
+impl<T> ItemConversion<T> {
+    /// Creates a successful conversion result when there is nothing to warn about.
+    pub fn without_warnings(value: T) -> Self {
+        Self {
+            value,
+            warnings: Vec::new(),
+        }
+    }
+}
+
+/// Enum for item-level failures: these get recorded in our DB table import_errors, and skipped
+/// entirely. Non run-ending.
+#[derive(Debug, Error)]
+pub enum ImportItemError {
+    #[error("{entity} has invalid {field}: {value}")]
+    InvalidReference {
+        entity: ImportEntity,
+        field: ImportField,
+        value: String,
+    },
+
+    #[error("{entity} references missing {relation} source_id {source_id}")]
+    MissingRelation {
+        entity: ImportEntity,
+        relation: ImportRelation,
+        source_id: i32,
+    },
+
+    #[error("{entity} is missing required field {field}")]
+    MissingRequiredField {
+        entity: ImportEntity,
+        field: ImportField,
+    },
+
+    #[error("{entity}.{field} is out of range: {value}")]
+    OutOfRange {
+        entity: ImportEntity,
+        field: ImportField,
+        value: String,
+    },
+
+    #[error("failed to load {relation} source_id {source_id} for {entity}: {source}")]
+    DatabaseLookup {
+        entity: ImportEntity,
+        relation: ImportRelation,
+        source_id: i32,
+        #[source]
+        source: DatabaseError,
+    },
+
+    #[error("failed to persist {entity} {source_id:?}: {source}")]
+    DatabaseWrite {
+        entity: ImportEntity,
+        source_id: Option<i32>,
+        #[source]
+        source: DatabaseError,
+    },
+
+    #[error("failed to import {entity} {source_id:?}: {message}")]
+    ImportFailure {
+        entity: ImportEntity,
+        field: Option<ImportField>,
+        source_id: Option<i32>,
+        message: String,
+    },
+}
+
+impl ImportItemError {
+    pub fn to_import_error(&self, run_id: Uuid, item_source_id: Option<i32>) -> ImportErrorCreate {
+        let mut error = ImportErrorCreate {
+            run_id: Some(run_id),
+            severity: "error".into(),
+            entity: self.entity().into(),
+            source_id: self.source_id().or(item_source_id),
+            error_kind: self.kind().into(),
+            field: self.field().map(Into::into),
+            relation: self.relation().map(Into::into),
+            relation_source_id: self.relation_source_id(),
+            message: self.to_string(),
+            payload: None,
+        };
+
+        if let Self::InvalidReference { value, .. } | Self::OutOfRange { value, .. } = self {
+            error.payload = Some(serde_json::json!({ "value": value }));
+        }
+
+        error
+    }
+
+    fn entity(&self) -> &'static str {
+        match self {
+            Self::InvalidReference { entity, .. }
+            | Self::MissingRelation { entity, .. }
+            | Self::MissingRequiredField { entity, .. }
+            | Self::OutOfRange { entity, .. }
+            | Self::DatabaseLookup { entity, .. }
+            | Self::DatabaseWrite { entity, .. }
+            | Self::ImportFailure { entity, .. } => entity.as_str(),
+        }
+    }
+
+    fn kind(&self) -> &'static str {
+        match self {
+            Self::InvalidReference { .. } => "invalid_reference",
+            Self::MissingRelation { .. } => "missing_relation",
+            Self::MissingRequiredField { .. } => "missing_required_field",
+            Self::OutOfRange { .. } => "out_of_range",
+            Self::DatabaseLookup { .. } => "database_lookup",
+            Self::DatabaseWrite { .. } => "database_write",
+            Self::ImportFailure { .. } => "import_failure",
+        }
+    }
+
+    fn field(&self) -> Option<&'static str> {
+        match self {
+            Self::InvalidReference { field, .. }
+            | Self::MissingRequiredField { field, .. }
+            | Self::OutOfRange { field, .. } => Some(field.as_str()),
+            Self::ImportFailure { field, .. } => field.map(ImportField::as_str),
+            Self::MissingRelation { .. }
+            | Self::DatabaseLookup { .. }
+            | Self::DatabaseWrite { .. } => None,
+        }
+    }
+
+    fn relation(&self) -> Option<&'static str> {
+        match self {
+            Self::MissingRelation { relation, .. } | Self::DatabaseLookup { relation, .. } => {
+                Some(relation.as_str())
+            }
+            Self::InvalidReference { .. }
+            | Self::MissingRequiredField { .. }
+            | Self::OutOfRange { .. }
+            | Self::DatabaseWrite { .. }
+            | Self::ImportFailure { .. } => None,
+        }
+    }
+
+    fn relation_source_id(&self) -> Option<i32> {
+        match self {
+            Self::MissingRelation { source_id, .. } | Self::DatabaseLookup { source_id, .. } => {
+                Some(*source_id)
+            }
+            Self::InvalidReference { .. }
+            | Self::MissingRequiredField { .. }
+            | Self::OutOfRange { .. }
+            | Self::DatabaseWrite { .. }
+            | Self::ImportFailure { .. } => None,
+        }
+    }
+
+    fn source_id(&self) -> Option<i32> {
+        match self {
+            Self::DatabaseWrite { source_id, .. } | Self::ImportFailure { source_id, .. } => {
+                *source_id
+            }
+            Self::InvalidReference { .. }
+            | Self::MissingRelation { .. }
+            | Self::MissingRequiredField { .. }
+            | Self::OutOfRange { .. }
+            | Self::DatabaseLookup { .. } => None,
+        }
+    }
+
+    pub fn invalid_reference(
+        entity: impl Into<ImportEntity>,
+        field: impl Into<ImportField>,
+        value: impl Into<String>,
+    ) -> Self {
+        Self::InvalidReference {
+            entity: entity.into(),
+            field: field.into(),
+            value: value.into(),
+        }
+    }
+
+    pub fn missing_relation(
+        entity: impl Into<ImportEntity>,
+        relation: impl Into<ImportRelation>,
+        source_id: i32,
+    ) -> Self {
+        Self::MissingRelation {
+            entity: entity.into(),
+            relation: relation.into(),
+            source_id,
+        }
+    }
+
+    pub fn missing_required_field(
+        entity: impl Into<ImportEntity>,
+        field: impl Into<ImportField>,
+    ) -> Self {
+        Self::MissingRequiredField {
+            entity: entity.into(),
+            field: field.into(),
+        }
+    }
+
+    pub fn out_of_range(
+        entity: impl Into<ImportEntity>,
+        field: impl Into<ImportField>,
+        value: impl Into<String>,
+    ) -> Self {
+        Self::OutOfRange {
+            entity: entity.into(),
+            field: field.into(),
+            value: value.into(),
+        }
+    }
+
+    pub fn database_lookup(
+        entity: impl Into<ImportEntity>,
+        relation: impl Into<ImportRelation>,
+        source_id: i32,
+        source: DatabaseError,
+    ) -> Self {
+        Self::DatabaseLookup {
+            entity: entity.into(),
+            relation: relation.into(),
+            source_id,
+            source,
+        }
+    }
+
+    pub fn database_write(
+        entity: impl Into<ImportEntity>,
+        source_id: Option<i32>,
+        source: DatabaseError,
+    ) -> Self {
+        Self::DatabaseWrite {
+            entity: entity.into(),
+            source_id,
+            source,
+        }
+    }
+
+    pub fn import_failure(
+        entity: impl Into<ImportEntity>,
+        field: Option<ImportField>,
+        source_id: Option<i32>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self::ImportFailure {
+            entity: entity.into(),
+            field,
+            source_id,
+            message: message.into(),
+        }
+    }
+}
+
+/// Enum for item-level issues like missing references or unexpected values.
+/// These items still get logged in our DB, but the warning is recorded in the import_errors DB
+/// table.
+#[derive(Debug, Error)]
+pub enum ImportItemWarning {
+    #[error("{entity}.{field} has unexpected value {value:?}, defaulting to {fallback}")]
+    UnexpectedFieldValue {
+        entity: ImportEntity,
+        field: ImportField,
+        value: String,
+        fallback: &'static str,
+    },
+
+    #[error("{entity} references missing optional {relation} source_id {source_id}")]
+    MissingOptionalRelation {
+        entity: ImportEntity,
+        relation: ImportRelation,
+        source_id: i32,
+    },
+}
+
+impl ImportItemWarning {
+    pub fn missing_optional_relation(
+        entity: impl Into<ImportEntity>,
+        relation: impl Into<ImportRelation>,
+        source_id: i32,
+    ) -> Self {
+        Self::MissingOptionalRelation {
+            entity: entity.into(),
+            relation: relation.into(),
+            source_id,
+        }
+    }
+
+    pub fn to_import_error(&self, run_id: Uuid, item_source_id: Option<i32>) -> ImportErrorCreate {
+        ImportErrorCreate {
+            run_id: Some(run_id),
+            severity: "warning".into(),
+            entity: self.entity().into(),
+            source_id: item_source_id,
+            error_kind: self.kind().into(),
+            field: self.field().map(Into::into),
+            relation: self.relation().map(Into::into),
+            relation_source_id: self.relation_source_id(),
+            message: self.to_string(),
+            payload: self.payload(),
+        }
+    }
+
+    fn entity(&self) -> &'static str {
+        match self {
+            Self::UnexpectedFieldValue { entity, .. }
+            | Self::MissingOptionalRelation { entity, .. } => entity.as_str(),
+        }
+    }
+
+    fn kind(&self) -> &'static str {
+        match self {
+            Self::UnexpectedFieldValue { .. } => "unexpected_field_value",
+            Self::MissingOptionalRelation { .. } => "missing_optional_relation",
+        }
+    }
+
+    fn field(&self) -> Option<&'static str> {
+        match self {
+            Self::UnexpectedFieldValue { field, .. } => Some(field.as_str()),
+            Self::MissingOptionalRelation { .. } => None,
+        }
+    }
+
+    fn relation(&self) -> Option<&'static str> {
+        match self {
+            Self::MissingOptionalRelation { relation, .. } => Some(relation.as_str()),
+            Self::UnexpectedFieldValue { .. } => None,
+        }
+    }
+
+    fn relation_source_id(&self) -> Option<i32> {
+        match self {
+            Self::MissingOptionalRelation { source_id, .. } => Some(*source_id),
+            Self::UnexpectedFieldValue { .. } => None,
+        }
+    }
+
+    fn payload(&self) -> Option<serde_json::Value> {
+        match self {
+            Self::UnexpectedFieldValue {
+                value, fallback, ..
+            } => Some(serde_json::json!({
+                "value": value,
+                "fallback": fallback,
+            })),
+            Self::MissingOptionalRelation { .. } => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn run_id() -> Uuid {
+        Uuid::nil()
+    }
+
+    #[test]
+    fn import_entities_have_stable_database_values() {
+        let values = [
+            (ImportEntity::Event, "event"),
+            (ImportEntity::EventPrice, "event_price"),
+            (ImportEntity::Gallery, "gallery"),
+            (ImportEntity::Hall, "hall"),
+            (ImportEntity::Location, "location"),
+            (ImportEntity::Media, "media"),
+            (ImportEntity::MediaVariant, "media_variant"),
+            (ImportEntity::Price, "price"),
+            (ImportEntity::PriceRank, "price_rank"),
+            (ImportEntity::Production, "production"),
+            (ImportEntity::Space, "space"),
+        ];
+
+        for (entity, value) in values {
+            assert_eq!(entity.to_string(), value);
+            assert_eq!(ImportEntity::from(value), entity);
+        }
+    }
+
+    #[test]
+    fn import_fields_have_stable_database_values() {
+        let values = [
+            (ImportField::Amount, "amount"),
+            (ImportField::CdnUrl, "cdn_url"),
+            (ImportField::Crop, "crop"),
+            (ImportField::Event, "event"),
+            (ImportField::Format, "format"),
+            (ImportField::GalleryUrl, "gallery_url"),
+            (ImportField::Location, "location"),
+            (ImportField::MaxTicketsPerOrder, "max_tickets_per_order"),
+            (ImportField::Name, "name"),
+            (ImportField::OpenSeating, "open_seating"),
+            (ImportField::Price, "price"),
+            (ImportField::Production, "production"),
+            (ImportField::Rank, "rank"),
+            (ImportField::SeatSelection, "seat_selection"),
+            (ImportField::SourceId, "source_id"),
+            (ImportField::SourceUri, "source_uri"),
+        ];
+
+        for (field, value) in values {
+            assert_eq!(field.to_string(), value);
+            assert_eq!(ImportField::from(value), field);
+        }
+    }
+
+    #[test]
+    fn import_relations_have_stable_database_values() {
+        let values = [
+            (ImportRelation::Event, "event"),
+            (ImportRelation::EventPrice, "event_price"),
+            (ImportRelation::Gallery, "gallery"),
+            (ImportRelation::Hall, "hall"),
+            (ImportRelation::Location, "location"),
+            (ImportRelation::Media, "media"),
+            (ImportRelation::MediaVariant, "media_variant"),
+            (ImportRelation::Price, "price"),
+            (ImportRelation::PriceRank, "price_rank"),
+            (ImportRelation::Production, "production"),
+            (ImportRelation::Space, "space"),
+        ];
+
+        for (relation, value) in values {
+            assert_eq!(relation.to_string(), value);
+            assert_eq!(ImportRelation::from(value), relation);
+        }
+    }
+
+    #[test]
+    fn invalid_reference_maps_entity_kind_field_and_payload() {
+        let err = ImportItemError::invalid_reference("space", "location", "/garbage");
+        let record = err.to_import_error(run_id(), Some(99));
+
+        assert_eq!(record.severity, "error");
+        assert_eq!(record.entity, "space");
+        assert_eq!(record.error_kind, "invalid_reference");
+        assert_eq!(record.field.as_deref(), Some("location"));
+        assert!(record.relation.is_none());
+        assert!(record.relation_source_id.is_none());
+        assert_eq!(record.source_id, Some(99));
+        assert_eq!(
+            record.payload,
+            Some(serde_json::json!({ "value": "/garbage" }))
+        );
+    }
+
+    #[test]
+    fn missing_relation_maps_relation_and_relation_source_id() {
+        let err = ImportItemError::missing_relation("space", "location", 7);
+        let record = err.to_import_error(run_id(), Some(42));
+
+        assert_eq!(record.entity, "space");
+        assert_eq!(record.error_kind, "missing_relation");
+        assert!(record.field.is_none());
+        assert_eq!(record.relation.as_deref(), Some("location"));
+        assert_eq!(record.relation_source_id, Some(7));
+        // No payload when there's no value to attach.
+        assert!(record.payload.is_none());
+    }
+
+    #[test]
+    fn missing_required_field_maps_field_only() {
+        let err = ImportItemError::missing_required_field("hall", "name");
+        let record = err.to_import_error(run_id(), Some(1));
+
+        assert_eq!(record.entity, "hall");
+        assert_eq!(record.error_kind, "missing_required_field");
+        assert_eq!(record.field.as_deref(), Some("name"));
+        assert!(record.relation.is_none());
+    }
+
+    #[test]
+    fn out_of_range_maps_field_and_payload() {
+        let err = ImportItemError::out_of_range("event", "max_tickets_per_order", "9999999999");
+        let record = err.to_import_error(run_id(), Some(100));
+
+        assert_eq!(record.error_kind, "out_of_range");
+        assert_eq!(record.field.as_deref(), Some("max_tickets_per_order"));
+        assert_eq!(
+            record.payload,
+            Some(serde_json::json!({ "value": "9999999999" }))
+        );
+    }
+
+    #[test]
+    fn database_lookup_maps_relation_metadata() {
+        let err = ImportItemError::database_lookup("space", "location", 5, DatabaseError::NotFound);
+        let record = err.to_import_error(run_id(), None);
+
+        assert_eq!(record.error_kind, "database_lookup");
+        assert_eq!(record.relation.as_deref(), Some("location"));
+        assert_eq!(record.relation_source_id, Some(5));
+    }
+
+    #[test]
+    fn database_write_prefers_own_source_id_over_item_source_id() {
+        let err = ImportItemError::database_write("space", Some(11), DatabaseError::NotFound);
+        let record = err.to_import_error(run_id(), Some(99));
+
+        assert_eq!(record.error_kind, "database_write");
+        // The variant carries its own source_id, which should win over the item-level fallback.
+        assert_eq!(record.source_id, Some(11));
+    }
+
+    #[test]
+    fn database_write_falls_back_to_item_source_id() {
+        let err = ImportItemError::database_write("space", None, DatabaseError::NotFound);
+        let record = err.to_import_error(run_id(), Some(99));
+
+        assert_eq!(record.source_id, Some(99));
+    }
+
+    #[test]
+    fn import_failure_maps_entity_source_id_and_field() {
+        let err = ImportItemError::import_failure(
+            ImportEntity::Media,
+            Some(ImportField::CdnUrl),
+            Some(404),
+            "download failed",
+        );
+        let record = err.to_import_error(run_id(), None);
+
+        assert_eq!(record.entity, "media");
+        assert_eq!(record.source_id, Some(404));
+        assert_eq!(record.error_kind, "import_failure");
+        assert_eq!(record.field.as_deref(), Some("cdn_url"));
+        assert!(record.relation.is_none());
+        assert!(record.payload.is_none());
+    }
+
+    #[test]
+    fn warning_unexpected_field_value_maps_payload_with_value_and_fallback() {
+        let warning = ImportItemWarning::UnexpectedFieldValue {
+            entity: ImportEntity::Hall,
+            field: ImportField::SeatSelection,
+            value: "yes".into(),
+            fallback: "false",
+        };
+        let record = warning.to_import_error(run_id(), Some(8));
+
+        assert_eq!(record.severity, "warning");
+        assert_eq!(record.entity, "hall");
+        assert_eq!(record.error_kind, "unexpected_field_value");
+        assert_eq!(record.field.as_deref(), Some("seat_selection"));
+        assert_eq!(record.source_id, Some(8));
+        assert_eq!(
+            record.payload,
+            Some(serde_json::json!({
+                "value": "yes",
+                "fallback": "false",
+            }))
+        );
+    }
+
+    #[test]
+    fn warning_missing_optional_relation_maps_relation_metadata() {
+        let warning = ImportItemWarning::missing_optional_relation("hall", "space", 4);
+        let record = warning.to_import_error(run_id(), Some(8));
+
+        assert_eq!(record.severity, "warning");
+        assert_eq!(record.error_kind, "missing_optional_relation");
+        assert_eq!(record.relation.as_deref(), Some("space"));
+        assert_eq!(record.relation_source_id, Some(4));
+        assert!(record.field.is_none());
+        assert!(record.payload.is_none());
+    }
+}
+
+impl std::fmt::Display for ImportEntity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::fmt::Display for ImportField {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::fmt::Display for ImportRelation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
 }

--- a/backend/api/src/insert/event_prices.rs
+++ b/backend/api/src/insert/event_prices.rs
@@ -1,61 +1,143 @@
-use database::{Database, error::DatabaseError};
-use tracing::warn;
+use database::Database;
 
-use crate::helper::{extract_source_id, parse_amount_cents};
 use crate::models::event_price::ApiEventPrice;
+use crate::{
+    error::{ImportEntity, ImportField, ImportItemError, ImportRelation, ItemConversion},
+    helper::{extract_source_id, parse_amount_cents},
+};
 
 impl ApiEventPrice {
-    pub async fn insert(self, db: &Database) -> Result<(), DatabaseError> {
+    pub async fn upsert_import(
+        self,
+        db: &Database,
+    ) -> Result<ItemConversion<Option<i32>>, ImportItemError> {
+        let event_price_source_id = extract_source_id(&self.id);
+
         let Some(amount_cents) = parse_amount_cents(&self.amount) else {
-            warn!(
-                "EventPrices: invalid amount '{}' for event price {}, skipping",
-                self.amount, self.id
-            );
-            return Ok(());
+            return Err(ImportItemError::invalid_reference(
+                ImportEntity::EventPrice,
+                ImportField::Amount,
+                &self.amount,
+            ));
         };
 
         let Some(event_source_id) = extract_source_id(&self.event) else {
-            warn!("EventPrices: event_price has no event source_id, skipping");
-            return Ok(());
+            return Err(ImportItemError::invalid_reference(
+                ImportEntity::EventPrice,
+                ImportField::Event,
+                &self.event,
+            ));
         };
 
         let Some(price_source_id) = extract_source_id(&self.price) else {
-            warn!("EventPrices: event_price has no price source_id, skipping");
-            return Ok(());
+            return Err(ImportItemError::invalid_reference(
+                ImportEntity::EventPrice,
+                ImportField::Price,
+                &self.price,
+            ));
         };
 
         let Some(rank_source_id) = extract_source_id(&self.rank) else {
-            warn!("EventPrices: event_price has no rank source_id, skipping");
-            return Ok(());
+            return Err(ImportItemError::invalid_reference(
+                ImportEntity::EventPrice,
+                ImportField::Rank,
+                &self.rank,
+            ));
         };
 
-        let Some(event) = db.events().by_source_id(event_source_id).await? else {
-            warn!("EventPrices: event source_id {event_source_id} not found in db, skipping");
-            return Ok(());
-        };
+        let event = db
+            .events()
+            .by_source_id(event_source_id)
+            .await
+            .map_err(|err| {
+                ImportItemError::database_lookup(
+                    ImportEntity::EventPrice,
+                    ImportRelation::Event,
+                    event_source_id,
+                    err,
+                )
+            })?
+            .ok_or_else(|| {
+                ImportItemError::missing_relation(
+                    ImportEntity::EventPrice,
+                    ImportRelation::Event,
+                    event_source_id,
+                )
+            })?;
 
-        let Some(price) = db.prices().by_source_id(price_source_id).await? else {
-            warn!("EventPrices: price source_id {price_source_id} not found in db, skipping");
-            return Ok(());
-        };
+        let price = db
+            .prices()
+            .by_source_id(price_source_id)
+            .await
+            .map_err(|err| {
+                ImportItemError::database_lookup(
+                    ImportEntity::EventPrice,
+                    ImportRelation::Price,
+                    price_source_id,
+                    err,
+                )
+            })?
+            .ok_or_else(|| {
+                ImportItemError::missing_relation(
+                    ImportEntity::EventPrice,
+                    ImportRelation::Price,
+                    price_source_id,
+                )
+            })?;
 
-        let Some(rank) = db.price_ranks().by_source_id(rank_source_id).await? else {
-            warn!("EventPrices: rank source_id {rank_source_id} not found in db, skipping");
-            return Ok(());
-        };
+        let rank = db
+            .price_ranks()
+            .by_source_id(rank_source_id)
+            .await
+            .map_err(|err| {
+                ImportItemError::database_lookup(
+                    ImportEntity::EventPrice,
+                    ImportRelation::PriceRank,
+                    rank_source_id,
+                    err,
+                )
+            })?
+            .ok_or_else(|| {
+                ImportItemError::missing_relation(
+                    ImportEntity::EventPrice,
+                    ImportRelation::PriceRank,
+                    rank_source_id,
+                )
+            })?;
 
-        let source_id = extract_source_id(&self.id);
-
-        if let Some(source_id) = source_id
-            && let Some(existing) = db.event_prices().by_source_id(source_id).await?
+        if let Some(source_id) = event_price_source_id
+            && let Some(existing) =
+                db.event_prices()
+                    .by_source_id(source_id)
+                    .await
+                    .map_err(|err| {
+                        ImportItemError::database_lookup(
+                            ImportEntity::EventPrice,
+                            ImportRelation::EventPrice,
+                            source_id,
+                            err,
+                        )
+                    })?
         {
             let model = self.to_model(existing.id, event.id, price.id, rank.id, amount_cents);
-            db.event_prices().update(model).await?;
-            return Ok(());
+            db.event_prices().update(model).await.map_err(|err| {
+                ImportItemError::database_write(ImportEntity::EventPrice, Some(source_id), err)
+            })?;
+            return Ok(ItemConversion::without_warnings(Some(source_id)));
         }
 
         let event_price_create = self.to_create(event.id, price.id, rank.id, amount_cents);
-        db.event_prices().insert(event_price_create).await?;
-        Ok(())
+        db.event_prices()
+            .insert(event_price_create)
+            .await
+            .map_err(|err| {
+                ImportItemError::database_write(
+                    ImportEntity::EventPrice,
+                    event_price_source_id,
+                    err,
+                )
+            })?;
+
+        Ok(ItemConversion::without_warnings(event_price_source_id))
     }
 }

--- a/backend/api/src/insert/events.rs
+++ b/backend/api/src/insert/events.rs
@@ -1,32 +1,89 @@
-use database::{Database, error::DatabaseError};
-use tracing::warn;
+use database::Database;
 
-use crate::models::event::ApiEvent;
+use crate::{
+    error::{
+        ImportEntity, ImportField, ImportItemError, ImportItemWarning, ImportRelation,
+        ItemConversion,
+    },
+    helper::extract_source_id,
+    models::event::ApiEvent,
+};
 
 impl ApiEvent {
-    pub async fn insert(self, db: &Database) -> Result<(), DatabaseError> {
-        let Some(prod_source_id) = self.production_source_id() else {
-            warn!("Events: event has no production source_id, skipping");
-            return Ok(());
+    pub async fn upsert_import(
+        self,
+        db: &Database,
+    ) -> Result<ItemConversion<Option<i32>>, ImportItemError> {
+        let event_source_id = extract_source_id(&self.id);
+        let mut warnings = Vec::new();
+
+        let Some(production_source_id) = self.production_source_id() else {
+            return Err(ImportItemError::invalid_reference(
+                ImportEntity::Event,
+                ImportField::Production,
+                &self.production.id,
+            ));
         };
 
-        let Some(production) = db.productions().by_source_id(prod_source_id).await? else {
-            warn!("Events: production source_id {prod_source_id} not found in db, skipping");
-            return Ok(());
-        };
+        let production = db
+            .productions()
+            .by_source_id(production_source_id)
+            .await
+            .map_err(|err| {
+                ImportItemError::database_lookup(
+                    ImportEntity::Event,
+                    ImportRelation::Production,
+                    production_source_id,
+                    err,
+                )
+            })?
+            .ok_or_else(|| {
+                ImportItemError::missing_relation(
+                    ImportEntity::Event,
+                    ImportRelation::Production,
+                    production_source_id,
+                )
+            })?;
 
         let hall_uuid = if let Some(hall_source_id) = self.hall_source_id() {
-            let hall_opt = db.halls().by_source_id(hall_source_id).await?;
-            if hall_opt.is_none() {
-                warn!("Events: hall source_id {hall_source_id} not found in db");
+            match db.halls().by_source_id(hall_source_id).await {
+                Ok(hall_opt) => {
+                    if hall_opt.is_none() {
+                        warnings.push(ImportItemWarning::missing_optional_relation(
+                            ImportEntity::Event,
+                            ImportRelation::Hall,
+                            hall_source_id,
+                        ));
+                    }
+
+                    hall_opt.map(|hall| hall.id)
+                }
+                Err(err) => {
+                    return Err(ImportItemError::database_lookup(
+                        ImportEntity::Event,
+                        ImportRelation::Hall,
+                        hall_source_id,
+                        err,
+                    ));
+                }
             }
-            hall_opt.map(|h| h.id)
         } else {
             None
         };
 
-        let event_create = self.to_create(production.production.id, hall_uuid);
-        db.events().insert(event_create).await?;
-        Ok(())
+        let event_conversion = self.to_create(production.production.id, hall_uuid)?;
+        warnings.extend(event_conversion.warnings);
+
+        db.events()
+            .upsert_by_source_id(event_conversion.value)
+            .await
+            .map_err(|err| {
+                ImportItemError::database_write(ImportEntity::Event, event_source_id, err)
+            })?;
+
+        Ok(ItemConversion {
+            value: event_source_id,
+            warnings,
+        })
     }
 }

--- a/backend/api/src/insert/halls.rs
+++ b/backend/api/src/insert/halls.rs
@@ -1,25 +1,60 @@
-use database::{Database, error::DatabaseError};
-use tracing::warn;
+use database::Database;
 
-use crate::helper::extract_source_id;
-use crate::models::hall::ApiHall;
+use crate::{
+    error::{ImportEntity, ImportItemError, ImportItemWarning, ImportRelation, ItemConversion},
+    helper::extract_source_id,
+    models::hall::ApiHall,
+};
 
 impl ApiHall {
-    pub async fn insert(self, db: &Database) -> Result<(), DatabaseError> {
-        let source_id = self.space.as_deref().and_then(extract_source_id);
-        let space_uuid = match source_id {
-            Some(id) => {
-                let db_uuid = db.spaces().by_source_id(id).await?.map(|s| s.id);
-                if db_uuid.is_none() {
-                    warn!("Halls: Space source_id {id} expected but not found in db");
+    pub async fn upsert_import(
+        self,
+        db: &Database,
+    ) -> Result<ItemConversion<Option<i32>>, ImportItemError> {
+        let hall_source_id = extract_source_id(&self.id);
+        let mut warnings = Vec::new();
+
+        let space_source_id = self.space.as_deref().and_then(extract_source_id);
+        let space_uuid = match space_source_id {
+            Some(source_id) => match db.spaces().by_source_id(source_id).await {
+                Ok(space_opt) => {
+                    let db_uuid = space_opt.map(|space| space.id);
+
+                    if db_uuid.is_none() {
+                        warnings.push(ImportItemWarning::missing_optional_relation(
+                            ImportEntity::Hall,
+                            ImportRelation::Space,
+                            source_id,
+                        ));
+                    }
+
+                    db_uuid
                 }
-                db_uuid
-            }
+                Err(err) => {
+                    return Err(ImportItemError::database_lookup(
+                        ImportEntity::Hall,
+                        ImportRelation::Space,
+                        source_id,
+                        err,
+                    ));
+                }
+            },
             None => None,
         };
 
-        let hall_create = self.to_create(space_uuid);
-        db.halls().insert(hall_create).await?;
-        Ok(())
+        let hall_conversion = self.to_create(space_uuid)?;
+        warnings.extend(hall_conversion.warnings);
+
+        db.halls()
+            .upsert_by_source_id(hall_conversion.value)
+            .await
+            .map_err(|err| {
+                ImportItemError::database_write(ImportEntity::Hall, hall_source_id, err)
+            })?;
+
+        Ok(ItemConversion {
+            value: hall_source_id,
+            warnings,
+        })
     }
 }

--- a/backend/api/src/insert/locations.rs
+++ b/backend/api/src/insert/locations.rs
@@ -1,10 +1,22 @@
-use database::{Database, error::DatabaseError};
+use database::Database;
 
-use crate::models::location::ApiLocation;
+use crate::{
+    error::{ImportEntity, ImportItemError},
+    helper::extract_source_id,
+    models::location::ApiLocation,
+};
 
 impl ApiLocation {
-    pub async fn insert(self, db: &Database) -> Result<(), DatabaseError> {
-        db.locations().insert(self.into(), vec![]).await?;
-        Ok(())
+    pub async fn upsert_import(self, db: &Database) -> Result<Option<i32>, ImportItemError> {
+        let source_id = extract_source_id(&self.id);
+
+        db.locations()
+            .upsert_by_source_id(self.into())
+            .await
+            .map_err(|err| {
+                ImportItemError::database_write(ImportEntity::Location, source_id, err)
+            })?;
+
+        Ok(source_id)
     }
 }

--- a/backend/api/src/insert/mod.rs
+++ b/backend/api/src/insert/mod.rs
@@ -1,5 +1,6 @@
-//! each submodule provides an inherent `insert` method on its `Api*` struct
-//! that performs the FK lookups + insert. Shared between the live importer
+//! Each submodule provides importer-specific inherent methods on its `Api*`
+//! struct. The live importer keeps orchestration in `lib.rs` while the
+//! entity-specific upsert and FK resolution logic lives here.
 
 pub mod event_prices;
 pub mod events;

--- a/backend/api/src/insert/price_ranks.rs
+++ b/backend/api/src/insert/price_ranks.rs
@@ -1,21 +1,43 @@
-use database::{Database, error::DatabaseError};
+use database::Database;
 
-use crate::helper::extract_source_id;
 use crate::models::price_rank::ApiPriceRank;
+use crate::{
+    error::{ImportEntity, ImportItemError, ImportRelation, ItemConversion},
+    helper::extract_source_id,
+};
 
 impl ApiPriceRank {
-    pub async fn insert(self, db: &Database) -> Result<(), DatabaseError> {
+    pub async fn upsert_import(
+        self,
+        db: &Database,
+    ) -> Result<ItemConversion<Option<i32>>, ImportItemError> {
         let source_id = extract_source_id(&self.id);
 
         if let Some(source_id) = source_id
-            && let Some(existing) = db.price_ranks().by_source_id(source_id).await?
+            && let Some(existing) =
+                db.price_ranks()
+                    .by_source_id(source_id)
+                    .await
+                    .map_err(|err| {
+                        ImportItemError::database_lookup(
+                            ImportEntity::PriceRank,
+                            ImportRelation::PriceRank,
+                            source_id,
+                            err,
+                        )
+                    })?
         {
             let model = self.to_model(existing.id);
-            db.price_ranks().update(model).await?;
-            return Ok(());
+            db.price_ranks().update(model).await.map_err(|err| {
+                ImportItemError::database_write(ImportEntity::PriceRank, Some(source_id), err)
+            })?;
+            return Ok(ItemConversion::without_warnings(Some(source_id)));
         }
 
-        db.price_ranks().insert(self.into()).await?;
-        Ok(())
+        db.price_ranks().insert(self.into()).await.map_err(|err| {
+            ImportItemError::database_write(ImportEntity::PriceRank, source_id, err)
+        })?;
+
+        Ok(ItemConversion::without_warnings(source_id))
     }
 }

--- a/backend/api/src/insert/prices.rs
+++ b/backend/api/src/insert/prices.rs
@@ -1,21 +1,40 @@
-use database::{Database, error::DatabaseError};
+use database::Database;
 
-use crate::helper::extract_source_id;
 use crate::models::price::ApiPrice;
+use crate::{
+    error::{ImportEntity, ImportItemError, ImportRelation, ItemConversion},
+    helper::extract_source_id,
+};
 
 impl ApiPrice {
-    pub async fn insert(self, db: &Database) -> Result<(), DatabaseError> {
+    pub async fn upsert_import(
+        self,
+        db: &Database,
+    ) -> Result<ItemConversion<Option<i32>>, ImportItemError> {
         let source_id = extract_source_id(&self.id);
 
         if let Some(source_id) = source_id
-            && let Some(existing) = db.prices().by_source_id(source_id).await?
+            && let Some(existing) = db.prices().by_source_id(source_id).await.map_err(|err| {
+                ImportItemError::database_lookup(
+                    ImportEntity::Price,
+                    ImportRelation::Price,
+                    source_id,
+                    err,
+                )
+            })?
         {
             let model = self.to_model(existing.id);
-            db.prices().update(model).await?;
-            return Ok(());
+            db.prices().update(model).await.map_err(|err| {
+                ImportItemError::database_write(ImportEntity::Price, Some(source_id), err)
+            })?;
+            return Ok(ItemConversion::without_warnings(Some(source_id)));
         }
 
-        db.prices().insert(self.into()).await?;
-        Ok(())
+        db.prices()
+            .insert(self.into())
+            .await
+            .map_err(|err| ImportItemError::database_write(ImportEntity::Price, source_id, err))?;
+
+        Ok(ItemConversion::without_warnings(source_id))
     }
 }

--- a/backend/api/src/insert/productions.rs
+++ b/backend/api/src/insert/productions.rs
@@ -1,18 +1,22 @@
-use database::{Database, error::DatabaseError};
+use database::Database;
 
-use crate::helper::extract_source_id;
-use crate::models::production::{ApiProduction, ProductionImportData};
+use crate::{
+    error::{ImportEntity, ImportItemError},
+    helper::extract_source_id,
+    models::production::{ApiProduction, ProductionImportData},
+};
 
 impl ApiProduction {
-    /// returns the 404 API source_id so the live importer can drive per-production
-    /// gallery fetches. seed binary ignores this.
-    pub async fn insert(self, db: &Database) -> Result<Option<i32>, DatabaseError> {
+    pub async fn upsert_import(self, db: &Database) -> Result<Option<i32>, ImportItemError> {
         let source_id = extract_source_id(&self.id);
-
         let data: ProductionImportData = self.into();
+
         db.productions()
-            .insert(data.production, data.translations)
-            .await?;
+            .upsert_by_source_id(data.production, data.translations)
+            .await
+            .map_err(|err| {
+                ImportItemError::database_write(ImportEntity::Production, source_id, err)
+            })?;
 
         Ok(source_id)
     }

--- a/backend/api/src/insert/spaces.rs
+++ b/backend/api/src/insert/spaces.rs
@@ -1,18 +1,50 @@
-use database::{Database, error::DatabaseError};
+use database::Database;
 
-use crate::helper::extract_source_id;
-use crate::models::space::ApiSpace;
+use crate::{
+    error::{ImportEntity, ImportField, ImportItemError, ImportRelation},
+    helper::extract_source_id,
+    models::space::ApiSpace,
+};
 
 impl ApiSpace {
-    pub async fn insert(self, db: &Database) -> Result<(), DatabaseError> {
-        let location_source_id = extract_source_id(&self.location).unwrap();
+    pub async fn upsert_import(self, db: &Database) -> Result<Option<i32>, ImportItemError> {
+        let source_id = extract_source_id(&self.id);
+
+        let Some(location_source_id) = extract_source_id(&self.location) else {
+            return Err(ImportItemError::invalid_reference(
+                ImportEntity::Space,
+                ImportField::Location,
+                &self.location,
+            ));
+        };
+
         let location = db
             .locations()
             .by_source_id(location_source_id)
-            .await?
-            .unwrap();
-        let space_create = self.to_create(location.location.id);
-        db.spaces().insert(space_create).await?;
-        Ok(())
+            .await
+            .map_err(|err| {
+                ImportItemError::database_lookup(
+                    ImportEntity::Space,
+                    ImportRelation::Location,
+                    location_source_id,
+                    err,
+                )
+            })?
+            .ok_or_else(|| {
+                ImportItemError::missing_relation(
+                    ImportEntity::Space,
+                    ImportRelation::Location,
+                    location_source_id,
+                )
+            })?;
+
+        let space_create = self.to_create(location.id)?;
+
+        db.spaces()
+            .upsert_by_source_id(space_create)
+            .await
+            .map_err(|err| ImportItemError::database_write(ImportEntity::Space, source_id, err))?;
+
+        Ok(source_id)
     }
 }

--- a/backend/api/src/lib.rs
+++ b/backend/api/src/lib.rs
@@ -1,4 +1,5 @@
 use std::pin::pin;
+use std::time::Duration;
 
 use base64::{Engine as _, engine::general_purpose};
 use chrono::Utc;
@@ -10,9 +11,12 @@ use futures::{Stream, StreamExt, stream};
 use reqwest::Client;
 use serde::de::DeserializeOwned;
 use sha2::{Digest, Sha256};
+use tokio::time::sleep;
 use tracing::{info, warn};
 
-use crate::error::ImporterError;
+use crate::error::{
+    ImportEntity, ImportField, ImportItemError, ImportItemWarning, ImportRelation, ImporterError,
+};
 use crate::helper::extract_source_id;
 use crate::models::{
     collection::ApiCollection,
@@ -50,6 +54,8 @@ pub mod models {
 
 const API_BASE_URL: &str = "https://www.viernulvier.gent/api/v1";
 const BASE_URL: &str = "https://www.viernulvier.gent";
+const FETCH_RETRY_ATTEMPTS: u32 = 3;
+const FETCH_INITIAL_BACKOFF_MS: u64 = 250;
 
 pub struct ApiImporter {
     db: Database,
@@ -96,7 +102,7 @@ impl ApiImporter {
 
     /// saves the last updated time
     async fn set_last_updated(&self, timestamp: String) {
-        let _ = self // ignore the result, if not saved, we import again later
+        let _ = self
             .db
             .internal()
             .set_value(InternalStateKey::LastApiUpdate, &timestamp)
@@ -105,28 +111,30 @@ impl ApiImporter {
 
     /// updates all objects from the external api since we last updated
     pub async fn update_since_last(&self) -> Result<(), reqwest::Error> {
-        // save the current timestamp now, to insure we don't lose any updated items
-        // this can happen when updates are made while we are importing, as it takes quite long
+        let run_id = Uuid::now_v7();
+        // Save the current timestamp now, before we start importing, so that any
+        // updates made on the upstream API while we're running are still picked up
+        // by the next run (the import takes a while).
         let current_ts = Utc::now().to_rfc3339();
         let last_update_ts = self.get_last_updated().await;
 
-        // TODO start transactions
-        // order : locations -> spaces -> halls
-        // a location contains a space, which in turn contains one or more hall
+        // Order matters: a location contains spaces, a space contains halls,
+        // a production has events, and events reference halls. We import the
+        // dependencies before the dependents so relation lookups in each loop
+        // can resolve to existing rows.
         let res = async {
-            self.update_locations(&last_update_ts).await?;
-            self.update_spaces(&last_update_ts).await?;
-            self.update_halls(&last_update_ts).await?;
-            self.update_productions(&last_update_ts).await?;
-            self.update_prices(&last_update_ts).await?;
-            self.update_price_ranks(&last_update_ts).await?;
-            self.update_events(&last_update_ts).await?;
-            self.update_event_prices(&last_update_ts).await?;
+            self.update_locations(&last_update_ts, run_id).await?;
+            self.update_spaces(&last_update_ts, run_id).await?;
+            self.update_halls(&last_update_ts, run_id).await?;
+            self.update_productions(&last_update_ts, run_id).await?;
+            self.update_prices(&last_update_ts, run_id).await?;
+            self.update_price_ranks(&last_update_ts, run_id).await?;
+            self.update_events(&last_update_ts, run_id).await?;
+            self.update_event_prices(&last_update_ts, run_id).await?;
             Ok::<(), reqwest::Error>(())
         }
         .await;
 
-        // save timestamp for next time
         if res.is_ok() {
             self.set_last_updated(current_ts).await;
         }
@@ -144,19 +152,35 @@ impl ApiImporter {
         updated_after: &str,
     ) -> Result<ApiCollection<T>, reqwest::Error> {
         let url = format!("{API_BASE_URL}{path}");
+        let mut backoff = Duration::from_millis(FETCH_INITIAL_BACKOFF_MS);
 
-        let request = self.client.get(&url).query(&[
-            ("page", page.to_string().as_str()),
-            ("updated_at[after]", updated_after),
-        ]);
+        for attempt in 1..=FETCH_RETRY_ATTEMPTS {
+            let request = self
+                .client
+                .get(&url)
+                .query(&[
+                    ("page", page.to_string().as_str()),
+                    ("updated_at[after]", updated_after),
+                ])
+                .header("X-AUTH-TOKEN", &self.auth_token);
 
-        request
-            .header("X-AUTH-TOKEN", &self.auth_token)
-            .send()
-            .await?
-            .error_for_status()?
-            .json()
-            .await
+            let response = match request.send().await {
+                Ok(response) => response,
+                Err(err) if attempt < FETCH_RETRY_ATTEMPTS => {
+                    warn!(
+                        "API fetch failed for {path} page {page} (attempt {attempt}/{FETCH_RETRY_ATTEMPTS}), retrying: {err}"
+                    );
+                    sleep(backoff).await;
+                    backoff *= 2;
+                    continue;
+                }
+                Err(err) => return Err(err),
+            };
+
+            return response.error_for_status()?.json().await;
+        }
+
+        unreachable!("fetch retry loop returns on success or final error")
     }
 
     /// make a stream over the pages of the collection api results
@@ -166,7 +190,7 @@ impl ApiImporter {
         updated_after: &str,
     ) -> impl Stream<Item = Result<Vec<T>, reqwest::Error>> {
         stream::unfold(Some(1), move |page_opt| async move {
-            let page = page_opt?; // stop when page_opt is None
+            let page = page_opt?;
 
             match self.fetch_collection::<T>(path, page, updated_after).await {
                 Ok(collection) => {
@@ -178,7 +202,68 @@ impl ApiImporter {
         })
     }
 
-    pub async fn update_productions(&self, updated_after: &str) -> Result<(), reqwest::Error> {
+    async fn record_item_error(
+        &self,
+        run_id: Uuid,
+        stage: &str,
+        source_id: Option<i32>,
+        error: &ImportItemError,
+    ) {
+        warn!("{stage}: {error}");
+
+        if let Err(record_error) = self
+            .db
+            .import_errors()
+            .record(error.to_import_error(run_id, source_id))
+            .await
+        {
+            warn!("{stage}: failed to record import error: {record_error}");
+        }
+    }
+
+    async fn record_item_warning(
+        &self,
+        run_id: Uuid,
+        stage: &str,
+        source_id: Option<i32>,
+        warning: &ImportItemWarning,
+    ) {
+        warn!("{stage}: {warning}");
+
+        if let Err(record_error) = self
+            .db
+            .import_errors()
+            .record(warning.to_import_error(run_id, source_id))
+            .await
+        {
+            warn!("{stage}: failed to record import warning: {record_error}");
+        }
+    }
+
+    /// Resolve previously-recorded import errors for everything that succeeded
+    /// in the current batch in a single round trip. Called once per page of
+    /// items, instead of once per successful item, to avoid one wasted UPDATE
+    /// per item on full re-imports.
+    async fn resolve_item_errors_batch(&self, stage: &str, entity: &str, source_ids: &[i32]) {
+        if source_ids.is_empty() {
+            return;
+        }
+
+        if let Err(resolve_error) = self
+            .db
+            .import_errors()
+            .resolve_for_items(entity, source_ids)
+            .await
+        {
+            warn!("{stage}: failed to resolve previous import errors: {resolve_error}");
+        }
+    }
+
+    pub async fn update_productions(
+        &self,
+        updated_after: &str,
+        run_id: Uuid,
+    ) -> Result<(), reqwest::Error> {
         info!("Productions: start updating");
 
         let mut stream =
@@ -188,7 +273,9 @@ impl ApiImporter {
             let productions = batch_result?;
             let amt = productions.len();
             info!("Productions: got {amt} from api");
+            let mut resolved_source_ids: Vec<i32> = Vec::new();
             for production in productions {
+                let production_source_id_hint = extract_source_id(&production.id);
                 let galleries = [
                     (production.media_gallery.clone(), "media"),
                     (production.review_gallery.clone(), "review"),
@@ -196,30 +283,41 @@ impl ApiImporter {
                 ];
 
                 #[cfg(feature = "ai-normalization")]
-                let production_for_norm = production.clone();
+                if let Some(source_id) = production_source_id_hint {
+                    normalization::normalize_production(&self.db, &production, source_id).await;
+                }
 
-                let production_source_id = production.insert(&self.db).await.unwrap();
+                let production_source_id = match production.upsert_import(&self.db).await {
+                    Ok(source_id) => source_id,
+                    Err(err) => {
+                        self.record_item_error(
+                            run_id,
+                            "Productions",
+                            production_source_id_hint,
+                            &err,
+                        )
+                        .await;
+                        continue;
+                    }
+                };
+
+                if let Some(source_id) = production_source_id {
+                    resolved_source_ids.push(source_id);
+                }
 
                 let Some(source_id) = production_source_id else {
                     continue;
                 };
 
-                #[cfg(feature = "ai-normalization")]
-                normalization::normalize_production(&self.db, &production_for_norm, source_id)
-                    .await;
-
                 for (gallery_url, gallery_type) in galleries {
-                    if let Some(url) = gallery_url
-                        && let Err(e) = self
-                            .import_gallery_for_production(&url, source_id, gallery_type)
-                            .await
-                    {
-                        warn!(
-                            "Productions: failed to import {gallery_type} gallery for source_id {source_id}: {e}"
-                        );
+                    if let Some(url) = gallery_url {
+                        self.import_gallery_for_production(run_id, &url, source_id, gallery_type)
+                            .await;
                     }
                 }
             }
+            self.resolve_item_errors_batch("Productions", "production", &resolved_source_ids)
+                .await;
             info!("Productions: inserted {amt} into db");
         }
 
@@ -227,7 +325,11 @@ impl ApiImporter {
         Ok(())
     }
 
-    pub async fn update_locations(&self, updated_after: &str) -> Result<(), reqwest::Error> {
+    pub async fn update_locations(
+        &self,
+        updated_after: &str,
+        run_id: Uuid,
+    ) -> Result<(), reqwest::Error> {
         info!("Locations: start updating");
 
         let mut stream =
@@ -237,9 +339,22 @@ impl ApiImporter {
             let locations = batch_result?;
             let amt = locations.len();
             info!("Locations: got {amt} from api");
+            let mut resolved_source_ids: Vec<i32> = Vec::new();
             for location in locations {
-                location.insert(&self.db).await.unwrap();
+                let location_source_id = extract_source_id(&location.id);
+                match location.upsert_import(&self.db).await {
+                    Ok(Some(source_id)) => {
+                        resolved_source_ids.push(source_id);
+                    }
+                    Ok(None) => {}
+                    Err(err) => {
+                        self.record_item_error(run_id, "Locations", location_source_id, &err)
+                            .await;
+                    }
+                }
             }
+            self.resolve_item_errors_batch("Locations", "location", &resolved_source_ids)
+                .await;
             info!("Locations: inserted {amt} into db");
         }
 
@@ -247,7 +362,11 @@ impl ApiImporter {
         Ok(())
     }
 
-    pub async fn update_spaces(&self, updated_after: &str) -> Result<(), reqwest::Error> {
+    pub async fn update_spaces(
+        &self,
+        updated_after: &str,
+        run_id: Uuid,
+    ) -> Result<(), reqwest::Error> {
         info!("Spaces: start updating");
 
         let mut stream = pin!(self.paginated_collection::<ApiSpace>("/spaces", updated_after));
@@ -256,9 +375,22 @@ impl ApiImporter {
             let spaces = batch_result?;
             let amt = spaces.len();
             info!("Spaces: got {amt} from api");
+            let mut resolved_source_ids: Vec<i32> = Vec::new();
             for space in spaces {
-                space.insert(&self.db).await.unwrap();
+                let space_source_id = extract_source_id(&space.id);
+                match space.upsert_import(&self.db).await {
+                    Ok(Some(source_id)) => {
+                        resolved_source_ids.push(source_id);
+                    }
+                    Ok(None) => {}
+                    Err(err) => {
+                        self.record_item_error(run_id, "Spaces", space_source_id, &err)
+                            .await;
+                    }
+                }
             }
+            self.resolve_item_errors_batch("Spaces", "space", &resolved_source_ids)
+                .await;
             info!("Spaces: inserted {amt} into db");
         }
 
@@ -266,7 +398,11 @@ impl ApiImporter {
         Ok(())
     }
 
-    pub async fn update_halls(&self, updated_after: &str) -> Result<(), reqwest::Error> {
+    pub async fn update_halls(
+        &self,
+        updated_after: &str,
+        run_id: Uuid,
+    ) -> Result<(), reqwest::Error> {
         info!("Halls: start updating");
 
         let mut stream = pin!(self.paginated_collection::<ApiHall>("/halls", updated_after));
@@ -275,9 +411,27 @@ impl ApiImporter {
             let halls = batch_result?;
             let amt = halls.len();
             info!("Halls: got {amt} from api");
+            let mut resolved_source_ids: Vec<i32> = Vec::new();
             for hall in halls {
-                hall.insert(&self.db).await.unwrap();
+                let hall_source_id = extract_source_id(&hall.id);
+                match hall.upsert_import(&self.db).await {
+                    Ok(conversion) => {
+                        if let Some(source_id) = conversion.value {
+                            resolved_source_ids.push(source_id);
+                        }
+                        for warning in &conversion.warnings {
+                            self.record_item_warning(run_id, "Halls", hall_source_id, warning)
+                                .await;
+                        }
+                    }
+                    Err(err) => {
+                        self.record_item_error(run_id, "Halls", hall_source_id, &err)
+                            .await;
+                    }
+                }
             }
+            self.resolve_item_errors_batch("Halls", "hall", &resolved_source_ids)
+                .await;
             info!("Halls: inserted {amt} into db");
         }
 
@@ -285,7 +439,11 @@ impl ApiImporter {
         Ok(())
     }
 
-    pub async fn update_events(&self, updated_after: &str) -> Result<(), reqwest::Error> {
+    pub async fn update_events(
+        &self,
+        updated_after: &str,
+        run_id: Uuid,
+    ) -> Result<(), reqwest::Error> {
         info!("Events: start updating");
 
         let mut stream = pin!(self.paginated_collection::<ApiEvent>("/events", updated_after));
@@ -294,16 +452,38 @@ impl ApiImporter {
             let events = batch_result?;
             let amt = events.len();
             info!("Events: got {amt} from api");
+            let mut resolved_source_ids: Vec<i32> = Vec::new();
             for event in events {
-                event.insert(&self.db).await.unwrap();
+                let event_source_id = extract_source_id(&event.id);
+                match event.upsert_import(&self.db).await {
+                    Ok(conversion) => {
+                        if let Some(source_id) = conversion.value {
+                            resolved_source_ids.push(source_id);
+                        }
+                        for warning in &conversion.warnings {
+                            self.record_item_warning(run_id, "Events", event_source_id, warning)
+                                .await;
+                        }
+                    }
+                    Err(err) => {
+                        self.record_item_error(run_id, "Events", event_source_id, &err)
+                            .await;
+                    }
+                }
             }
+            self.resolve_item_errors_batch("Events", "event", &resolved_source_ids)
+                .await;
             info!("Events: inserted {amt} into db");
         }
 
         info!("Events: finished importing");
         Ok(())
     }
-    pub async fn update_prices(&self, updated_after: &str) -> Result<(), reqwest::Error> {
+    pub async fn update_prices(
+        &self,
+        updated_after: &str,
+        run_id: Uuid,
+    ) -> Result<(), reqwest::Error> {
         info!("Prices: start updating");
 
         let mut stream = pin!(self.paginated_collection::<ApiPrice>("/prices", updated_after));
@@ -311,10 +491,26 @@ impl ApiImporter {
         while let Some(batch_result) = stream.next().await {
             let prices = batch_result?;
             let amt = prices.len();
+            let mut resolved_source_ids = Vec::new();
             info!("Prices: got {amt} from api");
             for price in prices {
-                price.insert(&self.db).await.unwrap();
+                let price_source_id = extract_source_id(&price.id);
+
+                match price.upsert_import(&self.db).await {
+                    Ok(conversion) => {
+                        if let Some(source_id) = conversion.value {
+                            resolved_source_ids.push(source_id);
+                        }
+                    }
+                    Err(err) => {
+                        self.record_item_error(run_id, "Prices", price_source_id, &err)
+                            .await;
+                    }
+                }
             }
+
+            self.resolve_item_errors_batch("Prices", "price", &resolved_source_ids)
+                .await;
             info!("Prices: inserted {amt} into db");
         }
 
@@ -322,7 +518,11 @@ impl ApiImporter {
         Ok(())
     }
 
-    pub async fn update_price_ranks(&self, updated_after: &str) -> Result<(), reqwest::Error> {
+    pub async fn update_price_ranks(
+        &self,
+        updated_after: &str,
+        run_id: Uuid,
+    ) -> Result<(), reqwest::Error> {
         info!("PriceRanks: start updating");
 
         let mut stream =
@@ -331,10 +531,26 @@ impl ApiImporter {
         while let Some(batch_result) = stream.next().await {
             let ranks = batch_result?;
             let amt = ranks.len();
+            let mut resolved_source_ids = Vec::new();
             info!("PriceRanks: got {amt} from api");
             for rank in ranks {
-                rank.insert(&self.db).await.unwrap();
+                let rank_source_id = extract_source_id(&rank.id);
+
+                match rank.upsert_import(&self.db).await {
+                    Ok(conversion) => {
+                        if let Some(source_id) = conversion.value {
+                            resolved_source_ids.push(source_id);
+                        }
+                    }
+                    Err(err) => {
+                        self.record_item_error(run_id, "PriceRanks", rank_source_id, &err)
+                            .await;
+                    }
+                }
             }
+
+            self.resolve_item_errors_batch("PriceRanks", "price_rank", &resolved_source_ids)
+                .await;
             info!("PriceRanks: inserted {amt} into db");
         }
 
@@ -342,7 +558,11 @@ impl ApiImporter {
         Ok(())
     }
 
-    pub async fn update_event_prices(&self, updated_after: &str) -> Result<(), reqwest::Error> {
+    pub async fn update_event_prices(
+        &self,
+        updated_after: &str,
+        run_id: Uuid,
+    ) -> Result<(), reqwest::Error> {
         info!("EventPrices: start updating");
 
         let mut stream =
@@ -351,10 +571,26 @@ impl ApiImporter {
         while let Some(batch_result) = stream.next().await {
             let event_prices = batch_result?;
             let amt = event_prices.len();
+            let mut resolved_source_ids = Vec::new();
             info!("EventPrices: got {amt} from api");
             for event_price in event_prices {
-                event_price.insert(&self.db).await.unwrap();
+                let event_price_source_id = extract_source_id(&event_price.id);
+
+                match event_price.upsert_import(&self.db).await {
+                    Ok(conversion) => {
+                        if let Some(source_id) = conversion.value {
+                            resolved_source_ids.push(source_id);
+                        }
+                    }
+                    Err(err) => {
+                        self.record_item_error(run_id, "EventPrices", event_price_source_id, &err)
+                            .await;
+                    }
+                }
             }
+
+            self.resolve_item_errors_batch("EventPrices", "event_price", &resolved_source_ids)
+                .await;
             info!("EventPrices: inserted {amt} into db");
         }
 
@@ -364,66 +600,154 @@ impl ApiImporter {
 
     async fn import_gallery_for_production(
         &self,
+        run_id: Uuid,
         gallery_url: &str,
         production_source_id: i32,
         gallery_type: &str,
-    ) -> Result<(), reqwest::Error> {
+    ) {
         if self.s3_client.is_none() || self.s3_bucket.is_none() {
-            return Ok(());
+            return;
         }
 
         let url = format!("{BASE_URL}{gallery_url}");
-        let gallery: ApiMediaGallery = self
+        let gallery: ApiMediaGallery = match self
             .client
-            .get(url)
+            .get(&url)
             .header("X-AUTH-TOKEN", &self.auth_token)
             .send()
-            .await?
-            .error_for_status()?
-            .json()
-            .await?;
+            .await
+        {
+            Ok(response) => match response.error_for_status() {
+                Ok(response) => match response.json().await {
+                    Ok(gallery) => gallery,
+                    Err(err) => {
+                        self.record_item_error(
+                            run_id,
+                            "Gallery",
+                            Some(production_source_id),
+                            &ImportItemError::import_failure(
+                                ImportEntity::Gallery,
+                                Some(ImportField::GalleryUrl),
+                                Some(production_source_id),
+                                format!("failed to decode gallery {url}: {err}"),
+                            ),
+                        )
+                        .await;
+                        return;
+                    }
+                },
+                Err(err) => {
+                    self.record_item_error(
+                        run_id,
+                        "Gallery",
+                        Some(production_source_id),
+                        &ImportItemError::import_failure(
+                            ImportEntity::Gallery,
+                            Some(ImportField::GalleryUrl),
+                            Some(production_source_id),
+                            format!("gallery request failed for {url}: {err}"),
+                        ),
+                    )
+                    .await;
+                    return;
+                }
+            },
+            Err(err) => {
+                self.record_item_error(
+                    run_id,
+                    "Gallery",
+                    Some(production_source_id),
+                    &ImportItemError::import_failure(
+                        ImportEntity::Gallery,
+                        Some(ImportField::GalleryUrl),
+                        Some(production_source_id),
+                        format!("gallery request failed for {url}: {err}"),
+                    ),
+                )
+                .await;
+                return;
+            }
+        };
 
-        let Ok(Some(production)) = self
+        let production = match self
             .db
             .productions()
             .by_source_id(production_source_id)
             .await
-        else {
-            warn!("Media: production source_id {production_source_id} not found");
-            return Ok(());
+        {
+            Ok(Some(production)) => production,
+            Ok(None) => {
+                self.record_item_error(
+                    run_id,
+                    "Gallery",
+                    Some(production_source_id),
+                    &ImportItemError::missing_relation(
+                        ImportEntity::Gallery,
+                        ImportRelation::Production,
+                        production_source_id,
+                    ),
+                )
+                .await;
+                return;
+            }
+            Err(err) => {
+                self.record_item_error(
+                    run_id,
+                    "Gallery",
+                    Some(production_source_id),
+                    &ImportItemError::database_lookup(
+                        ImportEntity::Gallery,
+                        ImportRelation::Production,
+                        production_source_id,
+                        err,
+                    ),
+                )
+                .await;
+                return;
+            }
         };
 
         let mut count = 0;
+        let mut resolved_media_source_ids = Vec::new();
         for item in gallery.items {
             let item_url = item.id.clone().unwrap_or_default();
-            self.import_media_item(
-                item,
-                &item_url,
-                production.production.id,
-                production_source_id,
-                gallery_type,
-            )
-            .await;
+            if let Some(source_id) = self
+                .import_media_item(
+                    run_id,
+                    item,
+                    &item_url,
+                    production.production.id,
+                    production_source_id,
+                    gallery_type,
+                )
+                .await
+            {
+                resolved_media_source_ids.push(source_id);
+            }
             count += 1;
         }
+
+        self.resolve_item_errors_batch("Gallery", "gallery", &[production_source_id])
+            .await;
+        self.resolve_item_errors_batch("Media", "media", &resolved_media_source_ids)
+            .await;
 
         if count > 0 {
             info!(
                 "Media: imported {count} {gallery_type} items for production source_id {production_source_id}"
             );
         }
-
-        Ok(())
     }
 
     async fn import_media_item(
         &self,
+        run_id: Uuid,
         item: ApiMediaItem,
         item_url: &str,
         production_id: Uuid,
         production_source_id: i32,
         gallery_type: &str,
-    ) {
+    ) -> Option<i32> {
         let source_id = extract_source_id(item_url);
 
         let title_nl = item.title.nl;
@@ -463,19 +787,45 @@ impl ApiImporter {
             }
         }
 
-        if self
-            .db
-            .media()
-            .by_source_uri("viernulvier", item_url)
-            .await
-            .is_ok_and(|m| m.is_some())
-        {
-            return;
-        }
+        match self.db.media().by_source_uri("viernulvier", item_url).await {
+            Ok(Some(_)) => return source_id,
+            Ok(None) => {}
+            Err(err) => {
+                if let Some(source_id) = source_id {
+                    self.record_item_error(
+                        run_id,
+                        "Media",
+                        Some(source_id),
+                        &ImportItemError::database_lookup(
+                            ImportEntity::Media,
+                            ImportRelation::Media,
+                            source_id,
+                            err,
+                        ),
+                    )
+                    .await;
+                } else {
+                    self.record_item_error(
+                        run_id,
+                        "Media",
+                        None,
+                        &ImportItemError::database_write(ImportEntity::Media, None, err),
+                    )
+                    .await;
+                }
+                return None;
+            }
+        };
 
         let Some(url) = &cdn_url else {
-            warn!("Media: skipping import for {item_url} because source URL is missing");
-            return;
+            self.record_item_error(
+                run_id,
+                "Media",
+                source_id,
+                &ImportItemError::missing_required_field(ImportEntity::Media, ImportField::CdnUrl),
+            )
+            .await;
+            return None;
         };
 
         let s3_client = self.s3_client.as_ref().unwrap();
@@ -494,8 +844,19 @@ impl ApiImporter {
         {
             Ok(result) => result,
             Err(e) => {
-                warn!("Media: download/upload failed for {url}: {e}");
-                return;
+                self.record_item_error(
+                    run_id,
+                    "Media",
+                    source_id,
+                    &ImportItemError::import_failure(
+                        ImportEntity::Media,
+                        Some(ImportField::CdnUrl),
+                        source_id,
+                        format!("download/upload failed for {url}: {e}"),
+                    ),
+                )
+                .await;
+                return None;
             }
         };
 
@@ -526,72 +887,111 @@ impl ApiImporter {
             source_updated_at: item.updated_at,
         };
 
-        if let Ok(media) = self.db.media().insert(media_create).await {
-            let is_cover = item.position == Some(0);
-            let role = if is_cover && gallery_type == "media" {
-                "cover"
-            } else {
-                media_role_from_gallery_type(gallery_type)
-            };
-            let _ = self
-                .db
-                .media()
-                .link_to_entity(
-                    EntityType::Production,
-                    production_id,
-                    media.id,
-                    role,
-                    item.position.unwrap_or(999) as i32,
-                    is_cover,
+        let media = match self.db.media().insert(media_create).await {
+            Ok(media) => media,
+            Err(err) => {
+                self.record_item_error(
+                    run_id,
+                    "Media",
+                    source_id,
+                    &ImportItemError::database_write(ImportEntity::Media, source_id, err),
                 )
                 .await;
+                return None;
+            }
+        };
 
-            for crop in item.crops {
-                if let (Some(name), Some(url)) = (crop.name, crop.url)
-                    && (name == "hd_ready" || name == "FE3_header")
+        let is_cover = item.position == Some(0);
+        let role = if is_cover && gallery_type == "media" {
+            "cover"
+        } else {
+            media_role_from_gallery_type(gallery_type)
+        };
+        if let Err(err) = self
+            .db
+            .media()
+            .link_to_entity(
+                EntityType::Production,
+                production_id,
+                media.id,
+                role,
+                item.position.unwrap_or(999) as i32,
+                is_cover,
+            )
+            .await
+        {
+            self.record_item_error(
+                run_id,
+                "Media",
+                source_id,
+                &ImportItemError::database_write(ImportEntity::Media, source_id, err),
+            )
+            .await;
+            return None;
+        }
+
+        for crop in item.crops {
+            if let (Some(name), Some(url)) = (crop.name, crop.url)
+                && (name == "hd_ready" || name == "FE3_header")
+            {
+                let format = item.format.as_deref().unwrap_or("");
+                let format_info = get_format_info(format);
+                let ext = format_info.extension;
+                let file_uuid = Uuid::now_v7();
+                let crop_s3_key = format!(
+                    "media/production/{production_source_id}/{gallery_type}/crop_{name}_{file_uuid}.{ext}"
+                );
+
+                match self
+                    .download_and_upload_to_key(s3_client, s3_bucket, &url, &crop_s3_key, format)
+                    .await
                 {
-                    let format = item.format.as_deref().unwrap_or("");
-                    let format_info = get_format_info(format);
-                    let ext = format_info.extension;
-                    let file_uuid = Uuid::now_v7();
-                    let crop_s3_key = format!(
-                        "media/production/{production_source_id}/{gallery_type}/crop_{name}_{file_uuid}.{ext}"
-                    );
-
-                    match self
-                        .download_and_upload_to_key(
-                            s3_client,
-                            s3_bucket,
-                            &url,
-                            &crop_s3_key,
-                            format,
+                    Ok((checksum, file_size, width, height)) => {
+                        let upsert = database::repos::media_variant::CropVariantUpsert {
+                            media_id: media.id,
+                            crop_name: name.clone(),
+                            s3_key: crop_s3_key,
+                            mime_type: Some(format_info.mime.to_string()),
+                            file_size: Some(file_size),
+                            width,
+                            height,
+                            checksum: Some(checksum),
+                            source_uri: Some(url),
+                        };
+                        if let Err(err) = self.db.media_variants().upsert_crop(upsert).await {
+                            self.record_item_warning(
+                                run_id,
+                                "MediaVariant",
+                                source_id,
+                                &ImportItemWarning::UnexpectedFieldValue {
+                                    entity: ImportEntity::MediaVariant,
+                                    field: ImportField::Crop,
+                                    value: format!("failed to upsert crop {name}: {err}"),
+                                    fallback: "media_without_crop_variant",
+                                },
+                            )
+                            .await;
+                        }
+                    }
+                    Err(e) => {
+                        self.record_item_warning(
+                            run_id,
+                            "MediaVariant",
+                            source_id,
+                            &ImportItemWarning::UnexpectedFieldValue {
+                                entity: ImportEntity::MediaVariant,
+                                field: ImportField::Crop,
+                                value: format!("failed to download/upload crop {name}: {e}"),
+                                fallback: "media_without_crop_variant",
+                            },
                         )
-                        .await
-                    {
-                        Ok((checksum, file_size, width, height)) => {
-                            let upsert = database::repos::media_variant::CropVariantUpsert {
-                                media_id: media.id,
-                                crop_name: name,
-                                s3_key: crop_s3_key,
-                                mime_type: Some(format_info.mime.to_string()),
-                                file_size: Some(file_size),
-                                width,
-                                height,
-                                checksum: Some(checksum),
-                                source_uri: Some(url),
-                            };
-                            let _ = self.db.media_variants().upsert_crop(upsert).await;
-                        }
-                        Err(e) => {
-                            tracing::warn!(
-                                "Failed to download/upload crop '{name}' for media {}: {e}",
-                                media.id
-                            );
-                        }
+                        .await;
                     }
                 }
             }
         }
+
+        source_id
     }
 
     async fn download_and_upload(

--- a/backend/api/src/models/event.rs
+++ b/backend/api/src/models/event.rs
@@ -3,6 +3,7 @@ use database::models::event::EventCreate;
 use serde::Deserialize;
 use uuid::Uuid;
 
+use crate::error::{ImportEntity, ImportField, ImportItemError, ItemConversion};
 use crate::helper::extract_source_id;
 use crate::models::localized_text::ApiLocalizedText;
 
@@ -51,8 +52,24 @@ impl ApiEvent {
         extract_source_id(&self.hall)
     }
 
-    pub fn to_create(self, production_id: Uuid, hall_id: Option<Uuid>) -> EventCreate {
-        EventCreate {
+    pub fn to_create(
+        self,
+        production_id: Uuid,
+        hall_id: Option<Uuid>,
+    ) -> Result<ItemConversion<EventCreate>, ImportItemError> {
+        let max_tickets_per_order = self
+            .max_tickets_per_order
+            .map(i32::try_from)
+            .transpose()
+            .map_err(|_| {
+                ImportItemError::out_of_range(
+                    ImportEntity::Event,
+                    ImportField::MaxTicketsPerOrder,
+                    format!("{:?}", self.max_tickets_per_order),
+                )
+            })?;
+
+        Ok(ItemConversion::without_warnings(EventCreate {
             source_id: extract_source_id(&self.id),
             created_at: self.created_at,
             updated_at: self.updated_at,
@@ -63,12 +80,72 @@ impl ApiEvent {
             vendor_id: self.vendor_id,
             box_office_id: self.box_office_id,
             uitdatabank_id: self.uitdatabank_id,
-            max_tickets_per_order: self
-                .max_tickets_per_order
-                .map(|v| v.try_into().expect("max_tickets_per_order out of range")),
+            max_tickets_per_order,
             production_id,
             status: self.status,
             hall_id,
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_event(max_tickets_per_order: Option<u32>) -> ApiEvent {
+        let now = Utc::now();
+        ApiEvent {
+            id: "/api/v1/events/100".into(),
+            jsonld_type: "Event".into(),
+            created_at: now,
+            updated_at: now,
+            starts_at: now,
+            ends_at: None,
+            intermission_at: None,
+            doors_at: None,
+            box_office_id: None,
+            vendor_id: None,
+            max_tickets_per_order,
+            uitdatabank_id: None,
+            secure: false,
+            sms_verification: false,
+            production: ApiEventProduction {
+                id: "/api/v1/productions/7".into(),
+            },
+            status: "scheduled".into(),
+            hall: "/api/v1/halls/3".into(),
+            info: None,
+            eticket_info: None,
+            external_order_url: None,
         }
+    }
+
+    #[test]
+    fn to_create_returns_out_of_range_when_max_tickets_overflows_i32() {
+        let too_big = (i32::MAX as u32) + 1;
+        let event = make_event(Some(too_big));
+
+        let err = event.to_create(Uuid::nil(), None).unwrap_err();
+        match err {
+            ImportItemError::OutOfRange {
+                entity,
+                field,
+                value,
+            } => {
+                assert_eq!(entity, ImportEntity::Event);
+                assert_eq!(field, ImportField::MaxTicketsPerOrder);
+                assert_eq!(value, format!("Some({too_big})"));
+            }
+            other => panic!("expected OutOfRange, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn to_create_accepts_max_tickets_within_i32() {
+        let event = make_event(Some(10));
+        let conversion = event
+            .to_create(Uuid::nil(), None)
+            .expect("conversion succeeds");
+        assert_eq!(conversion.value.max_tickets_per_order, Some(10));
     }
 }

--- a/backend/api/src/models/event_price.rs
+++ b/backend/api/src/models/event_price.rs
@@ -72,3 +72,64 @@ impl ApiEventPrice {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_event_price(id: &str) -> ApiEventPrice {
+        let now = Utc::now();
+        ApiEventPrice {
+            id: id.into(),
+            jsonld_type: "EventPrice".into(),
+            created_at: now,
+            updated_at: now,
+            available: 12,
+            amount: "42.50".into(),
+            box_office_id: Some("box-office".into()),
+            contingent_id: Some(7),
+            expires_at: Some(now),
+            event: "/api/v1/events/1".into(),
+            price: "/api/v1/prices/2".into(),
+            rank: "/api/v1/prices/ranks/3".into(),
+        }
+    }
+
+    #[test]
+    fn to_create_maps_api_event_price_fields() {
+        let event_id = Uuid::now_v7();
+        let price_id = Uuid::now_v7();
+        let rank_id = Uuid::now_v7();
+
+        let create = make_event_price("/api/v1/events/prices/88")
+            .to_create(event_id, price_id, rank_id, 4250);
+
+        assert_eq!(create.source_id, Some(88));
+        assert_eq!(create.event_id, event_id);
+        assert_eq!(create.price_id, price_id);
+        assert_eq!(create.rank_id, rank_id);
+        assert_eq!(create.available, 12);
+        assert_eq!(create.amount_cents, 4250);
+        assert_eq!(create.box_office_id.as_deref(), Some("box-office"));
+        assert_eq!(create.contingent_id, Some(7));
+        assert!(create.expires_at.is_some());
+    }
+
+    #[test]
+    fn to_model_preserves_existing_id_and_create_fields() {
+        let id = Uuid::now_v7();
+        let event_id = Uuid::now_v7();
+        let price_id = Uuid::now_v7();
+        let rank_id = Uuid::now_v7();
+
+        let model = make_event_price("/api/v1/events/prices/not-an-id")
+            .to_model(id, event_id, price_id, rank_id, 4250);
+
+        assert_eq!(model.id, id);
+        assert_eq!(model.source_id, None);
+        assert_eq!(model.event_id, event_id);
+        assert_eq!(model.price_id, price_id);
+        assert_eq!(model.rank_id, rank_id);
+        assert_eq!(model.amount_cents, 4250);
+    }
+}

--- a/backend/api/src/models/hall.rs
+++ b/backend/api/src/models/hall.rs
@@ -1,11 +1,11 @@
 use crate::{
+    error::{ImportEntity, ImportField, ImportItemError, ImportItemWarning, ItemConversion},
     helper::{extract_source_id, flatten_single},
     models::localized_text::ApiLocalizedText,
 };
 use chrono::{DateTime, Utc};
 use database::models::hall::HallCreate;
 use serde::Deserialize;
-use tracing::warn;
 
 use slug::slugify;
 use uuid::Uuid;
@@ -38,17 +38,23 @@ pub struct ApiHall {
 // halls are linked to a space, many_to_one. function that takes an ApiModel and a Uuid for
 // space, and returns a create model for Halls
 impl ApiHall {
-    pub fn to_create(self, space_uuid: Option<Uuid>) -> HallCreate {
+    pub fn to_create(
+        self,
+        space_uuid: Option<Uuid>,
+    ) -> Result<ItemConversion<HallCreate>, ImportItemError> {
         let source_id = extract_source_id(&self.id);
+        let mut warnings = Vec::new();
 
         let seat_selection = match self.seat_selection.as_str() {
             "1" => true,
             "" => false,
             other => {
-                warn!(
-                    "unexpected seat_selection value: {}, defaulting to false",
-                    other
-                );
+                warnings.push(ImportItemWarning::UnexpectedFieldValue {
+                    entity: ImportEntity::Hall,
+                    field: ImportField::SeatSelection,
+                    value: other.into(),
+                    fallback: "false",
+                });
                 false
             }
         };
@@ -57,30 +63,146 @@ impl ApiHall {
             "1" => true,
             "" => false,
             other => {
-                warn!(
-                    "unexpected open_seating value: {}, defaulting to false",
-                    other
-                );
+                warnings.push(ImportItemWarning::UnexpectedFieldValue {
+                    entity: ImportEntity::Hall,
+                    field: ImportField::OpenSeating,
+                    value: other.into(),
+                    fallback: "false",
+                });
                 false
             }
         };
 
-        let name = flatten_single(Some(self.name)).expect("name should always be present"); // helper expects Option
+        let Some(name) = flatten_single(Some(self.name)) else {
+            return Err(ImportItemError::missing_required_field(
+                ImportEntity::Hall,
+                ImportField::Name,
+            ));
+        };
 
         let remark = flatten_single(self.remark);
 
-        let slug = format!("{}-{}", slugify(&name), source_id.unwrap_or(0)); // FIX
+        // The slug must be unique and stable across re-imports. We rely on the
+        // upstream `source_id` for that uniqueness, so refuse to fabricate a
+        // slug for halls that have no source_id (rather than collide on
+        // `<name>-0` for every such hall).
+        let Some(source_id_for_slug) = source_id else {
+            return Err(ImportItemError::missing_required_field(
+                ImportEntity::Hall,
+                ImportField::SourceId,
+            ));
+        };
+        let slug = format!("{}-{}", slugify(&name), source_id_for_slug);
 
-        HallCreate {
-            source_id,
-            slug,
-            vendor_id: self.vendor_id,
-            box_office_id: self.box_office_id,
-            seat_selection: Some(seat_selection),
-            open_seating: Some(open_seating),
+        Ok(ItemConversion {
+            value: HallCreate {
+                source_id,
+                slug,
+                vendor_id: self.vendor_id,
+                box_office_id: self.box_office_id,
+                seat_selection: Some(seat_selection),
+                open_seating: Some(open_seating),
+                name,
+                remark,
+                space_id: space_uuid,
+            },
+            warnings,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_hall(
+        id: &str,
+        seat_selection: &str,
+        open_seating: &str,
+        name: ApiLocalizedText,
+    ) -> ApiHall {
+        ApiHall {
+            id: id.into(),
+            jsonld_type: "Hall".into(),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            vendor_id: None,
+            box_office_id: None,
+            seat_selection: seat_selection.into(),
+            open_seating: open_seating.into(),
             name,
-            remark,
-            space_id: space_uuid,
+            remark: None,
+            space: None,
         }
+    }
+
+    fn name(value: &str) -> ApiLocalizedText {
+        ApiLocalizedText {
+            nl: Some(value.into()),
+            en: None,
+            fr: None,
+        }
+    }
+
+    #[test]
+    fn to_create_happy_path_no_warnings() {
+        let hall = make_hall("/api/v1/halls/9", "1", "", name("Main Hall"));
+
+        let conversion = hall.to_create(None).expect("conversion succeeds");
+        assert_eq!(conversion.value.name, "Main Hall");
+        assert_eq!(conversion.value.slug, "main-hall-9");
+        assert_eq!(conversion.value.seat_selection, Some(true));
+        assert_eq!(conversion.value.open_seating, Some(false));
+        assert!(conversion.warnings.is_empty());
+    }
+
+    #[test]
+    fn to_create_returns_missing_required_field_when_name_empty() {
+        let hall = make_hall("/api/v1/halls/9", "1", "", ApiLocalizedText::default());
+
+        let err = hall.to_create(None).unwrap_err();
+        match err {
+            ImportItemError::MissingRequiredField { entity, field } => {
+                assert_eq!(entity, ImportEntity::Hall);
+                assert_eq!(field, ImportField::Name);
+            }
+            other => panic!("expected MissingRequiredField, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn to_create_returns_missing_required_field_when_source_id_unparseable() {
+        let hall = make_hall("/api/v1/halls/abc", "1", "", name("Main Hall"));
+
+        let err = hall.to_create(None).unwrap_err();
+        match err {
+            ImportItemError::MissingRequiredField { entity, field } => {
+                assert_eq!(entity, ImportEntity::Hall);
+                assert_eq!(field, ImportField::SourceId);
+            }
+            other => panic!("expected MissingRequiredField for source_id, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn to_create_accumulates_warnings_for_unexpected_field_values() {
+        let hall = make_hall("/api/v1/halls/9", "yes", "no", name("Main Hall"));
+
+        let conversion = hall.to_create(None).expect("conversion still succeeds");
+        // Both seat_selection and open_seating fall back to false
+        assert_eq!(conversion.value.seat_selection, Some(false));
+        assert_eq!(conversion.value.open_seating, Some(false));
+        assert_eq!(conversion.warnings.len(), 2);
+
+        let fields: Vec<ImportField> = conversion
+            .warnings
+            .iter()
+            .map(|w| match w {
+                ImportItemWarning::UnexpectedFieldValue { field, .. } => *field,
+                other => panic!("unexpected warning variant: {other:?}"),
+            })
+            .collect();
+        assert!(fields.contains(&ImportField::SeatSelection));
+        assert!(fields.contains(&ImportField::OpenSeating));
     }
 }

--- a/backend/api/src/models/space.rs
+++ b/backend/api/src/models/space.rs
@@ -3,6 +3,7 @@ use serde::Deserialize;
 use uuid::Uuid;
 
 use crate::{
+    error::{ImportEntity, ImportField, ImportItemError},
     helper::{extract_source_id, flatten_single},
     models::localized_text::ApiLocalizedText,
 };
@@ -36,15 +37,51 @@ pub struct ApiSpace {
 // spaces are linked to a location, many_to_one. function that takes an ApiModel and a Uuid for
 // location, and returns a create model for Spaces
 impl ApiSpace {
-    pub fn to_create(self, location_uuid: Uuid) -> SpaceCreate {
+    pub fn to_create(self, location_uuid: Uuid) -> Result<SpaceCreate, ImportItemError> {
         let source_id = extract_source_id(&self.id);
 
-        let name_nl = flatten_single(Some(self.name)).expect("space should always have a name");
+        let Some(name_nl) = flatten_single(Some(self.name)) else {
+            return Err(ImportItemError::missing_required_field(
+                ImportEntity::Space,
+                ImportField::Name,
+            ));
+        };
 
-        SpaceCreate {
+        Ok(SpaceCreate {
             source_id,
             name_nl,
             location_id: location_uuid,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_space(name: ApiLocalizedText) -> ApiSpace {
+        ApiSpace {
+            id: "/api/v1/spaces/42".into(),
+            jsonld_type: "Space".into(),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            name,
+            location: "/api/v1/locations/1".into(),
+            halls: vec![],
+        }
+    }
+
+    #[test]
+    fn to_create_returns_missing_required_field_when_name_empty() {
+        let space = make_space(ApiLocalizedText::default());
+
+        let err = space.to_create(Uuid::nil()).unwrap_err();
+        match err {
+            ImportItemError::MissingRequiredField { entity, field } => {
+                assert_eq!(entity, ImportEntity::Space);
+                assert_eq!(field, ImportField::Name);
+            }
+            other => panic!("expected MissingRequiredField, got {other:?}"),
         }
     }
 }

--- a/backend/database/src/lib.rs
+++ b/backend/database/src/lib.rs
@@ -8,6 +8,7 @@ use crate::{
         event_price::EventPriceRepo, hall::HallRepo, internal_state::InternalStateRepo,
         location::LocationRepo, media::MediaRepo, media_variant::MediaVariantRepo,
         normalization_log::NormalizationLogRepo, price::PriceRepo, price_rank::PriceRankRepo,
+        import_error::ImportErrorRepo
         production::ProductionRepo, series::SeriesRepo, sessions::SessionRepo, space::SpaceRepo,
         tag::TagRepo, user::UserRepo,
     },
@@ -25,6 +26,7 @@ pub mod models {
     pub mod facet;
     pub mod filtering;
     pub mod hall;
+    pub mod import_error;
     pub mod internal_state;
     pub mod location;
     pub mod media;
@@ -48,6 +50,7 @@ pub mod repos {
     pub mod event;
     pub mod event_price;
     pub mod hall;
+    pub mod import_error;
     pub mod internal_state;
     pub mod location;
     pub mod media;
@@ -167,5 +170,8 @@ impl Database {
 
     pub fn normalization_log<'a>(&'a self) -> NormalizationLogRepo<'a> {
         NormalizationLogRepo::new(&self.db)
+    }
+
+    pub fn import_errors<'a>(&'a self) -> ImportErrorRepo<'a> {
     }
 }

--- a/backend/database/src/lib.rs
+++ b/backend/database/src/lib.rs
@@ -8,7 +8,7 @@ use crate::{
         event_price::EventPriceRepo, hall::HallRepo, internal_state::InternalStateRepo,
         location::LocationRepo, media::MediaRepo, media_variant::MediaVariantRepo,
         normalization_log::NormalizationLogRepo, price::PriceRepo, price_rank::PriceRankRepo,
-        import_error::ImportErrorRepo
+        import_error::ImportErrorRepo,
         production::ProductionRepo, series::SeriesRepo, sessions::SessionRepo, space::SpaceRepo,
         tag::TagRepo, user::UserRepo,
     },
@@ -173,5 +173,6 @@ impl Database {
     }
 
     pub fn import_errors<'a>(&'a self) -> ImportErrorRepo<'a> {
+        ImportErrorRepo::new(&self.db)
     }
 }

--- a/backend/database/src/models/import_error.rs
+++ b/backend/database/src/models/import_error.rs
@@ -1,0 +1,35 @@
+use chrono::{DateTime, Utc};
+use serde_json::Value;
+use uuid::Uuid;
+
+#[derive(Debug, sqlx::FromRow, PartialEq)]
+pub struct ImportError {
+    pub id: Uuid,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub last_seen_at: DateTime<Utc>,
+    pub resolved_at: Option<DateTime<Utc>>,
+    pub run_id: Option<Uuid>,
+    pub severity: String,
+    pub entity: String,
+    pub source_id: Option<i32>,
+    pub error_kind: String,
+    pub field: Option<String>,
+    pub relation: Option<String>,
+    pub relation_source_id: Option<i32>,
+    pub message: String,
+    pub payload: Option<Value>,
+}
+
+pub struct ImportErrorCreate {
+    pub run_id: Option<Uuid>,
+    pub severity: String,
+    pub entity: String,
+    pub source_id: Option<i32>,
+    pub error_kind: String,
+    pub field: Option<String>,
+    pub relation: Option<String>,
+    pub relation_source_id: Option<i32>,
+    pub message: String,
+    pub payload: Option<Value>,
+}

--- a/backend/database/src/repos/event.rs
+++ b/backend/database/src/repos/event.rs
@@ -66,16 +66,45 @@ impl<'a> EventRepo<'a> {
         Ok(event.insert(self.db).await?)
     }
 
-    pub async fn update(&self, event: Event) -> Result<Event, DatabaseError> {
-        Ok(event.update_all_fields(self.db).await?)
-    }
-
     pub async fn by_source_id(&self, source_id: i32) -> Result<Option<Event>, DatabaseError> {
         Ok(Event::select()
             .where_("source_id = $1")
             .bind(source_id)
             .fetch_optional(self.db)
             .await?)
+    }
+
+    pub async fn upsert_by_source_id(&self, event: EventCreate) -> Result<Event, DatabaseError> {
+        let Some(source_id) = event.source_id else {
+            return self.insert(event).await;
+        };
+
+        match self.by_source_id(source_id).await? {
+            Some(existing) => Ok(Event {
+                id: existing.id,
+                source_id: event.source_id,
+                created_at: event.created_at,
+                updated_at: event.updated_at,
+                starts_at: event.starts_at,
+                ends_at: event.ends_at,
+                intermission_at: event.intermission_at,
+                doors_at: event.doors_at,
+                vendor_id: event.vendor_id,
+                box_office_id: event.box_office_id,
+                uitdatabank_id: event.uitdatabank_id,
+                max_tickets_per_order: event.max_tickets_per_order,
+                production_id: event.production_id,
+                status: event.status,
+                hall_id: event.hall_id,
+            }
+            .update_all_fields(self.db)
+            .await?),
+            None => self.insert(event).await,
+        }
+    }
+
+    pub async fn update(&self, event: Event) -> Result<Event, DatabaseError> {
+        Ok(event.update_all_fields(self.db).await?)
     }
 
     pub async fn delete(&self, id: Uuid) -> Result<(), DatabaseError> {

--- a/backend/database/src/repos/hall.rs
+++ b/backend/database/src/repos/hall.rs
@@ -123,6 +123,30 @@ impl<'a> HallRepo<'a> {
         Ok(hall.insert(self.db).await?)
     }
 
+    pub async fn upsert_by_source_id(&self, hall: HallCreate) -> Result<Hall, DatabaseError> {
+        let Some(source_id) = hall.source_id else {
+            return self.insert(hall).await;
+        };
+
+        match self.by_source_id(source_id).await? {
+            Some(existing) => Ok(Hall {
+                id: existing.id,
+                source_id: hall.source_id,
+                slug: hall.slug,
+                vendor_id: hall.vendor_id,
+                box_office_id: hall.box_office_id,
+                seat_selection: hall.seat_selection,
+                open_seating: hall.open_seating,
+                name: hall.name,
+                remark: hall.remark,
+                space_id: hall.space_id,
+            }
+            .update_all_fields(self.db)
+            .await?),
+            None => self.insert(hall).await,
+        }
+    }
+
     pub async fn update(&self, hall: Hall) -> Result<Hall, DatabaseError> {
         Ok(hall.update_all_fields(self.db).await?)
     }

--- a/backend/database/src/repos/import_error.rs
+++ b/backend/database/src/repos/import_error.rs
@@ -1,0 +1,178 @@
+use chrono::{DateTime, Utc};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use crate::{
+    error::DatabaseError,
+    models::import_error::{ImportError, ImportErrorCreate},
+};
+
+pub struct ImportErrorRepo<'a> {
+    db: &'a PgPool,
+}
+
+impl<'a> ImportErrorRepo<'a> {
+    pub fn new(db: &'a PgPool) -> Self {
+        Self { db }
+    }
+
+    pub async fn list(
+        &self,
+        limit: i64,
+        resolved: bool,
+    ) -> Result<Vec<ImportError>, DatabaseError> {
+        self.all(limit as usize, None, resolved).await
+    }
+
+    pub async fn all(
+        &self,
+        limit: usize,
+        cursor: Option<(DateTime<Utc>, Uuid)>,
+        resolved: bool,
+    ) -> Result<Vec<ImportError>, DatabaseError> {
+        let mut query = sqlx::QueryBuilder::new("SELECT * FROM import_errors WHERE ");
+
+        if resolved {
+            query.push("resolved_at IS NOT NULL");
+        } else {
+            query.push("resolved_at IS NULL");
+        }
+
+        if let Some((last_seen_at, id)) = cursor {
+            query
+                .push(" AND (last_seen_at, id) < (")
+                .push_bind(last_seen_at)
+                .push(", ")
+                .push_bind(id)
+                .push(")");
+        }
+
+        query
+            .push(" ORDER BY last_seen_at DESC, id DESC LIMIT ")
+            .push_bind(limit as i64);
+
+        Ok(query.build_query_as::<ImportError>().fetch_all(self.db).await?)
+    }
+
+    pub async fn unresolved(&self, limit: i64) -> Result<Vec<ImportError>, DatabaseError> {
+        self.list(limit, false).await
+    }
+
+    pub async fn record(&self, error: ImportErrorCreate) -> Result<ImportError, DatabaseError> {
+        if let Some(existing) = sqlx::query_as::<_, ImportError>(
+            "UPDATE import_errors
+             SET
+                updated_at = now(),
+                last_seen_at = now(),
+                run_id = $1,
+                severity = $2,
+                message = $9,
+                payload = $10
+             WHERE resolved_at IS NULL
+               AND entity = $3
+               AND source_id IS NOT DISTINCT FROM $4
+               AND error_kind = $5
+               AND field IS NOT DISTINCT FROM $6
+               AND relation IS NOT DISTINCT FROM $7
+               AND relation_source_id IS NOT DISTINCT FROM $8
+             RETURNING *",
+        )
+        .bind(error.run_id)
+        .bind(&error.severity)
+        .bind(&error.entity)
+        .bind(error.source_id)
+        .bind(&error.error_kind)
+        .bind(&error.field)
+        .bind(&error.relation)
+        .bind(error.relation_source_id)
+        .bind(&error.message)
+        .bind(&error.payload)
+        .fetch_optional(self.db)
+        .await?
+        {
+            return Ok(existing);
+        }
+
+        Ok(sqlx::query_as::<_, ImportError>(
+            "INSERT INTO import_errors (
+                run_id,
+                severity,
+                entity,
+                source_id,
+                error_kind,
+                field,
+                relation,
+                relation_source_id,
+                message,
+                payload
+             )
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+             RETURNING *",
+        )
+        .bind(error.run_id)
+        .bind(error.severity)
+        .bind(error.entity)
+        .bind(error.source_id)
+        .bind(error.error_kind)
+        .bind(error.field)
+        .bind(error.relation)
+        .bind(error.relation_source_id)
+        .bind(error.message)
+        .bind(error.payload)
+        .fetch_one(self.db)
+        .await?)
+    }
+
+    pub async fn resolve_for_item(
+        &self,
+        entity: &str,
+        source_id: Option<i32>,
+    ) -> Result<u64, DatabaseError> {
+        let result = sqlx::query(
+            "UPDATE import_errors
+             SET
+                updated_at = now(),
+                resolved_at = now()
+             WHERE resolved_at IS NULL
+               AND entity = $1
+               AND source_id IS NOT DISTINCT FROM $2",
+        )
+        .bind(entity)
+        .bind(source_id)
+        .execute(self.db)
+        .await?;
+
+        Ok(result.rows_affected())
+    }
+
+    /// Batched variant of `resolve_for_item` for marking many items resolved
+    /// in a single round trip. Used by the importer to resolve previous errors
+    /// for everything that succeeded in the current batch without an UPDATE
+    /// per item. Items with `NULL` `source_id` cannot be addressed individually
+    /// and must continue to use `resolve_for_item`.
+    pub async fn resolve_for_items(
+        &self,
+        entity: &str,
+        source_ids: &[i32],
+    ) -> Result<u64, DatabaseError> {
+        if source_ids.is_empty() {
+            return Ok(0);
+        }
+
+        let result = sqlx::query(
+            "UPDATE import_errors
+             SET
+                updated_at = now(),
+                resolved_at = now()
+             WHERE resolved_at IS NULL
+               AND entity = $1
+               AND source_id = ANY($2)",
+        )
+        .bind(entity)
+        .bind(source_ids)
+        .execute(self.db)
+        .await?;
+
+        Ok(result.rows_affected())
+    }
+}

--- a/backend/database/src/repos/location.rs
+++ b/backend/database/src/repos/location.rs
@@ -204,25 +204,43 @@ impl<'a> LocationRepo<'a> {
         })
     }
 
-    pub async fn by_source_id(
+    pub async fn upsert_by_source_id(
         &self,
-        source_id: i32,
-    ) -> Result<Option<LocationWithTranslations>, DatabaseError> {
-        let Some(location) = Location::select()
+        location: LocationCreate,
+    ) -> Result<Location, DatabaseError> {
+        let Some(source_id) = location.source_id else {
+            return Ok(self.insert(location, vec![]).await?.location);
+        };
+
+        match self.by_source_id(source_id).await? {
+            Some(existing) => Ok(Location {
+                id: existing.id,
+                source_id: location.source_id,
+                name: location.name,
+                code: location.code,
+                street: location.street,
+                number: location.number,
+                postal_code: location.postal_code,
+                city: location.city,
+                country: location.country,
+                phone_1: location.phone_1,
+                phone_2: location.phone_2,
+                is_owned_by_viernulvier: location.is_owned_by_viernulvier,
+                uitdatabank_id: location.uitdatabank_id,
+                slug: location.slug,
+            }
+            .update_all_fields(self.db)
+            .await?),
+            None => Ok(self.insert(location, vec![]).await?.location),
+        }
+    }
+
+    pub async fn by_source_id(&self, source_id: i32) -> Result<Option<Location>, DatabaseError> {
+        Ok(Location::select()
             .where_("source_id = $1")
             .bind(source_id)
             .fetch_optional(self.db)
-            .await?
-        else {
-            return Ok(None);
-        };
-
-        let translations = self.fetch_translations_for(location.id).await?;
-
-        Ok(Some(LocationWithTranslations {
-            location,
-            translations,
-        }))
+            .await?)
     }
 
     pub async fn update(

--- a/backend/database/src/repos/production/mod.rs
+++ b/backend/database/src/repos/production/mod.rs
@@ -61,6 +61,45 @@ impl<'a> ProductionRepo<'a> {
         })
     }
 
+    /// Importer-only upsert: looks up the existing production by `source_id` and
+    /// overwrites every API-sourced field, then upserts the translations.
+    ///
+    /// All non-key fields on `Production` (`slug`, `video_1`, `video_2`,
+    /// `eticket_info`, `uitdatabank_theme`, `uitdatabank_type`) come from the
+    /// upstream API, so we copy all of them on every run. The CMS-edited copy
+    /// (titles, descriptions, taglines, etc.) lives on `production_translations`
+    /// and is reconciled by `upsert_translations` via the `translations`
+    /// parameter, not by this function.
+    pub async fn upsert_by_source_id(
+        &self,
+        production: ProductionCreate,
+        translations: Vec<ProductionTranslationData>,
+    ) -> Result<ProductionWithTranslations, DatabaseError> {
+        let Some(source_id) = production.source_id else {
+            return self.insert(production, translations).await;
+        };
+
+        match self.by_source_id(source_id).await? {
+            Some(existing) => {
+                self.update(
+                    Production {
+                        id: existing.production.id,
+                        source_id: production.source_id,
+                        slug: production.slug,
+                        video_1: production.video_1,
+                        video_2: production.video_2,
+                        eticket_info: production.eticket_info,
+                        uitdatabank_theme: production.uitdatabank_theme,
+                        uitdatabank_type: production.uitdatabank_type,
+                    },
+                    translations,
+                )
+                .await
+            }
+            None => self.insert(production, translations).await,
+        }
+    }
+
     pub async fn update(
         &self,
         production: Production,

--- a/backend/database/src/repos/space.rs
+++ b/backend/database/src/repos/space.rs
@@ -45,6 +45,21 @@ impl<'a> SpaceRepo<'a> {
         Ok(space.insert(self.db).await?)
     }
 
+    pub async fn upsert_by_source_id(&self, space: SpaceCreate) -> Result<Space, DatabaseError> {
+        let Some(source_id) = space.source_id else {
+            return self.insert(space).await;
+        };
+
+        match self.by_source_id(source_id).await? {
+            Some(mut existing) => {
+                existing.name_nl = space.name_nl;
+                existing.location_id = space.location_id;
+                self.update(existing).await
+            }
+            None => self.insert(space).await,
+        }
+    }
+
     pub async fn by_source_id(&self, source_id: i32) -> Result<Option<Space>, DatabaseError> {
         Ok(Space::select()
             .where_("source_id = $1")

--- a/backend/migrations/20260412213122_import_errors.down.sql
+++ b/backend/migrations/20260412213122_import_errors.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS import_errors_unresolved_last_seen_at_idx;
+DROP INDEX IF EXISTS import_errors_active_unique;
+DROP TABLE IF EXISTS import_errors;

--- a/backend/migrations/20260412213122_import_errors.up.sql
+++ b/backend/migrations/20260412213122_import_errors.up.sql
@@ -1,0 +1,35 @@
+CREATE TABLE import_errors (
+    id UUID PRIMARY KEY DEFAULT uuidv7(),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_seen_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    resolved_at TIMESTAMPTZ,
+
+    run_id UUID,
+    severity TEXT NOT NULL,
+    entity TEXT NOT NULL,
+    source_id INTEGER,
+    error_kind TEXT NOT NULL,
+    field TEXT,
+    relation TEXT,
+    relation_source_id INTEGER,
+    message TEXT NOT NULL,
+    payload JSONB,
+
+    CHECK (severity IN ('warning', 'error'))
+);
+
+CREATE UNIQUE INDEX import_errors_active_unique
+ON import_errors (
+    entity,
+    COALESCE(source_id, -1),
+    error_kind,
+    COALESCE(field, ''),
+    COALESCE(relation, ''),
+    COALESCE(relation_source_id, -1)
+)
+WHERE resolved_at IS NULL;
+
+CREATE INDEX import_errors_unresolved_last_seen_at_idx
+ON import_errors (last_seen_at DESC)
+WHERE resolved_at IS NULL;

--- a/backend/src/dto/import_error.rs
+++ b/backend/src/dto/import_error.rs
@@ -1,0 +1,88 @@
+use base64::{Engine, prelude::BASE64_URL_SAFE};
+use chrono::{DateTime, Utc};
+use database::{Database, models::import_error::ImportError};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use crate::{dto::paginated::PaginatedResponse, error::AppError};
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct ImportErrorPayload {
+    pub id: Uuid,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub last_seen_at: DateTime<Utc>,
+    pub resolved_at: Option<DateTime<Utc>>,
+    pub run_id: Option<Uuid>,
+    pub severity: String,
+    pub entity: String,
+    pub source_id: Option<i32>,
+    pub error_kind: String,
+    pub field: Option<String>,
+    pub relation: Option<String>,
+    pub relation_source_id: Option<i32>,
+    pub message: String,
+    pub payload: Option<Value>,
+}
+
+impl From<ImportError> for ImportErrorPayload {
+    fn from(value: ImportError) -> Self {
+        Self {
+            id: value.id,
+            created_at: value.created_at,
+            updated_at: value.updated_at,
+            last_seen_at: value.last_seen_at,
+            resolved_at: value.resolved_at,
+            run_id: value.run_id,
+            severity: value.severity,
+            entity: value.entity,
+            source_id: value.source_id,
+            error_kind: value.error_kind,
+            field: value.field,
+            relation: value.relation,
+            relation_source_id: value.relation_source_id,
+            message: value.message,
+            payload: value.payload,
+        }
+    }
+}
+
+impl ImportErrorPayload {
+    pub async fn all(
+        db: &Database,
+        cursor: Option<String>,
+        limit: usize,
+        resolved: bool,
+    ) -> Result<PaginatedResponse<Self>, AppError> {
+        let cursor = cursor.and_then(|cursor| decode_cursor(&cursor));
+        let mut errors = db.import_errors().all(limit + 1, cursor, resolved).await?;
+        let next_cursor = if errors.len() == limit + 1 {
+            errors.pop();
+            errors.last().map(encode_cursor)
+        } else {
+            None
+        };
+
+        Ok(PaginatedResponse {
+            data: errors.into_iter().map(Self::from).collect(),
+            next_cursor,
+        })
+    }
+}
+
+fn decode_cursor(cursor: &str) -> Option<(DateTime<Utc>, Uuid)> {
+    let decoded = BASE64_URL_SAFE.decode(cursor).ok()?;
+    let decoded = String::from_utf8(decoded).ok()?;
+    let (timestamp, id) = decoded.split_once('|')?;
+    let last_seen_at = DateTime::parse_from_rfc3339(timestamp)
+        .ok()?
+        .with_timezone(&Utc);
+    let id = Uuid::parse_str(id).ok()?;
+    Some((last_seen_at, id))
+}
+
+fn encode_cursor(error: &ImportError) -> String {
+    BASE64_URL_SAFE.encode(format!("{}|{}", error.last_seen_at.to_rfc3339(), error.id))
+}

--- a/backend/src/dto/mod.rs
+++ b/backend/src/dto/mod.rs
@@ -5,6 +5,7 @@ pub mod event;
 pub mod event_price;
 pub mod facet;
 pub mod hall;
+pub mod import_error;
 pub mod location;
 pub mod media;
 pub mod paginated;

--- a/backend/src/handlers/import_error.rs
+++ b/backend/src/handlers/import_error.rs
@@ -1,0 +1,41 @@
+use axum::extract::Query;
+
+use crate::{
+    dto::{import_error::ImportErrorPayload, paginated::PaginatedResponse},
+    error::ErrorResponse,
+    handlers::{
+        IntoApiResponse, JsonResponse,
+        queries::{import_error::GetImportErrorsFilterQuery, pagination::PaginationQuery},
+    },
+};
+use database::Database;
+
+#[utoipa::path(
+    method(get),
+    path = "/import-errors",
+    operation_id = "get_import_errors",
+    tag = "Editor",
+    description = "List importer errors for CMS usage. Returns unresolved errors by default.",
+    params(PaginationQuery, GetImportErrorsFilterQuery),
+    responses(
+        (status = 200, description = "Success", body = PaginatedResponse<ImportErrorPayload>),
+        (status = 401, description = "Unauthorized", body = ErrorResponse)
+    ),
+    security(
+        ("cookie_auth" = [])
+    )
+)]
+pub async fn get_all(
+    db: Database,
+    Query(pagination): Query<PaginationQuery>,
+    Query(filter): Query<GetImportErrorsFilterQuery>,
+) -> JsonResponse<PaginatedResponse<ImportErrorPayload>> {
+    ImportErrorPayload::all(
+        &db,
+        pagination.cursor,
+        pagination.limit as usize,
+        filter.resolved,
+    )
+    .await?
+    .json()
+}

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -13,6 +13,7 @@ pub mod auth;
 pub mod collection;
 pub mod event;
 pub mod hall;
+pub mod import_error;
 pub mod location;
 pub mod media;
 pub mod production;
@@ -24,6 +25,7 @@ pub mod taxonomy;
 pub mod version;
 pub mod queries {
     pub mod hall;
+    pub mod import_error;
     pub mod location;
     pub mod article;
     pub mod media;

--- a/backend/src/handlers/queries/import_error.rs
+++ b/backend/src/handlers/queries/import_error.rs
@@ -1,0 +1,8 @@
+use serde::Deserialize;
+use utoipa::IntoParams;
+
+#[derive(Deserialize, IntoParams)]
+pub struct GetImportErrorsFilterQuery {
+    #[serde(default)]
+    pub resolved: bool,
+}

--- a/backend/src/handlers/queries/pagination.rs
+++ b/backend/src/handlers/queries/pagination.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Deserializer};
-use utoipa::IntoParams;
+use utoipa::{IntoParams, ToSchema};
 
-#[derive(Deserialize, IntoParams)]
+#[derive(Deserialize, IntoParams, ToSchema)]
 pub struct PaginationQuery {
     pub cursor: Option<String>,
     #[serde(

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -28,8 +28,8 @@ use utoipa_swagger_ui::{Config, SwaggerUi};
 use crate::config::AppConfig;
 use crate::error::AppError;
 use crate::handlers::{
-    admin, article, artist, auth, collection, event, hall, location, media, production, series,
-    space, stats, tagging, taxonomy, version,
+    admin, article, artist, auth, collection, event, hall, import_error, location, media,
+    production, series, space, stats, tagging, taxonomy, version,
 };
 
 pub mod config;
@@ -285,6 +285,7 @@ fn editor_routes(state: AppState) -> OpenApiRouter<AppState> {
     OpenApiRouter::new()
         // Editor/Admin
         .routes(routes!(admin::editor_me))
+        .routes(routes!(import_error::get_all))
         // Location
         .routes(routes!(location::post))
         .routes(routes!(location::delete))

--- a/backend/tests/admin.rs
+++ b/backend/tests/admin.rs
@@ -1,7 +1,11 @@
 use axum::http::StatusCode;
-use database::models::user::UserRole;
+use database::{
+    Database,
+    models::{import_error::ImportErrorCreate, user::UserRole},
+};
 use serde::Deserialize;
 use sqlx::PgPool;
+use uuid::Uuid;
 
 use crate::common::{into_struct::IntoStruct, router::TestRouter};
 
@@ -11,6 +15,21 @@ mod common;
 struct EditorResponse {
     email: String,
     role: UserRole,
+}
+
+#[derive(Debug, Deserialize)]
+struct ImportErrorResponse {
+    severity: String,
+    entity: String,
+    source_id: Option<i32>,
+    error_kind: String,
+    resolved_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PaginatedImportErrorsResponse {
+    data: Vec<ImportErrorResponse>,
+    next_cursor: Option<String>,
 }
 
 #[sqlx::test]
@@ -98,4 +117,345 @@ async fn create_editor_editor_denied(db: PgPool) {
 
     let response = app.post("/editor/create", &payload).await;
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[sqlx::test]
+#[test_log::test]
+async fn import_errors_editor_access(db: PgPool) {
+    let database = Database::new(db.clone());
+    database
+        .import_errors()
+        .record(ImportErrorCreate {
+            run_id: Some(Uuid::now_v7()),
+            severity: "warning".into(),
+            entity: "space".into(),
+            source_id: Some(404),
+            error_kind: "missing_relation".into(),
+            field: None,
+            relation: Some("location".into()),
+            relation_source_id: Some(999),
+            message: "space references missing location".into(),
+            payload: None,
+        })
+        .await
+        .unwrap();
+
+    let unauth_app = TestRouter::new(db.clone());
+    let unauth_response = unauth_app.get("/import-errors").await;
+    assert_eq!(unauth_response.status(), StatusCode::UNAUTHORIZED);
+
+    let app = TestRouter::as_editor(db).await;
+    let response = app.get("/import-errors").await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let data: PaginatedImportErrorsResponse = response.into_struct().await;
+    assert_eq!(data.data.len(), 1);
+    assert_eq!(data.next_cursor, None);
+    let error = data.data.first().expect("expected one import error");
+    assert_eq!(error.severity, "warning");
+    assert_eq!(error.entity, "space");
+    assert_eq!(error.source_id, Some(404));
+    assert_eq!(error.error_kind, "missing_relation");
+    assert_eq!(error.resolved_at, None);
+}
+
+#[sqlx::test]
+#[test_log::test]
+async fn import_errors_resolved_filter(db: PgPool) {
+    let database = Database::new(db.clone());
+
+    database
+        .import_errors()
+        .record(ImportErrorCreate {
+            run_id: Some(Uuid::now_v7()),
+            severity: "warning".into(),
+            entity: "event".into(),
+            source_id: Some(1),
+            error_kind: "missing_relation".into(),
+            field: None,
+            relation: Some("hall".into()),
+            relation_source_id: Some(2),
+            message: "event imported without hall".into(),
+            payload: None,
+        })
+        .await
+        .unwrap();
+
+    database
+        .import_errors()
+        .record(ImportErrorCreate {
+            run_id: Some(Uuid::now_v7()),
+            severity: "error".into(),
+            entity: "space".into(),
+            source_id: Some(2),
+            error_kind: "missing_relation".into(),
+            field: None,
+            relation: Some("location".into()),
+            relation_source_id: Some(3),
+            message: "space references missing location".into(),
+            payload: None,
+        })
+        .await
+        .unwrap();
+
+    database
+        .import_errors()
+        .resolve_for_item("space", Some(2))
+        .await
+        .unwrap();
+
+    let app = TestRouter::as_editor(db).await;
+
+    let unresolved: PaginatedImportErrorsResponse =
+        app.get("/import-errors").await.into_struct().await;
+    assert_eq!(unresolved.data.len(), 1);
+    let unresolved_error = unresolved
+        .data
+        .first()
+        .expect("expected one unresolved import error");
+    assert_eq!(unresolved_error.entity, "event");
+    assert_eq!(unresolved_error.resolved_at, None);
+
+    let resolved: PaginatedImportErrorsResponse = app
+        .get("/import-errors?resolved=true")
+        .await
+        .into_struct()
+        .await;
+    assert_eq!(resolved.data.len(), 1);
+    let resolved_error = resolved
+        .data
+        .first()
+        .expect("expected one resolved import error");
+    assert_eq!(resolved_error.entity, "space");
+    assert!(resolved_error.resolved_at.is_some());
+}
+
+#[sqlx::test]
+#[test_log::test]
+async fn import_errors_paginates(db: PgPool) {
+    let database = Database::new(db.clone());
+
+    for source_id in [101, 102, 103] {
+        database
+            .import_errors()
+            .record(ImportErrorCreate {
+                run_id: Some(Uuid::now_v7()),
+                severity: "warning".into(),
+                entity: "event".into(),
+                source_id: Some(source_id),
+                error_kind: "missing_relation".into(),
+                field: None,
+                relation: Some("production".into()),
+                relation_source_id: Some(source_id + 1000),
+                message: format!(
+                    "event references missing production source_id {}",
+                    source_id + 1000
+                ),
+                payload: None,
+            })
+            .await
+            .unwrap();
+    }
+
+    let app = TestRouter::as_editor(db).await;
+
+    let first_page: PaginatedImportErrorsResponse =
+        app.get("/import-errors?limit=2").await.into_struct().await;
+    assert_eq!(first_page.data.len(), 2);
+    assert!(first_page.next_cursor.is_some());
+
+    let second_page: PaginatedImportErrorsResponse = app
+        .get(&format!(
+            "/import-errors?limit=2&cursor={}",
+            first_page.next_cursor.clone().unwrap()
+        ))
+        .await
+        .into_struct()
+        .await;
+    assert_eq!(second_page.data.len(), 1);
+    assert_eq!(second_page.next_cursor, None);
+}
+
+#[sqlx::test]
+#[test_log::test]
+async fn import_errors_invalid_cursor_falls_back_to_first_page(db: PgPool) {
+    let database = Database::new(db.clone());
+
+    for source_id in [201, 202] {
+        database
+            .import_errors()
+            .record(ImportErrorCreate {
+                run_id: Some(Uuid::now_v7()),
+                severity: "error".into(),
+                entity: "media".into(),
+                source_id: Some(source_id),
+                error_kind: "import_failure".into(),
+                field: Some("cdn_url".into()),
+                relation: None,
+                relation_source_id: None,
+                message: format!("media {source_id} failed"),
+                payload: None,
+            })
+            .await
+            .unwrap();
+    }
+
+    let app = TestRouter::as_editor(db).await;
+
+    let response: PaginatedImportErrorsResponse = app
+        .get("/import-errors?limit=1&cursor=not-a-valid-cursor")
+        .await
+        .into_struct()
+        .await;
+
+    assert_eq!(response.data.len(), 1);
+    assert!(response.next_cursor.is_some());
+    assert_eq!(response.data[0].entity, "media");
+}
+
+#[sqlx::test]
+#[test_log::test]
+async fn import_error_record_updates_matching_unresolved_error(db: PgPool) {
+    let database = Database::new(db);
+    let first = database
+        .import_errors()
+        .record(ImportErrorCreate {
+            run_id: Some(Uuid::now_v7()),
+            severity: "warning".into(),
+            entity: "media".into(),
+            source_id: Some(7),
+            error_kind: "import_failure".into(),
+            field: Some("cdn_url".into()),
+            relation: None,
+            relation_source_id: None,
+            message: "first failure".into(),
+            payload: Some(serde_json::json!({ "attempt": 1 })),
+        })
+        .await
+        .unwrap();
+
+    let second = database
+        .import_errors()
+        .record(ImportErrorCreate {
+            run_id: Some(Uuid::now_v7()),
+            severity: "error".into(),
+            entity: "media".into(),
+            source_id: Some(7),
+            error_kind: "import_failure".into(),
+            field: Some("cdn_url".into()),
+            relation: None,
+            relation_source_id: None,
+            message: "second failure".into(),
+            payload: Some(serde_json::json!({ "attempt": 2 })),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(second.id, first.id);
+    assert_eq!(second.severity, "error");
+    assert_eq!(second.message, "second failure");
+    assert_eq!(second.payload, Some(serde_json::json!({ "attempt": 2 })));
+
+    let unresolved = database.import_errors().unresolved(10).await.unwrap();
+    assert_eq!(unresolved.len(), 1);
+    assert_eq!(unresolved[0].id, first.id);
+}
+
+#[sqlx::test]
+#[test_log::test]
+async fn import_error_record_creates_new_row_after_resolution(db: PgPool) {
+    let database = Database::new(db);
+    let first = database
+        .import_errors()
+        .record(ImportErrorCreate {
+            run_id: Some(Uuid::now_v7()),
+            severity: "error".into(),
+            entity: "space".into(),
+            source_id: Some(42),
+            error_kind: "missing_relation".into(),
+            field: None,
+            relation: Some("location".into()),
+            relation_source_id: Some(9),
+            message: "location missing".into(),
+            payload: None,
+        })
+        .await
+        .unwrap();
+
+    let resolved = database
+        .import_errors()
+        .resolve_for_item("space", Some(42))
+        .await
+        .unwrap();
+    assert_eq!(resolved, 1);
+
+    let second = database
+        .import_errors()
+        .record(ImportErrorCreate {
+            run_id: Some(Uuid::now_v7()),
+            severity: "error".into(),
+            entity: "space".into(),
+            source_id: Some(42),
+            error_kind: "missing_relation".into(),
+            field: None,
+            relation: Some("location".into()),
+            relation_source_id: Some(9),
+            message: "location still missing".into(),
+            payload: None,
+        })
+        .await
+        .unwrap();
+
+    assert_ne!(second.id, first.id);
+    assert_eq!(
+        database.import_errors().unresolved(10).await.unwrap().len(),
+        1
+    );
+    assert_eq!(
+        database.import_errors().list(10, true).await.unwrap().len(),
+        1
+    );
+}
+
+#[sqlx::test]
+#[test_log::test]
+async fn import_error_resolve_for_items_batches_source_ids(db: PgPool) {
+    let database = Database::new(db);
+
+    for source_id in [1, 2, 3] {
+        database
+            .import_errors()
+            .record(ImportErrorCreate {
+                run_id: Some(Uuid::now_v7()),
+                severity: "error".into(),
+                entity: "media".into(),
+                source_id: Some(source_id),
+                error_kind: "import_failure".into(),
+                field: Some("cdn_url".into()),
+                relation: None,
+                relation_source_id: None,
+                message: format!("media {source_id} failed"),
+                payload: None,
+            })
+            .await
+            .unwrap();
+    }
+
+    let empty_resolved = database
+        .import_errors()
+        .resolve_for_items("media", &[])
+        .await
+        .unwrap();
+    assert_eq!(empty_resolved, 0);
+
+    let resolved = database
+        .import_errors()
+        .resolve_for_items("media", &[1, 3, 999])
+        .await
+        .unwrap();
+    assert_eq!(resolved, 2);
+
+    let unresolved = database.import_errors().unresolved(10).await.unwrap();
+    assert_eq!(unresolved.len(), 1);
+    assert_eq!(unresolved[0].source_id, Some(2));
 }

--- a/backend/tests/article.rs
+++ b/backend/tests/article.rs
@@ -463,7 +463,11 @@ async fn relations_crud(db: PgPool) {
     assert_eq!(response.status(), StatusCode::OK);
     let data: ArticleRelationsPayload = response.into_struct().await;
     assert_eq!(data.production_ids.len(), 1);
-    assert_eq!(data.production_ids[0], production_id);
+    let related_production = data
+        .production_ids
+        .first()
+        .expect("expected one related production");
+    assert_eq!(*related_production, production_id);
 
     let response = app
         .get(&format!("/articles/cms/{article_id}/relations"))

--- a/backend/tests/collection.rs
+++ b/backend/tests/collection.rs
@@ -42,8 +42,10 @@ async fn get_one_success(db: PgPool) {
         .expect("Dutch translation not found");
     assert_eq!(nl.title, "Zomerselectie");
     assert_eq!(data.items.len(), 2);
-    assert_eq!(data.items[0].position, 1);
-    assert_eq!(data.items[1].position, 2);
+    let first_item = data.items.first().expect("expected first collection item");
+    assert_eq!(first_item.position, 1);
+    let second_item = data.items.get(1).expect("expected second collection item");
+    assert_eq!(second_item.position, 2);
 }
 
 #[sqlx::test]

--- a/backend/tests/importer_errors.rs
+++ b/backend/tests/importer_errors.rs
@@ -1,0 +1,170 @@
+use api::{
+    error::{ImportEntity, ImportField, ImportItemError, ImportRelation},
+    models::{event_price::ApiEventPrice, localized_text::ApiLocalizedText, space::ApiSpace},
+};
+use chrono::Utc;
+use database::Database;
+use sqlx::PgPool;
+
+fn space_with_location(location: &str) -> ApiSpace {
+    ApiSpace {
+        id: "/api/v1/spaces/42".into(),
+        jsonld_type: "Space".into(),
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+        name: ApiLocalizedText {
+            nl: Some("Main space".into()),
+            en: None,
+            fr: None,
+        },
+        location: location.into(),
+        halls: vec![],
+    }
+}
+
+fn event_price_with_refs(amount: &str, event: &str, price: &str, rank: &str) -> ApiEventPrice {
+    ApiEventPrice {
+        id: "/api/v1/events/prices/88".into(),
+        jsonld_type: "EventPrice".into(),
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+        available: 10,
+        amount: amount.into(),
+        box_office_id: None,
+        contingent_id: None,
+        expires_at: None,
+        event: event.into(),
+        price: price.into(),
+        rank: rank.into(),
+    }
+}
+
+#[sqlx::test]
+#[test_log::test]
+async fn importer_space_invalid_location_reference_is_item_error(db: PgPool) {
+    let database = Database::new(db);
+    let err = space_with_location("/api/v1/locations/not-an-id")
+        .upsert_import(&database)
+        .await
+        .unwrap_err();
+
+    match err {
+        ImportItemError::InvalidReference {
+            entity,
+            field,
+            value,
+        } => {
+            assert_eq!(entity, ImportEntity::Space);
+            assert_eq!(field, ImportField::Location);
+            assert_eq!(value, "/api/v1/locations/not-an-id");
+        }
+        other => panic!("expected InvalidReference, got {other:?}"),
+    }
+}
+
+#[sqlx::test]
+#[test_log::test]
+async fn importer_space_missing_location_relation_is_item_error(db: PgPool) {
+    let database = Database::new(db);
+    let err = space_with_location("/api/v1/locations/404")
+        .upsert_import(&database)
+        .await
+        .unwrap_err();
+
+    match err {
+        ImportItemError::MissingRelation {
+            entity,
+            relation,
+            source_id,
+        } => {
+            assert_eq!(entity, ImportEntity::Space);
+            assert_eq!(relation, ImportRelation::Location);
+            assert_eq!(source_id, 404);
+        }
+        other => panic!("expected MissingRelation, got {other:?}"),
+    }
+}
+
+#[sqlx::test]
+#[test_log::test]
+async fn importer_event_price_invalid_amount_is_item_error(db: PgPool) {
+    let database = Database::new(db);
+    let err = event_price_with_refs(
+        "not-money",
+        "/api/v1/events/1",
+        "/api/v1/prices/2",
+        "/api/v1/prices/ranks/3",
+    )
+    .upsert_import(&database)
+    .await
+    .unwrap_err();
+
+    match err {
+        ImportItemError::InvalidReference {
+            entity,
+            field,
+            value,
+        } => {
+            assert_eq!(entity, ImportEntity::EventPrice);
+            assert_eq!(field, ImportField::Amount);
+            assert_eq!(value, "not-money");
+        }
+        other => panic!("expected InvalidReference, got {other:?}"),
+    }
+}
+
+#[sqlx::test]
+#[test_log::test]
+async fn importer_event_price_invalid_event_reference_is_item_error(db: PgPool) {
+    let database = Database::new(db);
+    let err = event_price_with_refs(
+        "12.34",
+        "/api/v1/events/nope",
+        "/api/v1/prices/2",
+        "/api/v1/prices/ranks/3",
+    )
+    .upsert_import(&database)
+    .await
+    .unwrap_err();
+
+    match err {
+        ImportItemError::InvalidReference {
+            entity,
+            field,
+            value,
+        } => {
+            assert_eq!(entity, ImportEntity::EventPrice);
+            assert_eq!(field, ImportField::Event);
+            assert_eq!(value, "/api/v1/events/nope");
+        }
+        other => panic!("expected InvalidReference, got {other:?}"),
+    }
+}
+
+#[sqlx::test]
+#[test_log::test]
+async fn importer_event_price_missing_event_relation_is_item_error(db: PgPool) {
+    let database = Database::new(db);
+    let err = event_price_with_refs(
+        "12.34",
+        "/api/v1/events/404",
+        "/api/v1/prices/2",
+        "/api/v1/prices/ranks/3",
+    )
+    .upsert_import(&database)
+    .await
+    .unwrap_err();
+
+    match err {
+        ImportItemError::MissingRelation {
+            entity,
+            relation,
+            source_id,
+        } => {
+            assert_eq!(entity, ImportEntity::EventPrice);
+            assert_eq!(relation, ImportRelation::Event);
+            assert_eq!(source_id, 404);
+        }
+        other => panic!("expected MissingRelation, got {other:?}"),
+    }
+}

--- a/backend/tests/media.rs
+++ b/backend/tests/media.rs
@@ -35,7 +35,8 @@ async fn get_entity_media_with_role_filter(db: PgPool) {
     assert_eq!(response.status(), StatusCode::OK);
     let data: Vec<MediaPayload> = response.into_struct().await;
     assert_eq!(data.len(), 1);
-    assert_eq!(data[0].gallery_type.as_deref(), Some("poster"));
+    let media = data.first().expect("expected one media item");
+    assert_eq!(media.gallery_type.as_deref(), Some("poster"));
 }
 
 #[sqlx::test(fixtures("productions", "media"))]
@@ -53,7 +54,7 @@ async fn get_entity_cover_media_via_filter(db: PgPool) {
     assert_eq!(response.status(), StatusCode::OK);
     let data: Vec<MediaPayload> = response.into_struct().await;
     assert_eq!(data.len(), 1);
-    let media = &data[0];
+    let media = data.first().expect("expected one media item");
     assert_eq!(media.alt_text_nl.as_deref(), Some("Cover image"));
 }
 
@@ -72,8 +73,10 @@ async fn get_entity_media_with_crops(db: PgPool) {
     assert_eq!(response.status(), StatusCode::OK);
     let data: Vec<MediaPayload> = response.into_struct().await;
     assert_eq!(data.len(), 1);
-    assert_eq!(data[0].crops.len(), 1);
-    assert_eq!(data[0].crops[0].crop_name.as_deref(), Some("square"));
+    let media = data.first().expect("expected one media item");
+    assert_eq!(media.crops.len(), 1);
+    let crop = media.crops.first().expect("expected one crop");
+    assert_eq!(crop.crop_name.as_deref(), Some("square"));
 }
 
 #[sqlx::test(fixtures("productions", "media"))]
@@ -307,7 +310,11 @@ async fn cleanup_orphans(db: PgPool) {
     assert_eq!(cleanup_res.status(), StatusCode::OK);
 
     let cleanup_data: serde_json::Value = cleanup_res.into_struct().await;
-    assert!(cleanup_data["deleted_count"].as_i64().unwrap() > 0);
+    let deleted_count = cleanup_data
+        .get("deleted_count")
+        .and_then(serde_json::Value::as_i64)
+        .expect("cleanup response should include deleted_count");
+    assert!(deleted_count > 0);
 
     // 'aaaaaaaa' should be gone because it became an orphan
     let response = app.get(&format!("/media/{media_id}")).await;

--- a/backend/tests/series.rs
+++ b/backend/tests/series.rs
@@ -470,7 +470,8 @@ async fn delete_series_cascades_join_rows(db: PgPool) {
         .await;
     let after_data: Vec<SeriesPayload> = after.into_struct().await;
     assert_eq!(after_data.len(), 1);
-    assert_eq!(after_data[0].slug, "fresh-juice");
+    let series = after_data.first().expect("expected one remaining series");
+    assert_eq!(series.slug, "fresh-juice");
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -185,9 +185,9 @@
             }
         },
         "node_modules/@asamuzakjp/dom-selector": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.0.tgz",
-            "integrity": "sha512-ASf825+5vsGuYWoyFyNsex2mNtPTXpCvYTR942+w/eNw7PqS0Lhl/PE1hC7bajneI3m/Oxi+yrP3vTOPxfwM8A==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+            "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1157,6 +1157,30 @@
                 "@noble/ciphers": "^1.0.0"
             }
         },
+        "node_modules/@emnapi/core": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+            "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.1",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/runtime": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+            "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
         "node_modules/@emnapi/wasi-threads": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -1963,13 +1987,13 @@
             }
         },
         "node_modules/@inquirer/confirm": {
-            "version": "6.0.11",
-            "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.11.tgz",
-            "integrity": "sha512-pTpHjg0iEIRMYV/7oCZUMf27/383E6Wyhfc/MY+AVQGEoUobffIYWOK9YLP2XFRGz/9i6WlTQh1CkFVIo2Y7XA==",
+            "version": "6.0.12",
+            "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.12.tgz",
+            "integrity": "sha512-h9FgGun3QwVYNj5TWIZZ+slii73bMoBFjPfVIGtnFuL4t8gBiNDV9PcSfIzkuxvgquJKt9nr1QzszpBzTbH8Og==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@inquirer/core": "^11.1.8",
+                "@inquirer/core": "^11.1.9",
                 "@inquirer/type": "^4.0.5"
             },
             "engines": {
@@ -1985,9 +2009,9 @@
             }
         },
         "node_modules/@inquirer/core": {
-            "version": "11.1.8",
-            "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.8.tgz",
-            "integrity": "sha512-/u+yJk2pOKNDOh1ZgdUH2RQaRx6OOH4I0uwL95qPvTFTIL38YBsuSC4r1yXBB3Q6JvNqFFc202gk0Ew79rrcjA==",
+            "version": "11.1.9",
+            "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.9.tgz",
+            "integrity": "sha512-BDE4fG22uYh1bGSifcj7JSx119TVYNViMhMu85usp4Fswrzh6M0DV3yld64jA98uOAa2GSQ4Bg4bZRm2d2cwSg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2161,9 +2185,9 @@
             "license": "MIT"
         },
         "node_modules/@mswjs/interceptors": {
-            "version": "0.41.3",
-            "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.3.tgz",
-            "integrity": "sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA==",
+            "version": "0.41.4",
+            "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.4.tgz",
+            "integrity": "sha512-3B9EinUkrdOUGYzHRzRWSXunQ4YFGboJnyLNRwEJWEde+j8fNhPUHvrN1E3g1DU/iS/s8JQrMNVe+S7AHHVs0w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4851,12 +4875,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/@remirror/core-constants": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-3.0.0.tgz",
-            "integrity": "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==",
-            "license": "MIT"
-        },
         "node_modules/@rolldown/binding-android-arm64": {
             "version": "1.0.0-rc.15",
             "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
@@ -5184,10 +5202,50 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@swc/core": {
+            "version": "1.15.30",
+            "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.30.tgz",
+            "integrity": "sha512-R8VQbQY1BZcbIF2p3gjlTCwAQzx1A194ugWfwld5y+WgVVWqVKm7eURGGOVbQVubgKWzidP2agomBbg96rZilQ==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@swc/counter": "^0.1.3",
+                "@swc/types": "^0.1.26"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/swc"
+            },
+            "optionalDependencies": {
+                "@swc/core-darwin-arm64": "1.15.30",
+                "@swc/core-darwin-x64": "1.15.30",
+                "@swc/core-linux-arm-gnueabihf": "1.15.30",
+                "@swc/core-linux-arm64-gnu": "1.15.30",
+                "@swc/core-linux-arm64-musl": "1.15.30",
+                "@swc/core-linux-ppc64-gnu": "1.15.30",
+                "@swc/core-linux-s390x-gnu": "1.15.30",
+                "@swc/core-linux-x64-gnu": "1.15.30",
+                "@swc/core-linux-x64-musl": "1.15.30",
+                "@swc/core-win32-arm64-msvc": "1.15.30",
+                "@swc/core-win32-ia32-msvc": "1.15.30",
+                "@swc/core-win32-x64-msvc": "1.15.30"
+            },
+            "peerDependencies": {
+                "@swc/helpers": ">=0.5.17"
+            },
+            "peerDependenciesMeta": {
+                "@swc/helpers": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@swc/core-darwin-arm64": {
-            "version": "1.15.26",
-            "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.26.tgz",
-            "integrity": "sha512-OmcP96CFsNOwa65tamQayRcfqhNlcQ3YCWOq+0Wb+CAM4uB7kOMrXY41Gj4atthxrGhLQ9pg7Vk26iApb88idA==",
+            "version": "1.15.30",
+            "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.30.tgz",
+            "integrity": "sha512-VvpP+vq08HmGYewMWvrdsxh9s2lthz/808zXm8Yu5kaqeR8Yia2b0eYXleHQ3VAjoStUDk6LzTheBW9KXYQdMA==",
             "cpu": [
                 "arm64"
             ],
@@ -5201,9 +5259,9 @@
             }
         },
         "node_modules/@swc/core-darwin-x64": {
-            "version": "1.15.26",
-            "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.26.tgz",
-            "integrity": "sha512-liTTTpKSv89ivIxcZ+iU1cRige9Y7JkOjVnJ2Ystzl+DsWNHqt7wLTTgm/u7gEqmmAS2JKryODLQn3q1UtFNPQ==",
+            "version": "1.15.30",
+            "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.30.tgz",
+            "integrity": "sha512-WiJA0hiZI3nwQAO6mu5RqigtWGDtth4Hiq6rbZxAaQyhIcqKIg5IoMRc1Y071lrNJn29eEDMC86Rq58xgUxlDg==",
             "cpu": [
                 "x64"
             ],
@@ -5217,9 +5275,9 @@
             }
         },
         "node_modules/@swc/core-linux-arm-gnueabihf": {
-            "version": "1.15.26",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.26.tgz",
-            "integrity": "sha512-Y/g+m3I8CeBof5A3kWWOS6QA2HOIUytF5EeTgfwcAK+GKT/tGe7Xqo5svBtaqflU5od2zzbMTWqkinPXgRWGgA==",
+            "version": "1.15.30",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.30.tgz",
+            "integrity": "sha512-YANuFUo48kIT6plJgCD0keae9HFXfjxsbvsgevqc0hr/07X/p7sAWTFOGYEc2SXcASaK7UvuQqzlbW8pr7R79g==",
             "cpu": [
                 "arm"
             ],
@@ -5233,9 +5291,9 @@
             }
         },
         "node_modules/@swc/core-linux-arm64-gnu": {
-            "version": "1.15.26",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.26.tgz",
-            "integrity": "sha512-19IvwyPfBN/rz9s7qXhOTQmW0922+pjpRUUvIebu+CMM75nX6YuDzHsGx8hSmn5dS89SNaMCh1lgUuXqm++6jg==",
+            "version": "1.15.30",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.30.tgz",
+            "integrity": "sha512-VndG8jaR4ugY6u+iVOT0Q+d2fZd7sLgjPgN8W/Le+3EbZKl+cRfFxV7Eoz4gfLqhmneZPdcIzf9T3LkgkmqNLg==",
             "cpu": [
                 "arm64"
             ],
@@ -5249,9 +5307,9 @@
             }
         },
         "node_modules/@swc/core-linux-arm64-musl": {
-            "version": "1.15.26",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.26.tgz",
-            "integrity": "sha512-iNlbvTIo425rkKzDLLWFJGnFXr3myETUdIDHcjuiPNZE8b0ogmcAuilC4yEJX7FSHGbnlsoJcCT2xf4b3VJmmQ==",
+            "version": "1.15.30",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.30.tgz",
+            "integrity": "sha512-1SYGs2l0Yyyi0pR/P/NKz/x0kqxkoiw+BXeJjLUdecSk/KasncWlJrc6hOvFSgKHOBrzgM5jwuluKtlT8dnrcA==",
             "cpu": [
                 "arm64"
             ],
@@ -5265,9 +5323,9 @@
             }
         },
         "node_modules/@swc/core-linux-ppc64-gnu": {
-            "version": "1.15.26",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.26.tgz",
-            "integrity": "sha512-AuuEOtG+YXKIjIUup4RsxYNklx6XVB3WKWfhxG6hnfPrn7vp89RNOLbbyyprgj6Sk7k9ulwGVTJElEvmBNPSCA==",
+            "version": "1.15.30",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.30.tgz",
+            "integrity": "sha512-TXREtiXeRhbfDFbmhnkIsXpKfzbfT73YkV2ZF6w0sfxgjC5zI2ZAbaCOq25qxvegofj2K93DtOpm9RLaBgqR2g==",
             "cpu": [
                 "ppc64"
             ],
@@ -5281,9 +5339,9 @@
             }
         },
         "node_modules/@swc/core-linux-s390x-gnu": {
-            "version": "1.15.26",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.26.tgz",
-            "integrity": "sha512-JcMDWQvW1BchUyRg8E0jHiTx7CQYpUr5uDEL1dnPDECrEjBEGG2ynmJ3XX70sWXql0JagqR1t3VpANYFWdUnqA==",
+            "version": "1.15.30",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.30.tgz",
+            "integrity": "sha512-DCR2YYeyd6DQE4OuDhImouuNcjXEiEdnn1Y0DyGteugPEDvVuvYk8Xddi+4o2SgWH6jiW8/I+3emZvbep1NC+g==",
             "cpu": [
                 "s390x"
             ],
@@ -5297,9 +5355,9 @@
             }
         },
         "node_modules/@swc/core-linux-x64-gnu": {
-            "version": "1.15.26",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.26.tgz",
-            "integrity": "sha512-FW7V7Mbpq4+PA7BiAq76LJs8MdNuUSylyuRVfQRkhIyeWadFroZ+KOPgjku8Z/fXzngxBRvsk+PGGB0t8mGcjA==",
+            "version": "1.15.30",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.30.tgz",
+            "integrity": "sha512-5Pizw3NgfOJ5BJOBK8TIRa59xFW2avESTOBDPTAYwZYa1JNDs+KMF9lUfjJiJLM5HiMs/wPheA9eiT0q9m2AoA==",
             "cpu": [
                 "x64"
             ],
@@ -5313,9 +5371,9 @@
             }
         },
         "node_modules/@swc/core-linux-x64-musl": {
-            "version": "1.15.26",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.26.tgz",
-            "integrity": "sha512-w8erqMHsVcdGwUfJxF6LaiTuPoKnyLOcUbhLcxiXrlLt5MLjtlgcIeUY/NWK/oPoyqkgH+/i8pOJnMTxvl83ZQ==",
+            "version": "1.15.30",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.30.tgz",
+            "integrity": "sha512-qyqydP/wyH8alcIP4a2hnGSjHLJjm9H7yDFup+CPy9oTahFgLLwnNcv5UHXqO2Qs3AIND+cls5f/Bb6hqpxdgA==",
             "cpu": [
                 "x64"
             ],
@@ -5329,9 +5387,9 @@
             }
         },
         "node_modules/@swc/core-win32-arm64-msvc": {
-            "version": "1.15.26",
-            "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.26.tgz",
-            "integrity": "sha512-uDCWCNpUiqkbvPmsuPUTn/P7ag9SqNXD2JT/W3dUu7yZ2krzN+nmmoQ2xRX63/J6RYiHI7aT4jo7Z++lsljlPA==",
+            "version": "1.15.30",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.30.tgz",
+            "integrity": "sha512-CaQENgDHVGOg1mSF5sQVgvfFHG9kjMor2rkLMLeLOkfZYNj13ppnJ9+lfaBZLZUMMbnlGQnavCJb8PVBUOso7Q==",
             "cpu": [
                 "arm64"
             ],
@@ -5345,9 +5403,9 @@
             }
         },
         "node_modules/@swc/core-win32-ia32-msvc": {
-            "version": "1.15.26",
-            "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.26.tgz",
-            "integrity": "sha512-2k1ax1QmmqLEnpC0uRCw7OXhBfyvdPqERBXupDasjYbChT6ZSO/uha28Bp38cw0viKIG79L27aTDkbkABsMW3w==",
+            "version": "1.15.30",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.30.tgz",
+            "integrity": "sha512-30VdLeGk6fugiUs/kUdJ/pAg7z/zpvVbR11RH60jZ0Z42WIeIniYx0rLEWN7h/pKJ3CopqsQ3RsogCAkRKiA2g==",
             "cpu": [
                 "ia32"
             ],
@@ -5361,9 +5419,9 @@
             }
         },
         "node_modules/@swc/core-win32-x64-msvc": {
-            "version": "1.15.26",
-            "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.26.tgz",
-            "integrity": "sha512-aUuYecSEGa4SUSdyCWaI/vk8jdseifYnsF1GZQx2+piL8GIuT/5QrVcFfmes4Iwy7FIVXxtzD063z/FfpZ7K7w==",
+            "version": "1.15.30",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.30.tgz",
+            "integrity": "sha512-4iObHPR+Q4oDY110EF5SF5eIaaVJNpMdG9C0q3Q92BsJ5y467uHz7sYQhP60WYlLFsLQ1el2YrIPUItUAQGOKg==",
             "cpu": [
                 "x64"
             ],
@@ -5769,9 +5827,9 @@
             }
         },
         "node_modules/@tanstack/query-core": {
-            "version": "5.99.0",
-            "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.99.0.tgz",
-            "integrity": "sha512-3Jv3WQG0BCcH7G+7lf/bP8QyBfJOXeY+T08Rin3GZ1bshvwlbPt7NrDHMEzGdKIOmOzvIQmxjk28YEQX60k7pQ==",
+            "version": "5.99.2",
+            "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.99.2.tgz",
+            "integrity": "sha512-1HunU0bXVsR1ZJMZbcOPE6VtaBJxsW809RE9xPe4Gz7MlB0GWwQvuTPhMoEmQ/hIzFKJ/DWAuttIe7BOaWx0tA==",
             "license": "MIT",
             "funding": {
                 "type": "github",
@@ -5779,9 +5837,9 @@
             }
         },
         "node_modules/@tanstack/query-devtools": {
-            "version": "5.99.0",
-            "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.99.0.tgz",
-            "integrity": "sha512-m4ufXaJ8FjWXw7xDtyzE/6fkZAyQFg9WrbMrUpt8ZecRJx58jiFOZ2lxZMphZdIpAnIeto/S8stbwLKLusyckQ==",
+            "version": "5.99.2",
+            "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.99.2.tgz",
+            "integrity": "sha512-TEF1d+RYO9l8oeCwgzmOHIgKwAzXQmw2s/ny2bW8qeg2OMkkLjALfVEivgCMR3OL/jVdMmeTPX56WrV+uvYJFg==",
             "license": "MIT",
             "funding": {
                 "type": "github",
@@ -5789,13 +5847,13 @@
             }
         },
         "node_modules/@tanstack/react-query": {
-            "version": "5.99.0",
-            "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.99.0.tgz",
-            "integrity": "sha512-OY2bCqPemT1LlqJ8Y2CUau4KELnIhhG9Ol3ZndPbdnB095pRbPo1cHuXTndg8iIwtoHTgwZjyaDnQ0xD0mYwAw==",
+            "version": "5.99.2",
+            "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.99.2.tgz",
+            "integrity": "sha512-vM91UEe45QUS9ED6OklsVL15i8qKcRqNwpWzPTVWvRPRSEgDudDgHpvyTjcdlwHcrKNa80T+xXYcchT2noPnZA==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@tanstack/query-core": "5.99.0"
+                "@tanstack/query-core": "5.99.2"
             },
             "funding": {
                 "type": "github",
@@ -5806,19 +5864,19 @@
             }
         },
         "node_modules/@tanstack/react-query-devtools": {
-            "version": "5.99.0",
-            "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.99.0.tgz",
-            "integrity": "sha512-CqqX7LCU9yOfCY/vBURSx2YSD83ryfX+QkfkaKionTfg1s2Hdm572Ro99gW3QPoJjzvsj1HM4pnN4nbDy3MXKA==",
+            "version": "5.99.2",
+            "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.99.2.tgz",
+            "integrity": "sha512-8txkK9A9XBNTB8RoxVgfp6W3qwBr25tNP10L4yu3KuyhAdEvccECfIRzesSwMVk/wpVVioAr+hbMtUkMMF+WVw==",
             "license": "MIT",
             "dependencies": {
-                "@tanstack/query-devtools": "5.99.0"
+                "@tanstack/query-devtools": "5.99.2"
             },
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/tannerlinsley"
             },
             "peerDependencies": {
-                "@tanstack/react-query": "^5.99.0",
+                "@tanstack/react-query": "^5.99.2",
                 "react": "^18 || ^19"
             }
         },
@@ -5946,9 +6004,9 @@
             }
         },
         "node_modules/@tiptap/core": {
-            "version": "3.22.3",
-            "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.22.3.tgz",
-            "integrity": "sha512-Dv9MKK5BDWCF0N2l6/Pxv3JNCce2kwuWf2cKMBc2bEetx0Pn6o7zlFmSxMvYK4UtG1Tw9Yg/ZHi6QOFWK0Zm9Q==",
+            "version": "3.22.4",
+            "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.22.4.tgz",
+            "integrity": "sha512-vGIGm/HpqLg8EAAQXQ+koV+/S828OEpzocfWcPOwo1u2QUVf9dQG47Yy6JJ8zFFaJwfv4dBcOXli+7BrJwsxDQ==",
             "license": "MIT",
             "peer": true,
             "funding": {
@@ -5956,39 +6014,39 @@
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/pm": "^3.22.3"
+                "@tiptap/pm": "3.22.4"
             }
         },
         "node_modules/@tiptap/extension-blockquote": {
-            "version": "3.22.3",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.22.3.tgz",
-            "integrity": "sha512-IaUx3zh7yLHXzIXKL+fw/jzFhsIImdhJyw0lMhe8FfYrefFqXJFYW/sey6+L/e8B3AWvTksPA6VBwefzbH77JA==",
+            "version": "3.22.4",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.22.4.tgz",
+            "integrity": "sha512-7/61kNPbGFhMgM//zMknD0pSb69rGdRIkpulXOWS1JBrFHkH6hjZDfrOETNzgKkO+NlmzVl9rXSTv0xauS3lzA==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "^3.22.3"
+                "@tiptap/core": "3.22.4"
             }
         },
         "node_modules/@tiptap/extension-bold": {
-            "version": "3.22.3",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.22.3.tgz",
-            "integrity": "sha512-tysipHla2zCWr8XNIWRaW9O+7i7/SoEqnRqSRUUi2ailcJjlia+RBy3RykhkgyThrQDStu5KGBS/UvrXwA+O1A==",
+            "version": "3.22.4",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.22.4.tgz",
+            "integrity": "sha512-jIaPKfNOQu2lhpbLDvtwlQqM+mjF+Kk+auHpzYjBnsuwUli1Cl5ZOau7RH+rru/SQvZe1DtpQlANujDywugZAA==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "^3.22.3"
+                "@tiptap/core": "3.22.4"
             }
         },
         "node_modules/@tiptap/extension-bubble-menu": {
-            "version": "3.22.3",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.22.3.tgz",
-            "integrity": "sha512-Y6zQjh0ypDg32HWgICEvmPSKjGLr39k3aDxxt/H0uQEZSfw4smT0hxUyyyjVjx68C6t6MTnwdfz0hPI5lL68vQ==",
+            "version": "3.22.4",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.22.4.tgz",
+            "integrity": "sha512-v4pux5Ql3THAEjaLMY4ldtdy/Xy2qU7PJLBkq8ugLp8qicaKC+tpqxp6sGif4vLIjz7Ap5hurRbTNbXzszyyHA==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -5999,80 +6057,80 @@
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "^3.22.3",
-                "@tiptap/pm": "^3.22.3"
+                "@tiptap/core": "3.22.4",
+                "@tiptap/pm": "3.22.4"
             }
         },
         "node_modules/@tiptap/extension-bullet-list": {
-            "version": "3.22.3",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.22.3.tgz",
-            "integrity": "sha512-xOmW/b1hgECIE6r3IeZvKn4VVlG3+dfTjCWE6lnnyLaqdNkNhKS1CwUmDZdYNLUS2ryIUtgz5ID1W/8A3PhbiA==",
+            "version": "3.22.4",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.22.4.tgz",
+            "integrity": "sha512-TB+d3fGcTixYjO7coKqTr1mGTJuqr8hjDCPUFgzuvKyJnBhqWITmBzQ/8CLq4rr6mihgGURbD3N+xkQuPAKFiw==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/extension-list": "^3.22.3"
+                "@tiptap/extension-list": "3.22.4"
             }
         },
         "node_modules/@tiptap/extension-code": {
-            "version": "3.22.3",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.22.3.tgz",
-            "integrity": "sha512-wafWTDQOuMKtXpZEuk1PFQmzopabBciNLryL90MB9S03MNLaQQZYLnmYkDBlzAaLAbgF5QiC+2XZQEBQuTVjFQ==",
+            "version": "3.22.4",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.22.4.tgz",
+            "integrity": "sha512-cnbxmVhAcc7X3G81QUYEmKP0ve2hRmvAiFXBuuv9RUtQlBiRnzmhHoJOMgkX0CsMR7+8kMRpTfeDUYq2xp5s5w==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "^3.22.3"
+                "@tiptap/core": "3.22.4"
             }
         },
         "node_modules/@tiptap/extension-code-block": {
-            "version": "3.22.3",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.22.3.tgz",
-            "integrity": "sha512-RiQtEjDAPrHpdo6sw6b7fOw/PijqgFIsozKKkGcSeBgWHQuFg7q9OxJTj+l0e60rVwSu/5gmKEEobzM9bX+t2Q==",
+            "version": "3.22.4",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.22.4.tgz",
+            "integrity": "sha512-MEurzNXfMET3rhjpoPJYUgMfxTdTqbzT9+ToFrqNGAHocdXVm6m1hhO2frVC7fEtHPnxXKsn0Z3NUbCRkRTLuA==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "^3.22.3",
-                "@tiptap/pm": "^3.22.3"
+                "@tiptap/core": "3.22.4",
+                "@tiptap/pm": "3.22.4"
             }
         },
         "node_modules/@tiptap/extension-document": {
-            "version": "3.22.3",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.22.3.tgz",
-            "integrity": "sha512-MCSr1PFPtTd++lA3H1RNgqAczAE59XXJ5wUFIQf2F+/0DPY5q2SU4g5QsNJVxPPft5mrNT4C6ty8xBPrALFEdA==",
+            "version": "3.22.4",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.22.4.tgz",
+            "integrity": "sha512-XQKla1+703FqQJC48tPDVgt9ucGiFbIEmQdOg5L5o07z9a6/NzuaZAc+1zJ7NxcUZzy+z6wBn1PrVMTiqiSXlw==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "^3.22.3"
+                "@tiptap/core": "3.22.4"
             }
         },
         "node_modules/@tiptap/extension-dropcursor": {
-            "version": "3.22.3",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.22.3.tgz",
-            "integrity": "sha512-taXq9Tl5aybdFbptJtFRHX9LFJzbXphAbPp4/vutFyTrBu5meXDxuS+B9pEmE+Or0XcolTlW2nDZB0Tqnr18JQ==",
+            "version": "3.22.4",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.22.4.tgz",
+            "integrity": "sha512-N9/yMDC35jJp0V/naL0+6gi4gUDUIcPpWEzFdCDWUSYBA8mt41c1kI1ZU7UTKYIBzTClenhYHRc2XKZxxx0+LQ==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/extensions": "^3.22.3"
+                "@tiptap/extensions": "3.22.4"
             }
         },
         "node_modules/@tiptap/extension-floating-menu": {
-            "version": "3.22.3",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.22.3.tgz",
-            "integrity": "sha512-0f8b4KZ3XKai8GXWseIYJGdOfQr3evtFbBo3U08zy2aYzMMXWG0zEF7qe5/oiYp2aZ95edjjITnEceviTsZkIg==",
+            "version": "3.22.4",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.22.4.tgz",
+            "integrity": "sha512-DFuyYxgaZPgxum5z1yvJPbfYCvDdO8geXsdyqt0qYYdiat3aGE4ncJhiLRIFDhSHBhaZg5eCgu/YPYAN6jZnrA==",
             "license": "MIT",
             "optional": true,
             "funding": {
@@ -6081,93 +6139,93 @@
             },
             "peerDependencies": {
                 "@floating-ui/dom": "^1.0.0",
-                "@tiptap/core": "^3.22.3",
-                "@tiptap/pm": "^3.22.3"
+                "@tiptap/core": "3.22.4",
+                "@tiptap/pm": "3.22.4"
             }
         },
         "node_modules/@tiptap/extension-gapcursor": {
-            "version": "3.22.3",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.22.3.tgz",
-            "integrity": "sha512-L/Px4UeQEVG/D9WIlcAOIej+4wyIBCMUSYicSR+hW68UsObe4rxVbUas1QgidQKm6DOhoT7U7D4KQHA/Gdg/7A==",
+            "version": "3.22.4",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.22.4.tgz",
+            "integrity": "sha512-UYBEUj3SFpKINIE7AdzcyeS3xICK+ee+YLBbuqNXyHStYChjJOohzJehqiqhjR16A88KQQ+ZjgyDcItKGygSog==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/extensions": "^3.22.3"
+                "@tiptap/extensions": "3.22.4"
             }
         },
         "node_modules/@tiptap/extension-hard-break": {
-            "version": "3.22.3",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.22.3.tgz",
-            "integrity": "sha512-J0v8I99y9tbvVmgKYKzKP/JYNsWaZYS7avn4rzLft2OhnyTfwt3OoY8DtpHmmi6apSUaCtoWHWta/TmoEfK1nQ==",
+            "version": "3.22.4",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.22.4.tgz",
+            "integrity": "sha512-xq+a4dE7T6VwApCkh/yU3p30gn3F8g8Arb9CyEZm58/WIJUIGvHSTjDdHmvU16+kiWSBg+wOOsaFHhYjJjxcKA==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "^3.22.3"
+                "@tiptap/core": "3.22.4"
             }
         },
         "node_modules/@tiptap/extension-heading": {
-            "version": "3.22.3",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.22.3.tgz",
-            "integrity": "sha512-XBHuhiEV2EEhZHpOLcplLqAmBIhJciU3I6AtwmqeEqDC0P114uMEfAO7JGlbBZdCYotNer26PKnu44TBTeNtkw==",
+            "version": "3.22.4",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.22.4.tgz",
+            "integrity": "sha512-TUaj5f0Ir5qy9HKKt2ocnwfXKpZDYeHgbbP9gshKFzdq5PLe1RbIgkjfy6bnoI865cYjmPYWRjcT7XsKyIcb9Q==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "^3.22.3"
+                "@tiptap/core": "3.22.4"
             }
         },
         "node_modules/@tiptap/extension-horizontal-rule": {
-            "version": "3.22.3",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.22.3.tgz",
-            "integrity": "sha512-wI2bFzScs+KgWeBH/BtypcVKeYelCyqV0RG8nxsZMWtPrBhqixzNd0Oi3gEKtjSjKUqMQ/kjJAIRuESr5UzlHA==",
+            "version": "3.22.4",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.22.4.tgz",
+            "integrity": "sha512-cCI1HekGQwhY/MbgaKQ0R/7HcH5ZM1oFAyI/J72QGLC0XnF403S/OXoHMuBWr1mCu8hNiQWCzeNRJUty0iytNw==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "^3.22.3",
-                "@tiptap/pm": "^3.22.3"
+                "@tiptap/core": "3.22.4",
+                "@tiptap/pm": "3.22.4"
             }
         },
         "node_modules/@tiptap/extension-image": {
-            "version": "3.22.3",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-image/-/extension-image-3.22.3.tgz",
-            "integrity": "sha512-Qpp8c5LOQaNpHrzjqZtoxtIR+8sSqJ7k8v+8anmYw3nxjvt2kpfT28Vd7aWMX55ZS43LaxMx+MkZqbmgUmMP0w==",
+            "version": "3.22.4",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-image/-/extension-image-3.22.4.tgz",
+            "integrity": "sha512-ZDc+fLaratTQ4IgnKcJJwfUgUgpcHjbZSBi6UQAILJwkflMy1Zxj8mpbma5P934nLSI+uDnR5ret6ZZLNITKhA==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "^3.22.3"
+                "@tiptap/core": "3.22.4"
             }
         },
         "node_modules/@tiptap/extension-italic": {
-            "version": "3.22.3",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.22.3.tgz",
-            "integrity": "sha512-LteA4cb4EGCiUtrK2JHvDF/Zg0/YqV4DUyHhAAho+oGEQDupZlsS6m0ia5wQcclkiTLzsoPrwcSNu6RDGQ16wQ==",
+            "version": "3.22.4",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.22.4.tgz",
+            "integrity": "sha512-fVSDx5AYXgDI3v2zZIqb7V8EewthwM2NJ/ZCX+XaxRsqNEpnjVhgHs7UlvDqK1wj2OJ6zmUNjPtVlAFRxwT+HQ==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "^3.22.3"
+                "@tiptap/core": "3.22.4"
             }
         },
         "node_modules/@tiptap/extension-link": {
-            "version": "3.22.3",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.22.3.tgz",
-            "integrity": "sha512-S8/P2o9pv6B3kqLjH2TRWwSAximGbciNc6R8/QcN6HWLYxp0N0JoqN3rZHl9VWIBAGRWc4zkt80dhqrl2xmgfQ==",
+            "version": "3.22.4",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.22.4.tgz",
+            "integrity": "sha512-uoP3yus02uwGPVzW2QaEPJWVIrUb/r5nKm6c8DiJv9fNSX1+gykZZMg42c6GwRFLZ/vyfWjVCbAE03VMUqafgA==",
             "license": "MIT",
             "dependencies": {
                 "linkifyjs": "^4.3.2"
@@ -6177,14 +6235,14 @@
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "^3.22.3",
-                "@tiptap/pm": "^3.22.3"
+                "@tiptap/core": "3.22.4",
+                "@tiptap/pm": "3.22.4"
             }
         },
         "node_modules/@tiptap/extension-list": {
-            "version": "3.22.3",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.22.3.tgz",
-            "integrity": "sha512-rqvv/dtqwbX+8KnPv0eMYp6PnBcuhPMol5cv1GlS8Nq/Cxt68EWGUHBuTFesw+hdnRQLmKwzoO1DlRn7PhxYRQ==",
+            "version": "3.22.4",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.22.4.tgz",
+            "integrity": "sha512-Xe8UFvvHmyp/c/TJsFwlwU9CWACYbBirNsluJ3U1+H8BTu1wqdrT/AXR5uIXeyCl5kiWKgX5q71eHWbYFOrqrg==",
             "license": "MIT",
             "peer": true,
             "funding": {
@@ -6192,118 +6250,118 @@
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "^3.22.3",
-                "@tiptap/pm": "^3.22.3"
+                "@tiptap/core": "3.22.4",
+                "@tiptap/pm": "3.22.4"
             }
         },
         "node_modules/@tiptap/extension-list-item": {
-            "version": "3.22.3",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.22.3.tgz",
-            "integrity": "sha512-80CNf4oO5y8+LdckT4CyMe1t01EyhpRrQC9H45JW20P7559Nrchp5my3vvMtIAJbpTPPZtcB7LwdzWGKsG5drg==",
+            "version": "3.22.4",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.22.4.tgz",
+            "integrity": "sha512-H659KXTvggSypIDWSOJBZ37jh9pKjQriDDvYPYvOZCdfij0D0hsDXN/wXoypArneUkoBdgruHfTtMkFOaQlgkw==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/extension-list": "^3.22.3"
+                "@tiptap/extension-list": "3.22.4"
             }
         },
         "node_modules/@tiptap/extension-list-keymap": {
-            "version": "3.22.3",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.22.3.tgz",
-            "integrity": "sha512-pKuyj5llu35zd/s2u/H9aydKZjmPRAIK5P1q/YXULhhCNln2RnmuRfQ5NklAqTD3yGciQ2lxDwwf7J6iw3ergA==",
+            "version": "3.22.4",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.22.4.tgz",
+            "integrity": "sha512-t/zhker4oIS78AIGYDdFFfZC6zSBlszfD7z/zqFLGCg5PHNNgkZK5hKj6Vyix6D2SapRn/ajnx+8mhbKIUH5eA==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/extension-list": "^3.22.3"
+                "@tiptap/extension-list": "3.22.4"
             }
         },
         "node_modules/@tiptap/extension-ordered-list": {
-            "version": "3.22.3",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.22.3.tgz",
-            "integrity": "sha512-orAghtmd+K4Euu4BgI1hG+iZDXBYOyl5YTwiLBc2mQn+pqtZ9LqaH2us4ETwEwNP3/IWXGSAimUZ19nuL+eM2w==",
+            "version": "3.22.4",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.22.4.tgz",
+            "integrity": "sha512-w77hPVf7pcHt97vfrybg/l0t5CimCd4y75OJKuHuo3CfgM5xbUP/gaPNMDyLLe7MYole/UHi/XvG3XjgzqTzAw==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/extension-list": "^3.22.3"
+                "@tiptap/extension-list": "3.22.4"
             }
         },
         "node_modules/@tiptap/extension-paragraph": {
-            "version": "3.22.3",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.22.3.tgz",
-            "integrity": "sha512-oO7rhfyhEuwm+50s9K3GZPjYyEEEvFAvm1wXopvZnhbkBLydIWImBfrZoC5IQh4/sRDlTIjosV2C+ji5y0tUSg==",
+            "version": "3.22.4",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.22.4.tgz",
+            "integrity": "sha512-de6dFkIhigiENESY6rNJ3yTVS/337ybfP30dNPudTwGe9oAu9ZCS+04j6QCvXSjhlI3ULiv7wiSHqrP26Gd+Hw==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "^3.22.3"
+                "@tiptap/core": "3.22.4"
             }
         },
         "node_modules/@tiptap/extension-placeholder": {
-            "version": "3.22.3",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-placeholder/-/extension-placeholder-3.22.3.tgz",
-            "integrity": "sha512-7vbtlDVO00odqCnsMSmA4b6wjL5PFdfExFsdsDO0K0VemqHZ/doIRx/tosNUD1VYSOyKQd8U7efUjkFyVoIPlg==",
+            "version": "3.22.4",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-placeholder/-/extension-placeholder-3.22.4.tgz",
+            "integrity": "sha512-Z3wtWL+KufwkC7CkJge5enAxx4q8C3oOYixme02snY9zfjX3V/1pjAmEfP4wxScgM5GIuTEJ83B9Yz3wRzPA6Q==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/extensions": "^3.22.3"
+                "@tiptap/extensions": "3.22.4"
             }
         },
         "node_modules/@tiptap/extension-strike": {
-            "version": "3.22.3",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.22.3.tgz",
-            "integrity": "sha512-jY2InoUlKkuk5KHoIDGdML1OCA2n6PRHAtxwHNkAmiYh0Khf0zaVPGFpx4dgQrN7W5Q1WE6oBZnjrvy6qb7w0g==",
+            "version": "3.22.4",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.22.4.tgz",
+            "integrity": "sha512-aRHWQj42HiailXSC9LkKYM3jWMcSeGwOjbqM4PiuxQZmHVDRFmeHkfJItOdn2cSHaO0vuEVK+TvrWUWsBFi3pg==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "^3.22.3"
+                "@tiptap/core": "3.22.4"
             }
         },
         "node_modules/@tiptap/extension-text": {
-            "version": "3.22.3",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.22.3.tgz",
-            "integrity": "sha512-Q9R7JsTdomP5uUjtPjNKxHT1xoh/i9OJZnmgJLe7FcgZEaPOQ3bWxmKZoLZQfDfZjyB8BtH+Hc7nUvhCMOePxw==",
+            "version": "3.22.4",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.22.4.tgz",
+            "integrity": "sha512-mM69uUW5cSxIhyEpWXi/YcfyupcJMDLCPEfYi62awH0iOP/LRoCv/nHjJq4Hyj/KxRJbe8HKwIUnqaCUf7m5Pg==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "^3.22.3"
+                "@tiptap/core": "3.22.4"
             }
         },
         "node_modules/@tiptap/extension-underline": {
-            "version": "3.22.3",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.22.3.tgz",
-            "integrity": "sha512-Ch6CBWRa5w90yYSPUW6x9Py9JdrXMqk3pZ9OIlMYD8A7BqyZGfiHerX7XDMYDS09KjyK3U9XH60/zxYOzXdDLA==",
+            "version": "3.22.4",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.22.4.tgz",
+            "integrity": "sha512-08kGdbhIrA6h10GWXqOkqIveaBj5tmxclK208/nUIAlonI9hPd739vu7fmVtpnmqCnSSNpoRtU4u6Gj5at0ZpA==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "^3.22.3"
+                "@tiptap/core": "3.22.4"
             }
         },
         "node_modules/@tiptap/extensions": {
-            "version": "3.22.3",
-            "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.22.3.tgz",
-            "integrity": "sha512-s5eiMq0m5N6N+W7dU6rd60KgZyyCD7FvtPNNswISfPr12EQwJBfbjWwTqd0UKNzA4fNrhQEERXnzORkykttPeA==",
+            "version": "3.22.4",
+            "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.22.4.tgz",
+            "integrity": "sha512-fOe8VptJvLPs32bNdUYo8SRyljwqKNQVXWW056VoXIc5en/59OdJlJQVeHI0jRRciH3MtrqODi/gfJR0VHNZ8A==",
             "license": "MIT",
             "peer": true,
             "funding": {
@@ -6311,33 +6369,27 @@
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "^3.22.3",
-                "@tiptap/pm": "^3.22.3"
+                "@tiptap/core": "3.22.4",
+                "@tiptap/pm": "3.22.4"
             }
         },
         "node_modules/@tiptap/pm": {
-            "version": "3.22.3",
-            "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.22.3.tgz",
-            "integrity": "sha512-NjfWjZuvrqmpICT+GZWNIjtOdhPyqFKDMtQy7tsQ5rErM9L2ZQdy/+T/BKSO1JdTeBhdg9OP+0yfsqoYp2aT6A==",
+            "version": "3.22.4",
+            "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.22.4.tgz",
+            "integrity": "sha512-hj8Qka6WcHRllHUdeSjDnq2XaisUo4KsoGJc1WcFpoa1Yd+OeD861zUMnV7DFVGdZRy45Obht0CUYJpXQ4yA4w==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
                 "prosemirror-changeset": "^2.3.0",
-                "prosemirror-collab": "^1.3.1",
                 "prosemirror-commands": "^1.6.2",
                 "prosemirror-dropcursor": "^1.8.1",
                 "prosemirror-gapcursor": "^1.3.2",
                 "prosemirror-history": "^1.4.1",
-                "prosemirror-inputrules": "^1.4.0",
                 "prosemirror-keymap": "^1.2.2",
-                "prosemirror-markdown": "^1.13.1",
-                "prosemirror-menu": "^1.2.4",
                 "prosemirror-model": "^1.24.1",
-                "prosemirror-schema-basic": "^1.2.3",
                 "prosemirror-schema-list": "^1.5.0",
                 "prosemirror-state": "^1.4.3",
                 "prosemirror-tables": "^1.6.4",
-                "prosemirror-trailing-node": "^3.0.0",
                 "prosemirror-transform": "^1.10.2",
                 "prosemirror-view": "^1.38.1"
             },
@@ -6347,9 +6399,9 @@
             }
         },
         "node_modules/@tiptap/react": {
-            "version": "3.22.3",
-            "resolved": "https://registry.npmjs.org/@tiptap/react/-/react-3.22.3.tgz",
-            "integrity": "sha512-6MNr6z0PxwfJFs+BKhHcvPNvY+UV1PXgqzTiTM4Z9guml84iVZxv7ZOCSj1dFYTr3Bf1MiOs4hT1yvBFlTfIaQ==",
+            "version": "3.22.4",
+            "resolved": "https://registry.npmjs.org/@tiptap/react/-/react-3.22.4.tgz",
+            "integrity": "sha512-XIQZPwLakR1t8+Q1UeCpr+kUHDWxpJzGy9r2xUi3mpPd6Wh8dtNltScBkUlCcr0sqc6J1GF6Is02JJVQGmCZMA==",
             "license": "MIT",
             "dependencies": {
                 "@types/use-sync-external-store": "^0.0.6",
@@ -6361,12 +6413,12 @@
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "optionalDependencies": {
-                "@tiptap/extension-bubble-menu": "^3.22.3",
-                "@tiptap/extension-floating-menu": "^3.22.3"
+                "@tiptap/extension-bubble-menu": "^3.22.4",
+                "@tiptap/extension-floating-menu": "^3.22.4"
             },
             "peerDependencies": {
-                "@tiptap/core": "^3.22.3",
-                "@tiptap/pm": "^3.22.3",
+                "@tiptap/core": "3.22.4",
+                "@tiptap/pm": "3.22.4",
                 "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
                 "@types/react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
                 "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
@@ -6374,35 +6426,35 @@
             }
         },
         "node_modules/@tiptap/starter-kit": {
-            "version": "3.22.3",
-            "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.22.3.tgz",
-            "integrity": "sha512-vdW/Oo1fdwTL1VOQ5YYbTov00ANeHLquBVEZyL/EkV7Xv5io9rXQsCysJfTSHhiQlyr2MtWFB4+CPGuwXjQWOQ==",
+            "version": "3.22.4",
+            "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.22.4.tgz",
+            "integrity": "sha512-qWjw+vfdin1rzMRpRU4cC5tLTwMJtUpXeQukv+6mOqqvhptuwuZBjUHImVEJaSPoHXS7+1ut+nTnrLyWyEuE5Q==",
             "license": "MIT",
             "dependencies": {
-                "@tiptap/core": "^3.22.3",
-                "@tiptap/extension-blockquote": "^3.22.3",
-                "@tiptap/extension-bold": "^3.22.3",
-                "@tiptap/extension-bullet-list": "^3.22.3",
-                "@tiptap/extension-code": "^3.22.3",
-                "@tiptap/extension-code-block": "^3.22.3",
-                "@tiptap/extension-document": "^3.22.3",
-                "@tiptap/extension-dropcursor": "^3.22.3",
-                "@tiptap/extension-gapcursor": "^3.22.3",
-                "@tiptap/extension-hard-break": "^3.22.3",
-                "@tiptap/extension-heading": "^3.22.3",
-                "@tiptap/extension-horizontal-rule": "^3.22.3",
-                "@tiptap/extension-italic": "^3.22.3",
-                "@tiptap/extension-link": "^3.22.3",
-                "@tiptap/extension-list": "^3.22.3",
-                "@tiptap/extension-list-item": "^3.22.3",
-                "@tiptap/extension-list-keymap": "^3.22.3",
-                "@tiptap/extension-ordered-list": "^3.22.3",
-                "@tiptap/extension-paragraph": "^3.22.3",
-                "@tiptap/extension-strike": "^3.22.3",
-                "@tiptap/extension-text": "^3.22.3",
-                "@tiptap/extension-underline": "^3.22.3",
-                "@tiptap/extensions": "^3.22.3",
-                "@tiptap/pm": "^3.22.3"
+                "@tiptap/core": "^3.22.4",
+                "@tiptap/extension-blockquote": "^3.22.4",
+                "@tiptap/extension-bold": "^3.22.4",
+                "@tiptap/extension-bullet-list": "^3.22.4",
+                "@tiptap/extension-code": "^3.22.4",
+                "@tiptap/extension-code-block": "^3.22.4",
+                "@tiptap/extension-document": "^3.22.4",
+                "@tiptap/extension-dropcursor": "^3.22.4",
+                "@tiptap/extension-gapcursor": "^3.22.4",
+                "@tiptap/extension-hard-break": "^3.22.4",
+                "@tiptap/extension-heading": "^3.22.4",
+                "@tiptap/extension-horizontal-rule": "^3.22.4",
+                "@tiptap/extension-italic": "^3.22.4",
+                "@tiptap/extension-link": "^3.22.4",
+                "@tiptap/extension-list": "^3.22.4",
+                "@tiptap/extension-list-item": "^3.22.4",
+                "@tiptap/extension-list-keymap": "^3.22.4",
+                "@tiptap/extension-ordered-list": "^3.22.4",
+                "@tiptap/extension-paragraph": "^3.22.4",
+                "@tiptap/extension-strike": "^3.22.4",
+                "@tiptap/extension-text": "^3.22.4",
+                "@tiptap/extension-underline": "^3.22.4",
+                "@tiptap/extensions": "^3.22.4",
+                "@tiptap/pm": "^3.22.4"
             },
             "funding": {
                 "type": "github",
@@ -6570,28 +6622,6 @@
             "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
             "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
             "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@types/linkify-it": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
-            "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
-            "license": "MIT"
-        },
-        "node_modules/@types/markdown-it": {
-            "version": "14.1.2",
-            "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
-            "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/linkify-it": "^5",
-                "@types/mdurl": "^2"
-            }
-        },
-        "node_modules/@types/mdurl": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
-            "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
             "license": "MIT"
         },
         "node_modules/@types/node": {
@@ -8020,9 +8050,9 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-            "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+            "version": "1.15.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
+            "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.15.11",
@@ -8059,9 +8089,9 @@
             "license": "MIT"
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.19",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.19.tgz",
-            "integrity": "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==",
+            "version": "2.10.20",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.20.tgz",
+            "integrity": "sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==",
             "license": "Apache-2.0",
             "bin": {
                 "baseline-browser-mapping": "dist/cli.cjs"
@@ -8641,12 +8671,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
-        },
-        "node_modules/crelt": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
-            "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
-            "license": "MIT"
         },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
@@ -9536,7 +9560,6 @@
             "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@rtsao/scc": "^1.1.0",
                 "array-includes": "^3.1.9",
@@ -12420,15 +12443,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/linkify-it": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-            "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
-            "license": "MIT",
-            "dependencies": {
-                "uc.micro": "^2.0.0"
-            }
-        },
         "node_modules/linkifyjs": {
             "version": "4.3.2",
             "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.2.tgz",
@@ -12601,41 +12615,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/markdown-it": {
-            "version": "14.1.1",
-            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-            "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
-            "license": "MIT",
-            "dependencies": {
-                "argparse": "^2.0.1",
-                "entities": "^4.4.0",
-                "linkify-it": "^5.0.0",
-                "mdurl": "^2.0.0",
-                "punycode.js": "^2.3.1",
-                "uc.micro": "^2.1.0"
-            },
-            "bin": {
-                "markdown-it": "bin/markdown-it.mjs"
-            }
-        },
-        "node_modules/markdown-it/node_modules/argparse": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "license": "Python-2.0"
-        },
-        "node_modules/markdown-it/node_modules/entities": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-            "license": "BSD-2-Clause",
-            "engines": {
-                "node": ">=0.12"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/entities?sponsor=1"
-            }
-        },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -12651,12 +12630,6 @@
             "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
             "dev": true,
             "license": "CC0-1.0"
-        },
-        "node_modules/mdurl": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
-            "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
-            "license": "MIT"
         },
         "node_modules/media-typer": {
             "version": "1.1.0",
@@ -13033,46 +13006,6 @@
             "resolved": "https://registry.npmjs.org/next-intl-swc-plugin-extractor/-/next-intl-swc-plugin-extractor-4.9.1.tgz",
             "integrity": "sha512-8whJJ6oxJz8JqkHarggmmuEDyXgC7nEnaPhZD91CJwEWW4xp0AST3Mw17YxvHyP2vAF3taWfFbs1maD+WWtz3w==",
             "license": "MIT"
-        },
-        "node_modules/next-intl/node_modules/@swc/core": {
-            "version": "1.15.26",
-            "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.26.tgz",
-            "integrity": "sha512-tglZGyx8N5PC+x1Nd/JrZxqpqlcZoSuG9gTDKO6AuFToFiVB3uS8HvbKFuO7g3lJzvFf9riAb94xs9HU2UhAHQ==",
-            "hasInstallScript": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@swc/counter": "^0.1.3",
-                "@swc/types": "^0.1.26"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/swc"
-            },
-            "optionalDependencies": {
-                "@swc/core-darwin-arm64": "1.15.26",
-                "@swc/core-darwin-x64": "1.15.26",
-                "@swc/core-linux-arm-gnueabihf": "1.15.26",
-                "@swc/core-linux-arm64-gnu": "1.15.26",
-                "@swc/core-linux-arm64-musl": "1.15.26",
-                "@swc/core-linux-ppc64-gnu": "1.15.26",
-                "@swc/core-linux-s390x-gnu": "1.15.26",
-                "@swc/core-linux-x64-gnu": "1.15.26",
-                "@swc/core-linux-x64-musl": "1.15.26",
-                "@swc/core-win32-arm64-msvc": "1.15.26",
-                "@swc/core-win32-ia32-msvc": "1.15.26",
-                "@swc/core-win32-x64-msvc": "1.15.26"
-            },
-            "peerDependencies": {
-                "@swc/helpers": ">=0.5.17"
-            },
-            "peerDependenciesMeta": {
-                "@swc/helpers": {
-                    "optional": true
-                }
-            }
         },
         "node_modules/next-themes": {
             "version": "0.4.6",
@@ -14107,15 +14040,6 @@
                 "prosemirror-transform": "^1.0.0"
             }
         },
-        "node_modules/prosemirror-collab": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/prosemirror-collab/-/prosemirror-collab-1.3.1.tgz",
-            "integrity": "sha512-4SnynYR9TTYaQVXd/ieUvsVV4PDMBzrq2xPUWutHivDuOshZXqQ5rGbZM84HEaXKbLdItse7weMGOUdDVcLKEQ==",
-            "license": "MIT",
-            "dependencies": {
-                "prosemirror-state": "^1.0.0"
-            }
-        },
         "node_modules/prosemirror-commands": {
             "version": "1.7.1",
             "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz",
@@ -14162,16 +14086,6 @@
                 "rope-sequence": "^1.3.0"
             }
         },
-        "node_modules/prosemirror-inputrules": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.5.1.tgz",
-            "integrity": "sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==",
-            "license": "MIT",
-            "dependencies": {
-                "prosemirror-state": "^1.0.0",
-                "prosemirror-transform": "^1.0.0"
-            }
-        },
         "node_modules/prosemirror-keymap": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz",
@@ -14182,46 +14096,13 @@
                 "w3c-keyname": "^2.2.0"
             }
         },
-        "node_modules/prosemirror-markdown": {
-            "version": "1.13.4",
-            "resolved": "https://registry.npmjs.org/prosemirror-markdown/-/prosemirror-markdown-1.13.4.tgz",
-            "integrity": "sha512-D98dm4cQ3Hs6EmjK500TdAOew4Z03EV71ajEFiWra3Upr7diytJsjF4mPV2dW+eK5uNectiRj0xFxYI9NLXDbw==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/markdown-it": "^14.0.0",
-                "markdown-it": "^14.0.0",
-                "prosemirror-model": "^1.25.0"
-            }
-        },
-        "node_modules/prosemirror-menu": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/prosemirror-menu/-/prosemirror-menu-1.3.2.tgz",
-            "integrity": "sha512-6VgUJTYod0nMBlCaYJGhXGLu7Gt4AvcwcOq0YfJCY/6Uh+3S7UsWhpy6rJFCBFOmonq1hD8KyWOtZhkppd4YPg==",
-            "license": "MIT",
-            "dependencies": {
-                "crelt": "^1.0.0",
-                "prosemirror-commands": "^1.0.0",
-                "prosemirror-history": "^1.0.0",
-                "prosemirror-state": "^1.0.0"
-            }
-        },
         "node_modules/prosemirror-model": {
             "version": "1.25.4",
             "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
             "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "orderedmap": "^2.0.0"
-            }
-        },
-        "node_modules/prosemirror-schema-basic": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/prosemirror-schema-basic/-/prosemirror-schema-basic-1.2.4.tgz",
-            "integrity": "sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==",
-            "license": "MIT",
-            "dependencies": {
-                "prosemirror-model": "^1.25.0"
             }
         },
         "node_modules/prosemirror-schema-list": {
@@ -14240,7 +14121,6 @@
             "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
             "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "prosemirror-model": "^1.0.0",
                 "prosemirror-transform": "^1.0.0",
@@ -14260,21 +14140,6 @@
                 "prosemirror-view": "^1.41.4"
             }
         },
-        "node_modules/prosemirror-trailing-node": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-3.0.0.tgz",
-            "integrity": "sha512-xiun5/3q0w5eRnGYfNlW1uU9W6x5MoFKWwq/0TIRgt09lv7Hcser2QYV8t4muXbEr+Fwo0geYn79Xs4GKywrRQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@remirror/core-constants": "3.0.0",
-                "escape-string-regexp": "^4.0.0"
-            },
-            "peerDependencies": {
-                "prosemirror-model": "^1.22.1",
-                "prosemirror-state": "^1.4.2",
-                "prosemirror-view": "^1.33.8"
-            }
-        },
         "node_modules/prosemirror-transform": {
             "version": "1.12.0",
             "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.12.0.tgz",
@@ -14289,7 +14154,6 @@
             "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.8.tgz",
             "integrity": "sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "prosemirror-model": "^1.20.0",
                 "prosemirror-state": "^1.0.0",
@@ -14324,15 +14188,6 @@
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
             "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
             "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/punycode.js": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
-            "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -14733,9 +14588,9 @@
             }
         },
         "node_modules/rettime": {
-            "version": "0.11.7",
-            "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.11.7.tgz",
-            "integrity": "sha512-DoAm1WjR1eH7z8sHPtvvUMIZh4/CSKkGCz6CxPqOrEAnOGtOuHSnSE9OC+razqxKuf4ub7pAYyl/vZV0vGs5tg==",
+            "version": "0.11.8",
+            "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.11.8.tgz",
+            "integrity": "sha512-0fERGXktJTyJ+h8fBEiPxHPEFOu0h15JY7JtwrOVqR5K+vb99ho6IyOo7ekLS3h4sJCzIDy4VWKIbZUfe9njmg==",
             "dev": true,
             "license": "MIT"
         },
@@ -16370,12 +16225,6 @@
                 "typescript": ">=4.8.4 <6.1.0"
             }
         },
-        "node_modules/uc.micro": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
-            "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
-            "license": "MIT"
-        },
         "node_modules/unbash": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/unbash/-/unbash-2.2.0.tgz",
@@ -16688,7 +16537,6 @@
             "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "lightningcss": "^1.32.0",
                 "picomatch": "^4.0.4",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -249,6 +249,7 @@
             "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.29.0",
                 "@babel/generator": "^7.29.0",
@@ -847,6 +848,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=20.19.0"
             },
@@ -895,6 +897,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=20.19.0"
             }
@@ -925,6 +928,7 @@
             "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
             "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@dnd-kit/accessibility": "^3.1.1",
                 "@dnd-kit/utilities": "^3.2.2",
@@ -1153,28 +1157,6 @@
                 "@noble/ciphers": "^1.0.0"
             }
         },
-        "node_modules/@emnapi/core": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-            "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@emnapi/wasi-threads": "1.2.1",
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@emnapi/runtime": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-            "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
         "node_modules/@emnapi/wasi-threads": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -1370,6 +1352,7 @@
             "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
             "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@floating-ui/core": "^1.7.5",
                 "@floating-ui/utils": "^0.2.11"
@@ -1596,9 +1579,6 @@
             "cpu": [
                 "arm"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -1614,9 +1594,6 @@
             "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
             "cpu": [
                 "arm64"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
@@ -1634,9 +1611,6 @@
             "cpu": [
                 "ppc64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -1652,9 +1626,6 @@
             "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
             "cpu": [
                 "riscv64"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
@@ -1672,9 +1643,6 @@
             "cpu": [
                 "s390x"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -1690,9 +1658,6 @@
             "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
@@ -1710,9 +1675,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "musl"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -1729,9 +1691,6 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "musl"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -1747,9 +1706,6 @@
             "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
             "cpu": [
                 "arm"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "Apache-2.0",
             "optional": true,
@@ -1773,9 +1729,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1797,9 +1750,6 @@
             "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
             "cpu": [
                 "ppc64"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "Apache-2.0",
             "optional": true,
@@ -1823,9 +1773,6 @@
             "cpu": [
                 "riscv64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1847,9 +1794,6 @@
             "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
             "cpu": [
                 "s390x"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "Apache-2.0",
             "optional": true,
@@ -1873,9 +1817,6 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1898,9 +1839,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "musl"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1922,9 +1860,6 @@
             "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "Apache-2.0",
             "optional": true,
@@ -2333,9 +2268,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2351,9 +2283,6 @@
             "integrity": "sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==",
             "cpu": [
                 "arm64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -2371,9 +2300,6 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2389,9 +2315,6 @@
             "integrity": "sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -2440,6 +2363,7 @@
             "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": "^14.21.3 || >=16"
             },
@@ -2540,6 +2464,7 @@
             "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@octokit/auth-token": "^4.0.0",
                 "@octokit/graphql": "^7.1.0",
@@ -2837,9 +2762,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2854,9 +2776,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2871,9 +2790,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2888,9 +2804,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2905,9 +2818,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2922,9 +2832,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2939,9 +2846,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2956,9 +2860,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3160,9 +3061,6 @@
             "cpu": [
                 "arm"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3182,9 +3080,6 @@
             "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
             "cpu": [
                 "arm"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -3206,9 +3101,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3228,9 +3120,6 @@
             "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
             "cpu": [
                 "arm64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -3252,9 +3141,6 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3274,9 +3160,6 @@
             "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -3357,6 +3240,7 @@
             "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
             "devOptional": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "playwright": "1.59.1"
             },
@@ -5066,9 +4950,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5086,9 +4967,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5106,9 +4984,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5126,9 +5001,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5146,9 +5018,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5166,9 +5035,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5318,46 +5184,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@swc/core": {
-            "version": "1.15.26",
-            "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.26.tgz",
-            "integrity": "sha512-tglZGyx8N5PC+x1Nd/JrZxqpqlcZoSuG9gTDKO6AuFToFiVB3uS8HvbKFuO7g3lJzvFf9riAb94xs9HU2UhAHQ==",
-            "hasInstallScript": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@swc/counter": "^0.1.3",
-                "@swc/types": "^0.1.26"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/swc"
-            },
-            "optionalDependencies": {
-                "@swc/core-darwin-arm64": "1.15.26",
-                "@swc/core-darwin-x64": "1.15.26",
-                "@swc/core-linux-arm-gnueabihf": "1.15.26",
-                "@swc/core-linux-arm64-gnu": "1.15.26",
-                "@swc/core-linux-arm64-musl": "1.15.26",
-                "@swc/core-linux-ppc64-gnu": "1.15.26",
-                "@swc/core-linux-s390x-gnu": "1.15.26",
-                "@swc/core-linux-x64-gnu": "1.15.26",
-                "@swc/core-linux-x64-musl": "1.15.26",
-                "@swc/core-win32-arm64-msvc": "1.15.26",
-                "@swc/core-win32-ia32-msvc": "1.15.26",
-                "@swc/core-win32-x64-msvc": "1.15.26"
-            },
-            "peerDependencies": {
-                "@swc/helpers": ">=0.5.17"
-            },
-            "peerDependenciesMeta": {
-                "@swc/helpers": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/@swc/core-darwin-arm64": {
             "version": "1.15.26",
             "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.26.tgz",
@@ -5413,9 +5239,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -5431,9 +5254,6 @@
             "integrity": "sha512-iNlbvTIo425rkKzDLLWFJGnFXr3myETUdIDHcjuiPNZE8b0ogmcAuilC4yEJX7FSHGbnlsoJcCT2xf4b3VJmmQ==",
             "cpu": [
                 "arm64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "Apache-2.0 AND MIT",
             "optional": true,
@@ -5451,9 +5271,6 @@
             "cpu": [
                 "ppc64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -5469,9 +5286,6 @@
             "integrity": "sha512-JcMDWQvW1BchUyRg8E0jHiTx7CQYpUr5uDEL1dnPDECrEjBEGG2ynmJ3XX70sWXql0JagqR1t3VpANYFWdUnqA==",
             "cpu": [
                 "s390x"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "Apache-2.0 AND MIT",
             "optional": true,
@@ -5489,9 +5303,6 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -5507,9 +5318,6 @@
             "integrity": "sha512-w8erqMHsVcdGwUfJxF6LaiTuPoKnyLOcUbhLcxiXrlLt5MLjtlgcIeUY/NWK/oPoyqkgH+/i8pOJnMTxvl83ZQ==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "Apache-2.0 AND MIT",
             "optional": true,
@@ -5809,9 +5617,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5829,9 +5634,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5849,9 +5651,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5869,9 +5668,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5996,6 +5792,7 @@
             "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.99.0.tgz",
             "integrity": "sha512-OY2bCqPemT1LlqJ8Y2CUau4KELnIhhG9Ol3ZndPbdnB095pRbPo1cHuXTndg8iIwtoHTgwZjyaDnQ0xD0mYwAw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@tanstack/query-core": "5.99.0"
             },
@@ -6152,6 +5949,7 @@
             "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.22.3.tgz",
             "integrity": "sha512-Dv9MKK5BDWCF0N2l6/Pxv3JNCce2kwuWf2cKMBc2bEetx0Pn6o7zlFmSxMvYK4UtG1Tw9Yg/ZHi6QOFWK0Zm9Q==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
@@ -6387,6 +6185,7 @@
             "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.22.3.tgz",
             "integrity": "sha512-rqvv/dtqwbX+8KnPv0eMYp6PnBcuhPMol5cv1GlS8Nq/Cxt68EWGUHBuTFesw+hdnRQLmKwzoO1DlRn7PhxYRQ==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
@@ -6505,6 +6304,7 @@
             "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.22.3.tgz",
             "integrity": "sha512-s5eiMq0m5N6N+W7dU6rd60KgZyyCD7FvtPNNswISfPr12EQwJBfbjWwTqd0UKNzA4fNrhQEERXnzORkykttPeA==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
@@ -6519,6 +6319,7 @@
             "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.22.3.tgz",
             "integrity": "sha512-NjfWjZuvrqmpICT+GZWNIjtOdhPyqFKDMtQy7tsQ5rErM9L2ZQdy/+T/BKSO1JdTeBhdg9OP+0yfsqoYp2aT6A==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "prosemirror-changeset": "^2.3.0",
                 "prosemirror-collab": "^1.3.1",
@@ -6711,8 +6512,7 @@
             "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
             "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@types/chai": {
             "version": "5.2.3",
@@ -6798,6 +6598,7 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
             "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "undici-types": "~6.21.0"
             }
@@ -6807,6 +6608,7 @@
             "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
             "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "csstype": "^3.2.2"
             }
@@ -6816,6 +6618,7 @@
             "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
             "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
             "license": "MIT",
+            "peer": true,
             "peerDependencies": {
                 "@types/react": "^19.2.0"
             }
@@ -6895,6 +6698,7 @@
             "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.58.2",
                 "@typescript-eslint/types": "8.58.2",
@@ -7238,9 +7042,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -7255,9 +7056,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -7272,9 +7070,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -7289,9 +7084,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -7306,9 +7098,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -7323,9 +7112,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -7340,9 +7126,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -7357,9 +7140,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -7444,6 +7224,7 @@
             "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@bcoe/v8-coverage": "^1.0.2",
                 "@vitest/utils": "4.1.4",
@@ -7787,6 +7568,7 @@
             "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -8263,6 +8045,7 @@
             "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
             "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/types": "^7.26.0"
             }
@@ -8371,6 +8154,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.10.12",
                 "caniuse-lite": "^1.0.30001782",
@@ -9223,8 +9007,7 @@
             "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
             "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/dotenv": {
             "version": "17.4.2",
@@ -9566,6 +9349,7 @@
             "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -9751,6 +9535,7 @@
             "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@rtsao/scc": "^1.1.0",
                 "array-includes": "^3.1.9",
@@ -10688,6 +10473,7 @@
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
             "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
@@ -11121,6 +10907,7 @@
             "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=16.9.0"
             }
@@ -12507,9 +12294,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -12531,9 +12315,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -12555,9 +12336,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -12579,9 +12357,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -12783,7 +12558,6 @@
             "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "lz-string": "bin/bin.js"
             }
@@ -13258,6 +13032,46 @@
             "resolved": "https://registry.npmjs.org/next-intl-swc-plugin-extractor/-/next-intl-swc-plugin-extractor-4.9.1.tgz",
             "integrity": "sha512-8whJJ6oxJz8JqkHarggmmuEDyXgC7nEnaPhZD91CJwEWW4xp0AST3Mw17YxvHyP2vAF3taWfFbs1maD+WWtz3w==",
             "license": "MIT"
+        },
+        "node_modules/next-intl/node_modules/@swc/core": {
+            "version": "1.15.26",
+            "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.26.tgz",
+            "integrity": "sha512-tglZGyx8N5PC+x1Nd/JrZxqpqlcZoSuG9gTDKO6AuFToFiVB3uS8HvbKFuO7g3lJzvFf9riAb94xs9HU2UhAHQ==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@swc/counter": "^0.1.3",
+                "@swc/types": "^0.1.26"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/swc"
+            },
+            "optionalDependencies": {
+                "@swc/core-darwin-arm64": "1.15.26",
+                "@swc/core-darwin-x64": "1.15.26",
+                "@swc/core-linux-arm-gnueabihf": "1.15.26",
+                "@swc/core-linux-arm64-gnu": "1.15.26",
+                "@swc/core-linux-arm64-musl": "1.15.26",
+                "@swc/core-linux-ppc64-gnu": "1.15.26",
+                "@swc/core-linux-s390x-gnu": "1.15.26",
+                "@swc/core-linux-x64-gnu": "1.15.26",
+                "@swc/core-linux-x64-musl": "1.15.26",
+                "@swc/core-win32-arm64-msvc": "1.15.26",
+                "@swc/core-win32-ia32-msvc": "1.15.26",
+                "@swc/core-win32-x64-msvc": "1.15.26"
+            },
+            "peerDependencies": {
+                "@swc/helpers": ">=0.5.17"
+            },
+            "peerDependenciesMeta": {
+                "@swc/helpers": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/next-themes": {
             "version": "0.4.6",
@@ -14106,6 +13920,7 @@
             "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -14201,7 +14016,6 @@
             "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ansi-regex": "^5.0.1",
                 "ansi-styles": "^5.0.0",
@@ -14217,7 +14031,6 @@
             "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -14396,6 +14209,7 @@
             "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
             "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "orderedmap": "^2.0.0"
             }
@@ -14425,6 +14239,7 @@
             "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
             "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "prosemirror-model": "^1.0.0",
                 "prosemirror-transform": "^1.0.0",
@@ -14473,6 +14288,7 @@
             "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.8.tgz",
             "integrity": "sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "prosemirror-model": "^1.20.0",
                 "prosemirror-state": "^1.0.0",
@@ -14666,6 +14482,7 @@
             "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
             "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -14675,6 +14492,7 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
             "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "scheduler": "^0.27.0"
             },
@@ -14687,8 +14505,7 @@
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
             "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/react-remove-scroll": {
             "version": "2.7.2",
@@ -15142,6 +14959,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
             "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -16079,7 +15897,8 @@
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
             "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/tapable": {
             "version": "2.3.2",
@@ -16517,6 +16336,7 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "devOptional": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -16867,6 +16687,7 @@
             "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "lightningcss": "^1.32.0",
                 "picomatch": "^4.0.4",
@@ -16960,6 +16781,7 @@
             "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@vitest/expect": "4.1.4",
                 "@vitest/mocker": "4.1.4",
@@ -17222,6 +17044,7 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -17695,6 +17518,7 @@
             "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
             "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5387,6 +5387,7 @@
             "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
             "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.8.0"
             }

--- a/frontend/src/app/[locale]/(cms)/cms/(main)/import-errors/page.tsx
+++ b/frontend/src/app/[locale]/(cms)/cms/(main)/import-errors/page.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useEffect, useRef } from "react";
+import { animate } from "animejs";
+import { PageHeader } from "@/components/cms/PageHeader";
+import { ImportErrorsTable } from "../../tables/import-errors/import-errors-table";
+
+export default function ImportErrorsPage() {
+    const t = useTranslations("Cms.ImportErrors");
+    const tEditions = useTranslations("Cms.editions");
+    const contentRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        if (contentRef.current) {
+            const el = contentRef.current;
+            el.style.opacity = "0";
+            el.style.transform = "translateY(16px)";
+            animate(el, {
+                opacity: [0, 1],
+                translateY: [16, 0],
+                ease: "outQuad",
+                duration: 500,
+                delay: 200,
+            });
+        }
+    }, []);
+
+    return (
+        <div className="flex h-full flex-col px-4 py-3">
+            <PageHeader eyebrow={tEditions("edition6")} title={t("title")} />
+
+            <div ref={contentRef} className="flex-1 space-y-6 overflow-auto">
+                <ImportErrorsTable />
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/app/[locale]/(cms)/cms/(main)/import/page.tsx
+++ b/frontend/src/app/[locale]/(cms)/cms/(main)/import/page.tsx
@@ -30,7 +30,6 @@ export default function ImportPage() {
         <div className="flex h-full flex-col px-3 py-1 lg:px-4 lg:py-3">
             <PageHeader eyebrow={tEditions("edition6")} title={t("title")} />
 
-            {/* Content - scrollable */}
             <div ref={contentRef} className="flex-1 overflow-auto">
                 <div className="max-w-2xl">
                     <div className="border-foreground/20 bg-foreground/[0.02] border p-8">

--- a/frontend/src/app/[locale]/(cms)/cms/(overview)/page.tsx
+++ b/frontend/src/app/[locale]/(cms)/cms/(overview)/page.tsx
@@ -3,7 +3,16 @@
 import { useTranslations } from "next-intl";
 import { useEffect, useRef } from "react";
 import { animate, stagger } from "animejs";
-import { FileUp, Database, Drama, MapPin, Newspaper, Users, SquareStack } from "lucide-react";
+import {
+    FileUp,
+    Database,
+    Clapperboard,
+    MapPin,
+    Newspaper,
+    Users,
+    FolderArchive,
+    TriangleAlert,
+} from "lucide-react";
 
 import { SectionCard, SectionCardContent } from "@/components/cms/SectionCard";
 import { useGetStats } from "@/hooks/api/useStats";
@@ -13,7 +22,7 @@ interface ContentSection {
     href: string;
     editionKey: string;
     span: string;
-    icon: typeof Drama;
+    icon: typeof Clapperboard;
     comingSoon?: boolean;
 }
 
@@ -23,7 +32,7 @@ const CONTENT_SECTIONS: ContentSection[] = [
         href: "/cms/productions",
         editionKey: "edition1",
         span: "lg:col-span-8",
-        icon: Drama,
+        icon: Clapperboard,
     },
     {
         key: "locations",
@@ -52,7 +61,7 @@ const CONTENT_SECTIONS: ContentSection[] = [
         href: "/cms/collections",
         editionKey: "edition5",
         span: "lg:col-span-12",
-        icon: SquareStack,
+        icon: FolderArchive,
     },
 ];
 
@@ -74,6 +83,12 @@ const UTILITY_SECTIONS: UtilitySection[] = [
         key: "import",
         href: "/cms/import",
         icon: FileUp,
+        editionKey: "edition6",
+    },
+    {
+        key: "importErrors",
+        href: "/cms/import-errors",
+        icon: TriangleAlert,
         editionKey: "edition6",
     },
 ];

--- a/frontend/src/app/[locale]/(cms)/cms/tables/import-errors/import-errors-table.tsx
+++ b/frontend/src/app/[locale]/(cms)/cms/tables/import-errors/import-errors-table.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { ColumnDef } from "@tanstack/react-table";
+import { useTranslations } from "next-intl";
+
+import { DataTable } from "../data-table";
+import { useGetImportErrors } from "@/hooks/api/useImportErrors";
+import { ImportErrorResponse } from "@/types/api/import-error.api.types";
+import { Button } from "@/components/ui/button";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
+function formatDateTime(value: string): string {
+    return new Date(value).toLocaleString("nl-BE", {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+        timeZone: "Europe/Brussels",
+    });
+}
+
+function renderOptionalValue(value: string | number | null | undefined) {
+    if (value === null || value === undefined || value === "") {
+        return <span className="text-muted-foreground">—</span>;
+    }
+
+    return String(value);
+}
+
+type StatusFilter = "unresolved" | "resolved";
+
+export function ImportErrorsTable() {
+    const t = useTranslations("Cms.ImportErrors");
+    const [statusFilter, setStatusFilter] = useState<StatusFilter>("unresolved");
+    const [cursorHistory, setCursorHistory] = useState<(string | null)[]>([null]);
+    const [currentPageIndex, setCurrentPageIndex] = useState(0);
+    const currentCursor = cursorHistory[currentPageIndex];
+
+    const { data, isLoading } = useGetImportErrors({
+        pagination: currentCursor ? { cursor: currentCursor, limit: 50 } : { limit: 50 },
+        resolved: statusFilter === "resolved",
+    });
+
+    const handleStatusChange = (next: string) => {
+        if (next !== "unresolved" && next !== "resolved") return;
+        setStatusFilter(next);
+        // Reset pagination — cursors are scoped to a specific filter on the
+        // backend, so we cannot reuse them when the resolved filter flips.
+        setCursorHistory([null]);
+        setCurrentPageIndex(0);
+    };
+
+    const columns = useMemo<ColumnDef<ImportErrorResponse>[]>(
+        () => [
+            {
+                accessorKey: "severity",
+                header: t("severity"),
+                cell: ({ row }) => (
+                    <span className="font-medium capitalize">{row.original.severity}</span>
+                ),
+            },
+            {
+                accessorKey: "entity",
+                header: t("entity"),
+                cell: ({ row }) => <span className="capitalize">{row.original.entity}</span>,
+            },
+            {
+                accessorKey: "source_id",
+                header: t("sourceId"),
+                cell: ({ row }) => renderOptionalValue(row.original.source_id),
+            },
+            {
+                accessorKey: "error_kind",
+                header: t("errorKind"),
+                cell: ({ row }) => row.original.error_kind,
+            },
+            {
+                id: "relation",
+                header: t("relation"),
+                cell: ({ row }) => {
+                    const { relation, relation_source_id } = row.original;
+                    if (!relation && relation_source_id == null) {
+                        return <span className="text-muted-foreground">—</span>;
+                    }
+
+                    if (relation && relation_source_id != null) {
+                        return `${relation} (${relation_source_id})`;
+                    }
+
+                    return renderOptionalValue(relation ?? relation_source_id);
+                },
+            },
+            {
+                accessorKey: "message",
+                header: t("message"),
+                cell: ({ row }) => (
+                    <span className="block max-w-xl whitespace-normal">{row.original.message}</span>
+                ),
+            },
+            {
+                accessorKey: "last_seen_at",
+                header: t("lastSeen"),
+                cell: ({ row }) => formatDateTime(row.original.last_seen_at),
+            },
+        ],
+        [t]
+    );
+
+    return (
+        <div className="space-y-4 p-4">
+            <div className="space-y-1">
+                <h1 className="text-2xl font-semibold">{t("title")}</h1>
+                <p className="text-muted-foreground text-sm">{t("description")}</p>
+            </div>
+
+            <Tabs value={statusFilter} onValueChange={handleStatusChange}>
+                <TabsList>
+                    <TabsTrigger value="unresolved">{t("unresolvedTab")}</TabsTrigger>
+                    <TabsTrigger value="resolved">{t("resolvedTab")}</TabsTrigger>
+                </TabsList>
+            </Tabs>
+
+            <DataTable columns={columns} data={data?.data ?? []} loading={isLoading} />
+
+            <div className="flex justify-end gap-2">
+                <Button
+                    variant="outline"
+                    onClick={() => setCurrentPageIndex((current) => Math.max(0, current - 1))}
+                    disabled={currentPageIndex === 0 || isLoading}
+                >
+                    {t("previousPage")}
+                </Button>
+                <Button
+                    variant="outline"
+                    onClick={() => {
+                        if (!data?.nextCursor) return;
+
+                        setCursorHistory((current) => {
+                            if (current[currentPageIndex + 1] === data.nextCursor) {
+                                return current;
+                            }
+
+                            return [...current.slice(0, currentPageIndex + 1), data.nextCursor];
+                        });
+                        setCurrentPageIndex((current) => current + 1);
+                    }}
+                    disabled={data?.nextCursor == null || isLoading}
+                >
+                    {t("nextPage")}
+                </Button>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/components/cms/cms-sidebar.tsx
+++ b/frontend/src/components/cms/cms-sidebar.tsx
@@ -4,7 +4,16 @@ import { useCallback, useMemo, useState } from "react";
 import { useTranslations, useLocale } from "next-intl";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Link, usePathname } from "@/i18n/routing";
-import { Drama, MapPin, Newspaper, Users, Database, FileUp, SquareStack } from "lucide-react";
+import {
+    Clapperboard,
+    MapPin,
+    Newspaper,
+    Users,
+    Database,
+    FileUp,
+    FolderArchive,
+    TriangleAlert,
+} from "lucide-react";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import { Sheet, SheetContent, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
@@ -13,16 +22,22 @@ import { getLabel } from "@/lib/utils";
 import type { EntityType, Facet } from "@/types/models/taxonomy.types";
 
 const navItems = [
-    { key: "productions", href: "/cms/productions", icon: Drama, editionKey: "edition1" },
+    { key: "productions", href: "/cms/productions", icon: Clapperboard, editionKey: "edition1" },
     { key: "locations", href: "/cms/locations", icon: MapPin, editionKey: "edition2" },
     { key: "articles", href: "/cms/articles", icon: Newspaper, editionKey: "edition3" },
     { key: "performers", href: "/cms/performers", icon: Users, editionKey: "edition4" },
-    { key: "collections", href: "/cms/collections", icon: SquareStack, editionKey: "edition5" },
+    { key: "collections", href: "/cms/collections", icon: FolderArchive, editionKey: "edition5" },
 ];
 
 const utilityItems = [
     { key: "ingest", href: "/cms/ingest", icon: Database, editionKey: "edition5" },
     { key: "import", href: "/cms/import", icon: FileUp, editionKey: "edition6" },
+    {
+        key: "importErrors",
+        href: "/cms/import-errors",
+        icon: TriangleAlert,
+        editionKey: "edition6",
+    },
 ];
 
 const ENTITY_TYPE_MAP: Record<string, EntityType | null> = {

--- a/frontend/src/hooks/api/query-keys.ts
+++ b/frontend/src/hooks/api/query-keys.ts
@@ -1,11 +1,10 @@
 import { PaginationParams, SearchPaginationParams } from "@/types/api/api.types";
 import { EntityMediaParams, MediaSearchParams } from "@/types/models/media.types";
 
-const buildQueryKey = (
-    base: readonly string[],
-    params?: PaginationParams | SearchPaginationParams
-): readonly unknown[] => {
-    if (!params) return base;
+type QueryKeyParams = PaginationParams | SearchPaginationParams | Record<string, unknown>;
+
+const buildQueryKey = (base: readonly string[], params?: QueryKeyParams): readonly unknown[] => {
+    if (!params || Object.keys(params).length === 0) return base;
     return [...base, params];
 };
 
@@ -13,6 +12,10 @@ export const queryKeys = {
     user: ["user"] as const,
     version: ["version"] as const,
     stats: ["stats"] as const,
+    importErrors: {
+        all: (pagination?: PaginationParams, resolved?: boolean) =>
+            buildQueryKey(["import-errors"], { ...pagination, resolved: resolved ?? false }),
+    },
     locations: {
         all: (pagination?: PaginationParams) => buildQueryKey(["locations"], pagination),
         detail: (id: string) => ["locations", id] as const,

--- a/frontend/src/hooks/api/useImportErrors.ts
+++ b/frontend/src/hooks/api/useImportErrors.ts
@@ -1,0 +1,44 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { api } from "@/lib/api-client";
+import { PaginationParams, PaginatedResult } from "@/types/api/api.types";
+import { operations } from "@/types/api/generated";
+import { GetImportErrorsResponse, ImportErrorResponse } from "@/types/api/import-error.api.types";
+
+import { queryKeys } from "./query-keys";
+
+type GetImportErrorsQuery = NonNullable<operations["get_import_errors"]["parameters"]["query"]>;
+
+interface ImportErrorsQueryParams extends PaginationParams {
+    resolved?: GetImportErrorsQuery["resolved"];
+}
+
+interface ImportErrorsListOptions {
+    enabled?: boolean;
+    pagination?: PaginationParams;
+    resolved?: GetImportErrorsQuery["resolved"];
+}
+
+type ImportErrorsResult = PaginatedResult<ImportErrorResponse>;
+
+const fetchImportErrors = async (params?: ImportErrorsQueryParams): Promise<ImportErrorsResult> => {
+    const { data } = await api.get<GetImportErrorsResponse>("/import-errors", { params });
+    return {
+        data: data.data,
+        nextCursor: data.next_cursor ?? null,
+    };
+};
+
+export const useGetImportErrors = (options?: ImportErrorsListOptions) => {
+    const params: ImportErrorsQueryParams = {
+        cursor: options?.pagination?.cursor,
+        limit: options?.pagination?.limit ?? 50,
+        resolved: options?.resolved,
+    };
+
+    return useQuery({
+        queryKey: queryKeys.importErrors.all(options?.pagination, options?.resolved),
+        queryFn: () => fetchImportErrors(params),
+        ...options,
+    });
+};

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -196,12 +196,36 @@
         "collections": "Collections",
         "ingest": "Ingest",
         "import": "Import",
+        "importErrors": "Import errors",
         "TabBar": {
             "overview": "CMS Overview",
             "content": "Manage content",
             "collections": "Collections",
             "ingest": "Ingest",
-            "import": "Automatic import"
+            "import": "Automatic import",
+            "importErrors": "Import errors"
+        },
+        "Import": {
+            "title": "Import",
+            "subtitle": "Automatic import from external data sources",
+            "comingSoon": "Coming soon",
+            "notAvailable": "Import functionality",
+            "description": "This feature is still under development. Soon you will be able to import data from external sources such as UiTdatabank here."
+        },
+        "ImportErrors": {
+            "title": "Import errors",
+            "description": "Overview of errors and warnings from the automatic import.",
+            "previousPage": "Previous page",
+            "nextPage": "Next page",
+            "unresolvedTab": "Unresolved",
+            "resolvedTab": "Resolved",
+            "severity": "Severity",
+            "entity": "Entity",
+            "sourceId": "Source ID",
+            "errorKind": "Error kind",
+            "relation": "Relation",
+            "message": "Message",
+            "lastSeen": "Last seen"
         },
         "Sidebar": {
             "contentType": "Content type",
@@ -269,6 +293,8 @@
             "ingestDescription": "Upload and process archive materials",
             "import": "Import",
             "importDescription": "Import data from external sources",
+            "importErrors": "Import errors",
+            "importErrorsDescription": "Review warnings and errors from the automatic importer",
             "items": "items",
             "openSection": "Open section",
             "backToOverview": "Back to overview"
@@ -411,13 +437,6 @@
             "comingSoon": "Coming soon",
             "notAvailable": "Ingest functionality",
             "description": "This feature is still under development. Soon you will be able to upload and process media files here."
-        },
-        "Import": {
-            "title": "Import",
-            "subtitle": "Automatic import from external data sources",
-            "comingSoon": "Coming soon",
-            "notAvailable": "Import functionality",
-            "description": "This feature is still under development. Soon you will be able to import data from external sources such as UiTdatabank here."
         },
         "Collections": {
             "title": "Collections",

--- a/frontend/src/messages/nl.json
+++ b/frontend/src/messages/nl.json
@@ -196,12 +196,36 @@
         "collections": "Collecties",
         "ingest": "Ingest",
         "import": "Import",
+        "importErrors": "Importfouten",
         "TabBar": {
             "overview": "CMS Overzicht",
             "content": "Inhoud beheren",
             "collections": "Collecties",
             "ingest": "Importeren",
-            "import": "Automatische import"
+            "import": "Automatische import",
+            "importErrors": "Importfouten"
+        },
+        "Import": {
+            "title": "Import",
+            "subtitle": "Automatische import van externe databronnen",
+            "comingSoon": "Binnenkort beschikbaar",
+            "notAvailable": "Import functionaliteit",
+            "description": "Deze functionaliteit is nog in ontwikkeling. Later kunt u hier data importeren van externe bronnen zoals UiTdatabank."
+        },
+        "ImportErrors": {
+            "title": "Importfouten",
+            "description": "Overzicht van fouten en waarschuwingen uit de automatische import.",
+            "previousPage": "Vorige pagina",
+            "nextPage": "Volgende pagina",
+            "unresolvedTab": "Niet opgelost",
+            "resolvedTab": "Opgelost",
+            "severity": "Ernst",
+            "entity": "Entiteit",
+            "sourceId": "Source ID",
+            "errorKind": "Fouttype",
+            "relation": "Relatie",
+            "message": "Bericht",
+            "lastSeen": "Laatst gezien"
         },
         "Sidebar": {
             "contentType": "Inhoudstype",
@@ -269,6 +293,8 @@
             "ingestDescription": "Upload en verwerk archiefmaterialen",
             "import": "Import",
             "importDescription": "Importeer data van externe bronnen",
+            "importErrors": "Importfouten",
+            "importErrorsDescription": "Bekijk waarschuwingen en fouten uit de automatische importer",
             "items": "items",
             "openSection": "Open sectie",
             "backToOverview": "Terug naar overzicht"
@@ -411,13 +437,6 @@
             "comingSoon": "Binnenkort beschikbaar",
             "notAvailable": "Ingest functionaliteit",
             "description": "Deze functionaliteit is nog in ontwikkeling. Later kunt u hier mediabestanden uploaden en verwerken."
-        },
-        "Import": {
-            "title": "Import",
-            "subtitle": "Automatische import van externe databronnen",
-            "comingSoon": "Binnenkort beschikbaar",
-            "notAvailable": "Import functionaliteit",
-            "description": "Deze functionaliteit is nog in ontwikkeling. Later kunt u hier data importeren van externe bronnen zoals UiTdatabank."
         },
         "Collections": {
             "title": "Collecties",

--- a/frontend/src/types/api/generated.ts
+++ b/frontend/src/types/api/generated.ts
@@ -341,6 +341,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/import-errors": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description List importer errors for CMS usage. Returns unresolved errors by default. */
+        get: operations["get_import_errors"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/locations": {
         parameters: {
             query?: never;
@@ -1226,6 +1243,31 @@ export interface components {
             space_id?: string | null;
             vendor_id?: string | null;
         };
+        ImportErrorPayload: {
+            /** Format: date-time */
+            created_at: string;
+            entity: string;
+            error_kind: string;
+            field?: string | null;
+            /** Format: uuid */
+            id: string;
+            /** Format: date-time */
+            last_seen_at: string;
+            message: string;
+            payload?: unknown;
+            relation?: string | null;
+            /** Format: int32 */
+            relation_source_id?: number | null;
+            /** Format: date-time */
+            resolved_at?: string | null;
+            /** Format: uuid */
+            run_id?: string | null;
+            severity: string;
+            /** Format: int32 */
+            source_id?: number | null;
+            /** Format: date-time */
+            updated_at: string;
+        };
         LinkMediaRequest: {
             is_cover_image?: boolean | null;
             /** Format: uuid */
@@ -1407,6 +1449,34 @@ export interface components {
                 /** Format: uuid */
                 space_id?: string | null;
                 vendor_id?: string | null;
+            }[];
+            next_cursor?: string | null;
+        };
+        PaginatedResponse_ImportErrorPayload: {
+            data: {
+                /** Format: date-time */
+                created_at: string;
+                entity: string;
+                error_kind: string;
+                field?: string | null;
+                /** Format: uuid */
+                id: string;
+                /** Format: date-time */
+                last_seen_at: string;
+                message: string;
+                payload?: unknown;
+                relation?: string | null;
+                /** Format: int32 */
+                relation_source_id?: number | null;
+                /** Format: date-time */
+                resolved_at?: string | null;
+                /** Format: uuid */
+                run_id?: string | null;
+                severity: string;
+                /** Format: int32 */
+                source_id?: number | null;
+                /** Format: date-time */
+                updated_at: string;
             }[];
             next_cursor?: string | null;
         };
@@ -2749,6 +2819,39 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+        };
+    };
+    get_import_errors: {
+        parameters: {
+            query?: {
+                cursor?: string | null;
+                limit?: number;
+                resolved?: boolean;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Success */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PaginatedResponse_ImportErrorPayload"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
             };
         };
     };

--- a/frontend/src/types/api/import-error.api.types.ts
+++ b/frontend/src/types/api/import-error.api.types.ts
@@ -1,0 +1,5 @@
+import { PaginatedListResponse } from "./api.types";
+
+export type GetImportErrorsResponse = PaginatedListResponse<"get_import_errors">;
+export type ImportErrorsListResponse = GetImportErrorsResponse;
+export type ImportErrorResponse = GetImportErrorsResponse["data"][number];

--- a/frontend/test/integration/hooks/useImportErrors.test.tsx
+++ b/frontend/test/integration/hooks/useImportErrors.test.tsx
@@ -1,0 +1,69 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { queryKeys } from "@/hooks/api/query-keys";
+import { useGetImportErrors } from "@/hooks/api/useImportErrors";
+import { createQueryClientWrapper } from "../../utils/query-client";
+
+describe("useGetImportErrors", () => {
+    it("fetches unresolved import errors by default", async () => {
+        const { wrapper, queryClient } = createQueryClientWrapper();
+
+        const { result } = renderHook(() => useGetImportErrors(), { wrapper });
+
+        await waitFor(() => {
+            expect(result.current.isSuccess).toBe(true);
+        });
+
+        expect(result.current.data?.data).toHaveLength(1);
+        expect(result.current.data?.data[0]).toMatchObject({
+            entity: "media",
+            source_id: 404,
+            error_kind: "missing_required_field",
+        });
+        expect(result.current.data?.nextCursor).toBe("page2");
+
+        const cached = queryClient.getQueryData(queryKeys.importErrors.all(undefined, undefined));
+        expect(cached).toEqual(result.current.data);
+    });
+
+    it("passes pagination params and maps next_cursor to nextCursor", async () => {
+        const { wrapper } = createQueryClientWrapper();
+
+        const { result } = renderHook(
+            () => useGetImportErrors({ pagination: { cursor: "page2", limit: 10 } }),
+            { wrapper }
+        );
+
+        await waitFor(() => {
+            expect(result.current.isSuccess).toBe(true);
+        });
+
+        expect(result.current.data?.data).toHaveLength(1);
+        expect(result.current.data?.data[0].entity).toBe("media_variant");
+        expect(result.current.data?.nextCursor).toBeNull();
+    });
+
+    it("fetches resolved import errors under a separate query key", async () => {
+        const { wrapper, queryClient } = createQueryClientWrapper();
+
+        const { result } = renderHook(() => useGetImportErrors({ resolved: true }), { wrapper });
+
+        await waitFor(() => {
+            expect(result.current.isSuccess).toBe(true);
+        });
+
+        expect(result.current.data?.data[0]).toMatchObject({
+            entity: "event",
+            resolved_at: "2026-04-01T11:00:00Z",
+        });
+
+        const unresolvedCache = queryClient.getQueryData(
+            queryKeys.importErrors.all(undefined, false)
+        );
+        const resolvedCache = queryClient.getQueryData(queryKeys.importErrors.all(undefined, true));
+
+        expect(unresolvedCache).toBeUndefined();
+        expect(resolvedCache).toEqual(result.current.data);
+    });
+});

--- a/frontend/test/msw/handlers/import-errors.handlers.ts
+++ b/frontend/test/msw/handlers/import-errors.handlers.ts
@@ -1,0 +1,88 @@
+import { http, HttpResponse } from "msw";
+
+import type {
+    ImportErrorResponse,
+    ImportErrorsListResponse,
+} from "@/types/api/import-error.api.types";
+import { apiUrl } from "../../utils/env";
+
+const unresolvedError: ImportErrorResponse = {
+    id: "11111111-1111-7111-8111-111111111111",
+    created_at: "2026-04-01T08:00:00Z",
+    updated_at: "2026-04-01T08:00:00Z",
+    last_seen_at: "2026-04-01T08:15:00Z",
+    resolved_at: null,
+    run_id: "22222222-2222-7222-8222-222222222222",
+    severity: "error",
+    entity: "media",
+    source_id: 404,
+    error_kind: "missing_required_field",
+    field: "download_url",
+    relation: null,
+    relation_source_id: null,
+    message: "media is missing required field download_url",
+    payload: null,
+};
+
+const secondPageError: ImportErrorResponse = {
+    id: "33333333-3333-7333-8333-333333333333",
+    created_at: "2026-04-01T09:00:00Z",
+    updated_at: "2026-04-01T09:00:00Z",
+    last_seen_at: "2026-04-01T09:15:00Z",
+    resolved_at: null,
+    run_id: "44444444-4444-7444-8444-444444444444",
+    severity: "warning",
+    entity: "media_variant",
+    source_id: null,
+    error_kind: "unexpected_field_value",
+    field: "crop",
+    relation: "media",
+    relation_source_id: 404,
+    message: "failed to download crop",
+    payload: { value: "crop failed", fallback: "media_without_crop_variant" },
+};
+
+const resolvedError: ImportErrorResponse = {
+    id: "55555555-5555-7555-8555-555555555555",
+    created_at: "2026-04-01T10:00:00Z",
+    updated_at: "2026-04-01T11:00:00Z",
+    last_seen_at: "2026-04-01T10:15:00Z",
+    resolved_at: "2026-04-01T11:00:00Z",
+    run_id: "66666666-6666-7666-8666-666666666666",
+    severity: "warning",
+    entity: "event",
+    source_id: 12,
+    error_kind: "missing_optional_relation",
+    field: null,
+    relation: "hall",
+    relation_source_id: 99,
+    message: "event references missing optional hall source_id 99",
+    payload: null,
+};
+
+export const importErrorHandlers = [
+    http.get(apiUrl("/import-errors"), ({ request }) => {
+        const url = new URL(request.url);
+        const cursor = url.searchParams.get("cursor");
+        const resolved = url.searchParams.get("resolved") === "true";
+
+        if (resolved) {
+            return HttpResponse.json({
+                data: [resolvedError],
+                next_cursor: null,
+            } satisfies ImportErrorsListResponse);
+        }
+
+        if (cursor === "page2") {
+            return HttpResponse.json({
+                data: [secondPageError],
+                next_cursor: null,
+            } satisfies ImportErrorsListResponse);
+        }
+
+        return HttpResponse.json({
+            data: [unresolvedError],
+            next_cursor: "page2",
+        } satisfies ImportErrorsListResponse);
+    }),
+];

--- a/frontend/test/msw/handlers/index.ts
+++ b/frontend/test/msw/handlers/index.ts
@@ -2,6 +2,7 @@ import { articleHandlers } from "./articles.handlers";
 import { authHandlers } from "./auth.handlers";
 import { eventHandlers } from "./events.handlers";
 import { hallHandlers } from "./halls.handlers";
+import { importErrorHandlers } from "./import-errors.handlers";
 import { locationHandlers } from "./locations.handlers";
 import { mediaHandlers } from "./media.handlers";
 import { productionHandlers } from "./productions.handlers";
@@ -12,6 +13,7 @@ export const handlers = [
     ...articleHandlers,
     ...authHandlers,
     ...eventHandlers,
+    ...importErrorHandlers,
     ...locationHandlers,
     ...mediaHandlers,
     ...productionHandlers,

--- a/frontend/test/unit/components/cms/import-errors-table.test.tsx
+++ b/frontend/test/unit/components/cms/import-errors-table.test.tsx
@@ -1,0 +1,103 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ImportErrorsTable } from "@/app/[locale]/(cms)/cms/tables/import-errors/import-errors-table";
+import messages from "@/messages/en.json";
+import { createTestQueryClient } from "../../../utils/query-client";
+
+const renderImportErrorsTable = () => {
+    const queryClient = createTestQueryClient();
+
+    render(
+        <NextIntlClientProvider locale="en" messages={messages}>
+            <QueryClientProvider client={queryClient}>
+                <ImportErrorsTable />
+            </QueryClientProvider>
+        </NextIntlClientProvider>
+    );
+
+    return { queryClient };
+};
+
+afterEach(() => {
+    cleanup();
+});
+
+describe("ImportErrorsTable", () => {
+    it("renders unresolved import errors with relation fallback", async () => {
+        renderImportErrorsTable();
+
+        expect(screen.getByRole("heading", { name: "Import errors" })).toBeInTheDocument();
+
+        await waitFor(() => {
+            expect(screen.getByText("media")).toBeInTheDocument();
+        });
+
+        expect(screen.getByText("error")).toBeInTheDocument();
+        expect(screen.getByText("404")).toBeInTheDocument();
+        expect(screen.getByText("missing_required_field")).toBeInTheDocument();
+        expect(
+            screen.getByText("media is missing required field download_url")
+        ).toBeInTheDocument();
+        expect(screen.getByText("—")).toBeInTheDocument();
+    });
+
+    it("navigates to the next cursor page and back", async () => {
+        renderImportErrorsTable();
+
+        await waitFor(() => {
+            expect(
+                screen.getByText("media is missing required field download_url")
+            ).toBeInTheDocument();
+        });
+
+        fireEvent.click(screen.getByRole("button", { name: "Next page" }));
+
+        await waitFor(() => {
+            expect(screen.getByText("media_variant")).toBeInTheDocument();
+        });
+
+        expect(screen.getByText("warning")).toBeInTheDocument();
+        expect(screen.getByText("media (404)")).toBeInTheDocument();
+        expect(screen.getByText("failed to download crop")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Next page" })).toBeDisabled();
+
+        fireEvent.click(screen.getByRole("button", { name: "Previous page" }));
+
+        await waitFor(() => {
+            expect(
+                screen.getByText("media is missing required field download_url")
+            ).toBeInTheDocument();
+        });
+    });
+
+    it("resets pagination when switching to resolved errors", async () => {
+        const user = userEvent.setup();
+        renderImportErrorsTable();
+
+        await waitFor(() => {
+            expect(
+                screen.getByText("media is missing required field download_url")
+            ).toBeInTheDocument();
+        });
+
+        fireEvent.click(screen.getByRole("button", { name: "Next page" }));
+
+        await waitFor(() => {
+            expect(screen.getByText("media_variant")).toBeInTheDocument();
+        });
+
+        await user.click(screen.getByRole("tab", { name: "Resolved" }));
+
+        await waitFor(() => {
+            expect(screen.getByText("event")).toBeInTheDocument();
+        });
+
+        expect(screen.getByText("missing_optional_relation")).toBeInTheDocument();
+        expect(screen.getByText("hall (99)")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Previous page" })).toBeDisabled();
+    });
+});

--- a/frontend/test/unit/query-keys/query-keys.test.ts
+++ b/frontend/test/unit/query-keys/query-keys.test.ts
@@ -11,6 +11,7 @@ describe("queryKeys", () => {
         expect(queryKeys.events.all()).toEqual(["events"]);
         expect(queryKeys.halls.all()).toEqual(["halls"]);
         expect(queryKeys.spaces.all()).toEqual(["spaces"]);
+        expect(queryKeys.importErrors.all()).toEqual(["import-errors", { resolved: false }]);
     });
 
     it("builds deterministic detail keys", () => {
@@ -42,6 +43,10 @@ describe("queryKeys", () => {
             expect(queryKeys.locations.all(pagination)).toEqual(["locations", pagination]);
             expect(queryKeys.halls.all(pagination)).toEqual(["halls", pagination]);
             expect(queryKeys.spaces.all(pagination)).toEqual(["spaces", pagination]);
+            expect(queryKeys.importErrors.all(pagination, true)).toEqual([
+                "import-errors",
+                { ...pagination, resolved: true },
+            ]);
         });
 
         it("returns base key without pagination when no params provided", () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -300,9 +300,9 @@
       }
     },
     "node_modules/@conventional-changelog/git-client": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@conventional-changelog/git-client/-/git-client-2.6.0.tgz",
-      "integrity": "sha512-T+uPDciKf0/ioNNDpMGc8FDsehJClZP0yR3Q5MN6wE/Y/1QZ7F+80OgznnTCOlMEG4AV0LvH2UJi3C/nBnaBUg==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@conventional-changelog/git-client/-/git-client-2.7.0.tgz",
+      "integrity": "sha512-j7A8/LBEQ+3rugMzPXoKYzyUPpw/0CBQCyvtTR7Lmu4olG4yRC/Tfkq79Mr3yuPs0SUitlO2HwGP3gitMJnRFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -315,7 +315,7 @@
       },
       "peerDependencies": {
         "conventional-commits-filter": "^5.0.0",
-        "conventional-commits-parser": "^6.3.0"
+        "conventional-commits-parser": "^6.4.0"
       },
       "peerDependenciesMeta": {
         "conventional-commits-filter": {
@@ -417,14 +417,14 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.5.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
-      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/ajv": {
@@ -783,9 +783,9 @@
       }
     },
     "node_modules/conventional-changelog-angular": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.0.tgz",
-      "integrity": "sha512-DOuBwYSqWzfwuRByY9O4oOIvDlkUCTDzfbOgcSbkY+imXXj+4tmrEFao3K+FxemClYfYnZzsvudbwrhje9VHDA==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.1.tgz",
+      "integrity": "sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -796,9 +796,9 @@
       }
     },
     "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.0.tgz",
-      "integrity": "sha512-kYFx6gAyjSIMwNtASkI3ZE99U1fuVDJr0yTYgVy+I2QG46zNZfl2her+0+eoviG82c5WQvW1jMt1eOQTeJLodA==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.1.tgz",
+      "integrity": "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -809,9 +809,9 @@
       }
     },
     "node_modules/conventional-commits-parser": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.3.0.tgz",
-      "integrity": "sha512-RfOq/Cqy9xV9bOA8N+ZH6DlrDR+5S3Mi0B5kACEjESpE+AviIpAptx9a9cFpWCCvgRtWT+0BbUw+e1BZfts9jg==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
+      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -831,6 +831,7 @@
       "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -853,13 +854,13 @@
       }
     },
     "node_modules/cosmiconfig-typescript-loader": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-6.2.0.tgz",
-      "integrity": "sha512-GEN39v7TgdxgIoNcdkRE3uiAzQt3UXLyHbRHD6YoL048XAeOomyxaP+Hh/+2C6C2wYjxJ2onhJcsQp+L4YEkVQ==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-6.3.0.tgz",
+      "integrity": "sha512-Akr82WH1Wfqatyiqpj8HDkO2o2KmJRu1FhKfSNJP3K4IdXwHfEyL7MOb62i1AGQVLtIQM+iCE9CGOtrfhR+mmA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "jiti": "^2.6.1"
+        "jiti": "2.6.1"
       },
       "engines": {
         "node": ">=v18"
@@ -1234,9 +1235,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1367,9 +1368,9 @@
       }
     },
     "node_modules/joi": {
-      "version": "18.1.1",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-18.1.1.tgz",
-      "integrity": "sha512-pJkBiPtNo+o0h19LfSvUN46Y5zY+ck99AtHwch9n2HqVLNRgP0ZMyIH8FRMoP+HV8hy/+AG99dXFfwpf83iZfQ==",
+      "version": "18.1.2",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-18.1.2.tgz",
+      "integrity": "sha512-rF5MAmps5esSlhCA+N1b6IYHDw9j/btzGaqfgie522jS02Ju/HXBxamlXVlKEHAxoMKQL77HWI8jlqWsFuekZA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -1705,11 +1706,12 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -2002,9 +2004,9 @@
       }
     },
     "node_modules/tinyexec": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
-      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2029,9 +2031,9 @@
       "license": "0BSD"
     },
     "node_modules/typescript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
-      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -2044,12 +2046,11 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/wait-on": {
       "version": "8.0.5",


### PR DESCRIPTION
**Description**
Currently, when something goes wrong in the importer, it almost always just crashes. I added the following  behaviour:

  - conversion code such as ```to_create()``` (the one that coverts stuff like ```ApiProduction``` into ```ProductionCreate```) no longer panics on invalid API input. It now returns structured errors, which are
    handled by the importer loop.
  - in the import loop, item-level failures are handled per item instead of crashing the whole importer. Invalid relation
    references and invalid ```source_id``` values are explicitly detected; the affected item is skipped or partially imported depending
    on the relation.
  - importer errors and warnings are now explicit Rust enums instead of hardcoded strings, using the [thiserror crate](https://docs.rs/thiserror/latest/thiserror/).
  - the importer now supports partial progress instead of blocking on missing optional relations. Current behavior:

  | Entity | Relation | Required by importer? | If missing now | What happens later? |
  |---|---|---:|---|---|
  | space | location | Yes | space is skipped | it can be inserted/updated later if it is fetched again and the relation exists by then |
  | hall | space | No | hall is imported with space_id = None | a later import can fill in space_id |
  | event | production | Yes | event is skipped | it can be inserted/updated later if it is fetched again and the relation exists by then |
  | event | hall | No | event is imported with hall_id = None | a later import can fill in hall_id |

  - the importer now retries non-crashing fetch failures with exponential backoff (currently 3 retries starting at 250 ms).
  
  - importer item errors/warnings are now stored in a new ```import_errors``` DB table.
  
  - unresolved importer errors are exposed to an editor endpoint in the backend.
  
  - importer errors are now visible in the CMS in a read-only “Automatische import” tab.

## Next step
The CMS tab for the importer now mostly focusses on errors related to the items themselves. I'd make a seperate frontend for the importer itself, so the status can be checked, as wel as more serious importer-run errors such as network fails, fails with the viernulvier API,... But that is probably not a Milestone 2 issue.


**Related Issue**
Fixes #62 
Fixes #85 

**How Has This Been Tested?**
- [ ] Local manual testing
- [ ] Added/updated unit or integration tests
- [ ] Tested in the staging environment

**Developer Checklist:**
- [ ] I have performed a self-review of my own code.
- [ ] I have left comments in hard-to-understand areas of my code.
- [ ] My changes generate no new warnings or console errors.
- [ ] I have updated the documentation (if applicable).

**Screenshots / Video (if UI/UX changed):**
