### PR TITLE
feat(cms): improve actions API

### DIFF
--- a/frontend/src/app/[locale]/(cms)/cms/tables/actions-column.tsx
+++ b/frontend/src/app/[locale]/(cms)/cms/tables/actions-column.tsx
@@ -1,11 +1,10 @@
 "use client";
 
-import { memo, useCallback, useMemo, type ComponentType, type ReactNode } from "react";
+import { memo, useMemo, type ReactNode } from "react";
 import { ColumnDef } from "@tanstack/react-table";
-import { MoreHorizontal, SquarePen } from "lucide-react";
+import { MoreHorizontal } from "lucide-react";
 import { useState } from "react";
 import { useTranslations } from "next-intl";
-import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
     DropdownMenu,
@@ -14,100 +13,88 @@ import {
     DropdownMenuLabel,
     DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Action, ActionDisplay, ActionVariant } from "@/types/cms/actions";
 
-type CopyableKeys<TData> = {
-    [K in keyof TData]: TData[K] extends string | number | null | undefined ? K : never;
-}[keyof TData];
-
-export interface PromotedAction<TData> {
-    key: string;
-    icon: ComponentType<{ className?: string }>;
-    label: string;
-    onClick: (entity: TData) => void;
+function isSimpleAction<T>(action: Action<T>): action is Extract<Action<T>, { onClick: unknown }> {
+    return "onClick" in action;
 }
 
 interface ActionsColumnOptions<TData> {
-    label: string;
-    copyKey: CopyableKeys<TData>;
-    onEdit: (entity: TData) => void;
-    promotedActions?: PromotedAction<TData>[];
-    extraMenuItems?: (entity: TData, closeMenu: () => void) => ReactNode;
+    actions: Action<TData>[];
 }
 
 interface ActionsCellProps<TData> {
     entity: TData;
-    label: string;
-    copyKey: CopyableKeys<TData>;
-    onEdit: (entity: TData) => void;
-    promotedActions?: PromotedAction<TData>[];
-    extraMenuItems?: (entity: TData, closeMenu: () => void) => ReactNode;
+    actions: Action<TData>[];
 }
 
 function ActionsCellInner<TData extends Record<string, unknown>>({
     entity,
-    label,
-    copyKey,
-    onEdit,
-    promotedActions,
-    extraMenuItems,
+    actions,
 }: ActionsCellProps<TData>) {
     const t = useTranslations("Cms.ActionsColumn");
-    const copyValue = String(entity[copyKey] ?? "");
     const [open, setOpen] = useState(false);
+    const closeMenu = () => setOpen(false);
 
-    const handleEdit = useCallback(() => onEdit(entity), [onEdit, entity]);
+    const { inlineActions, menuActions } = useMemo(() => {
+        const inline: Extract<Action<TData>, { onClick: unknown }>[] = [];
+        const menu: Action<TData>[] = [];
 
-    const handleCopy = useCallback(async () => {
-        try {
-            await navigator.clipboard.writeText(copyValue);
-            toast.success(t("copied", { key: String(copyKey) }));
-        } catch {
-            toast.error(t("copyFailed"));
+        for (const action of actions) {
+            if (isSimpleAction(action) && action.display === ActionDisplay.Inline) {
+                inline.push(action);
+            } else {
+                menu.push(action);
+            }
         }
-    }, [copyValue, copyKey, t]);
 
-    const boundPromotedActions = useMemo(
-        () =>
-            promotedActions?.map((action) => ({
-                ...action,
-                onClick: () => action.onClick(entity),
-            })),
-        [promotedActions, entity]
-    );
+        return { inlineActions: inline, menuActions: menu };
+    }, [actions]);
 
     return (
         <div className="flex items-center gap-1">
-            <Button variant="ghost" className="h-8 w-8 p-0" onClick={handleEdit}>
-                <span className="sr-only">{t("edit", { label })}</span>
-                <SquarePen className="h-4 w-4" />
-            </Button>
-            {boundPromotedActions?.map((action) => (
+            {inlineActions.map((action) => (
                 <Button
                     key={action.key}
                     variant="ghost"
                     className="h-8 w-8 p-0"
-                    onClick={action.onClick}
+                    onClick={() => action.onClick(entity)}
                 >
                     <span className="sr-only">{action.label}</span>
-                    <action.icon className="h-4 w-4" />
+                    {action.icon && <action.icon className="h-4 w-4" />}
                 </Button>
             ))}
-            <DropdownMenu open={open} onOpenChange={setOpen}>
-                <DropdownMenuTrigger asChild>
-                    <Button variant="ghost" className="h-8 w-8 p-0">
-                        <span className="sr-only">{t("openMenu")}</span>
-                        <MoreHorizontal className="h-4 w-4" />
-                    </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
-                    <DropdownMenuLabel>{t("actions")}</DropdownMenuLabel>
-                    <DropdownMenuItem disabled={copyValue === ""} onClick={handleCopy}>
-                        {t("copy", { key: String(copyKey) })}
-                    </DropdownMenuItem>
-                    <DropdownMenuItem onClick={handleEdit}>{t("edit", { label })}</DropdownMenuItem>
-                    {extraMenuItems?.(entity, () => setOpen(false))}
-                </DropdownMenuContent>
-            </DropdownMenu>
+            {menuActions.length > 0 && (
+                <DropdownMenu open={open} onOpenChange={setOpen}>
+                    <DropdownMenuTrigger asChild>
+                        <Button variant="ghost" className="h-8 w-8 p-0">
+                            <span className="sr-only">{t("openMenu")}</span>
+                            <MoreHorizontal className="h-4 w-4" />
+                        </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                        <DropdownMenuLabel>{t("actions")}</DropdownMenuLabel>
+                        {menuActions.map((action) =>
+                            isSimpleAction(action) ? (
+                                <DropdownMenuItem
+                                    key={action.key}
+                                    onClick={() => action.onClick(entity)}
+                                    className={
+                                        action.variant === ActionVariant.Destructive
+                                            ? "text-destructive"
+                                            : undefined
+                                    }
+                                >
+                                    {action.icon && <action.icon className="h-4 w-4" />}
+                                    {action.label}
+                                </DropdownMenuItem>
+                            ) : (
+                                <span key={action.key}>{action.render(entity, closeMenu)}</span>
+                            )
+                        )}
+                    </DropdownMenuContent>
+                </DropdownMenu>
+            )}
         </div>
     );
 }
@@ -119,19 +106,10 @@ const ActionsCell = memo(ActionsCellInner) as <TData extends Record<string, unkn
 export function makeActionsColumn<TData extends Record<string, unknown>>(
     options: ActionsColumnOptions<TData>
 ): ColumnDef<TData> {
-    const { label, copyKey, onEdit, promotedActions, extraMenuItems } = options;
+    const { actions } = options;
 
     return {
         id: "actions",
-        cell: ({ row }) => (
-            <ActionsCell
-                entity={row.original}
-                label={label}
-                copyKey={copyKey}
-                onEdit={onEdit}
-                promotedActions={promotedActions}
-                extraMenuItems={extraMenuItems}
-            />
-        ),
+        cell: ({ row }) => <ActionsCell entity={row.original} actions={actions} />,
     };
 }

--- a/frontend/src/app/[locale]/(cms)/cms/tables/actions-column.tsx
+++ b/frontend/src/app/[locale]/(cms)/cms/tables/actions-column.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useMemo, type ReactNode } from "react";
+import { Fragment, memo, useMemo, type ReactNode } from "react";
 import { ColumnDef } from "@tanstack/react-table";
 import { MoreHorizontal } from "lucide-react";
 import { useState } from "react";
@@ -89,7 +89,9 @@ function ActionsCellInner<TData extends Record<string, unknown>>({
                                     {action.label}
                                 </DropdownMenuItem>
                             ) : (
-                                <span key={action.key}>{action.render(entity, closeMenu)}</span>
+                                <Fragment key={action.key}>
+                                    {action.render(entity, closeMenu)}
+                                </Fragment>
                             )
                         )}
                     </DropdownMenuContent>

--- a/frontend/src/app/[locale]/(cms)/cms/tables/articles/articles-table.tsx
+++ b/frontend/src/app/[locale]/(cms)/cms/tables/articles/articles-table.tsx
@@ -17,9 +17,14 @@ export function ArticlesTable() {
     const { data: articles = [], isLoading } = useGetArticlesCms();
     const createArticle = useCreateArticle();
 
+    const tActions = useTranslations("Cms.ActionsColumn");
     const columns = useMemo(
-        () => makeArticleColumns((article) => router.push(`/cms/articles/${article.id}/edit`)),
-        [router]
+        () =>
+            makeArticleColumns(
+                (article) => router.push(`/cms/articles/${article.id}/edit`),
+                tActions
+            ),
+        [router, tActions]
     );
 
     const handleNew = () => {

--- a/frontend/src/app/[locale]/(cms)/cms/tables/articles/columns.tsx
+++ b/frontend/src/app/[locale]/(cms)/cms/tables/articles/columns.tsx
@@ -1,9 +1,13 @@
 "use client";
 
 import { ColumnDef } from "@tanstack/react-table";
+import { SquarePen } from "lucide-react";
+import { toast } from "sonner";
+import { useTranslations } from "next-intl";
 
 import { StatusBadge } from "@/components/cms/status-badge";
 import { makeActionsColumn } from "../actions-column";
+import { Action, ActionDisplay } from "@/types/cms/actions";
 import { ArticleListItem } from "@/types/models/article.types";
 
 function formatDate(date: string | null): string {
@@ -17,8 +21,32 @@ function formatDate(date: string | null): string {
 }
 
 export function makeArticleColumns(
-    onEdit: (article: ArticleListItem) => void
+    onEdit: (article: ArticleListItem) => void,
+    t: ReturnType<typeof useTranslations<"Cms.ActionsColumn">>
 ): ColumnDef<ArticleListItem>[] {
+    const actions: Action<ArticleListItem>[] = [
+        {
+            key: "edit",
+            label: t("edit", { label: "article" }),
+            icon: SquarePen,
+            display: ActionDisplay.Inline,
+            onClick: onEdit,
+        },
+        {
+            key: "copy-slug",
+            label: t("copy", { key: "slug" }),
+            onClick: async (article) => {
+                const value = article.slug ?? "";
+                try {
+                    await navigator.clipboard.writeText(value);
+                    toast.success(t("copied", { key: "slug" }));
+                } catch {
+                    toast.error(t("copyFailed"));
+                }
+            },
+        },
+    ];
+
     return [
         {
             accessorKey: "status",
@@ -46,6 +74,6 @@ export function makeArticleColumns(
                 );
             },
         },
-        makeActionsColumn({ label: "article", copyKey: "slug", onEdit }),
+        makeActionsColumn({ actions }),
     ];
 }

--- a/frontend/src/app/[locale]/(cms)/cms/tables/collections/collections-table.tsx
+++ b/frontend/src/app/[locale]/(cms)/cms/tables/collections/collections-table.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useMemo, useState } from "react";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { toast } from "sonner";
 import { useRouter } from "@/i18n/routing";
 import { DataTable } from "../data-table";
@@ -14,6 +14,7 @@ import { CollectionRow } from "@/types/models/collection.types";
 
 export function CollectionsTable() {
     const t = useTranslations("Cms.Collections");
+    const locale = useLocale();
     const router = useRouter();
     const { data: collections = [], isLoading } = useGetCollections();
     const deleteCollection = useDeleteCollection();
@@ -21,6 +22,11 @@ export function CollectionsTable() {
     const [createOpen, setCreateOpen] = useState(false);
 
     const handleRowClick = useCallback(
+        (row: CollectionRow) => router.push(`/cms/collections/${row.id}`),
+        [router]
+    );
+
+    const handleOpen = useCallback(
         (row: CollectionRow) => router.push(`/cms/collections/${row.id}`),
         [router]
     );
@@ -41,8 +47,8 @@ export function CollectionsTable() {
     );
 
     const columns = useMemo(
-        () => makeCollectionColumns({ onDelete: handleDelete }),
-        [handleDelete]
+        () => makeCollectionColumns({ onDelete: handleDelete, onOpen: handleOpen, locale, t }),
+        [handleDelete, handleOpen, locale, t]
     );
 
     if (!isLoading && rows.length === 0) {

--- a/frontend/src/app/[locale]/(cms)/cms/tables/collections/columns.tsx
+++ b/frontend/src/app/[locale]/(cms)/cms/tables/collections/columns.tsx
@@ -1,70 +1,21 @@
 "use client";
 
 import { ColumnDef } from "@tanstack/react-table";
-import { ExternalLink, Link2, MoreHorizontal, Trash2 } from "lucide-react";
-import { useTranslations } from "next-intl";
+import { ExternalLink, Link2, Trash2 } from "lucide-react";
 import { toast } from "sonner";
-import { useRouter } from "@/i18n/routing";
-import { Button } from "@/components/ui/button";
-import {
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuItem,
-    DropdownMenuLabel,
-    DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
+import { useTranslations } from "next-intl";
+import { makeActionsColumn } from "../actions-column";
+import { Action, ActionVariant } from "@/types/cms/actions";
 import { CollectionRow } from "@/types/models/collection.types";
-
-function CollectionActionsCell({
-    row,
-    onDelete,
-}: {
-    row: CollectionRow;
-    onDelete: (row: CollectionRow) => void;
-}) {
-    const t = useTranslations("Cms.Collections");
-    const router = useRouter();
-
-    const copyShareableLink = async () => {
-        try {
-            const origin = window.location.origin;
-            await navigator.clipboard.writeText(`${origin}/en/collections/${row.slug}`);
-            toast.success(t("linkCopied"));
-        } catch {
-            toast.error(t("copyError"));
-        }
-    };
-
-    return (
-        <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-                <Button variant="ghost" className="h-8 w-8 p-0">
-                    <span className="sr-only">Open menu</span>
-                    <MoreHorizontal className="h-4 w-4" />
-                </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-                <DropdownMenuLabel>{t("title")}</DropdownMenuLabel>
-                <DropdownMenuItem onClick={copyShareableLink}>
-                    <Link2 className="mr-2 h-4 w-4" />
-                    {t("copyLink")}
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => router.push(`/cms/collections/${row.id}`)}>
-                    <ExternalLink className="mr-2 h-4 w-4" />
-                    {t("open")}
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => onDelete(row)} className="text-destructive">
-                    <Trash2 className="mr-2 h-4 w-4" />
-                    {t("deleteCollection")}
-                </DropdownMenuItem>
-            </DropdownMenuContent>
-        </DropdownMenu>
-    );
-}
 
 export function makeCollectionColumns(options: {
     onDelete: (row: CollectionRow) => void;
+    onOpen: (row: CollectionRow) => void;
+    locale: string;
+    t: ReturnType<typeof useTranslations<"Cms.Collections">>;
 }): ColumnDef<CollectionRow>[] {
+    const { onDelete, onOpen, locale, t } = options;
+
     const formatter = new Intl.DateTimeFormat(undefined, {
         year: "numeric",
         month: "short",
@@ -72,6 +23,38 @@ export function makeCollectionColumns(options: {
         hour: "2-digit",
         minute: "2-digit",
     });
+
+    const actions: Action<CollectionRow>[] = [
+        {
+            key: "copy-link",
+            label: t("copyLink"),
+            icon: Link2,
+            onClick: async (row) => {
+                try {
+                    const origin = window.location.origin;
+                    await navigator.clipboard.writeText(
+                        `${origin}/${locale}/collections/${row.slug}`
+                    );
+                    toast.success(t("linkCopied"));
+                } catch {
+                    toast.error(t("copyError"));
+                }
+            },
+        },
+        {
+            key: "open",
+            label: t("open"),
+            icon: ExternalLink,
+            onClick: onOpen,
+        },
+        {
+            key: "delete",
+            label: t("deleteCollection"),
+            icon: Trash2,
+            variant: ActionVariant.Destructive,
+            onClick: onDelete,
+        },
+    ];
 
     return [
         { accessorKey: "titleNl", header: "Title (NL)" },
@@ -82,11 +65,6 @@ export function makeCollectionColumns(options: {
             header: "Updated",
             accessorFn: (row) => formatter.format(new Date(row.updatedAt)),
         },
-        {
-            id: "actions",
-            cell: ({ row }) => (
-                <CollectionActionsCell row={row.original} onDelete={options.onDelete} />
-            ),
-        },
+        makeActionsColumn<CollectionRow>({ actions }),
     ];
 }

--- a/frontend/src/app/[locale]/(cms)/cms/tables/collections/create-collection-dialog.tsx
+++ b/frontend/src/app/[locale]/(cms)/cms/tables/collections/create-collection-dialog.tsx
@@ -3,7 +3,7 @@
 import { FormEvent, useState } from "react";
 import { useTranslations } from "next-intl";
 import { toast } from "sonner";
-import { useRouter } from "@/i18n/routing";
+
 import { useCreateCollection } from "@/hooks/api";
 import { slugify } from "@/lib/slugify";
 import { Button } from "@/components/ui/button";
@@ -24,7 +24,6 @@ interface CreateCollectionDialogProps {
 
 export function CreateCollectionDialog({ open, onOpenChange }: CreateCollectionDialogProps) {
     const t = useTranslations("Cms.Collections");
-    const router = useRouter();
     const createCollection = useCreateCollection();
 
     const [titleNl, setTitleNl] = useState("");
@@ -64,10 +63,9 @@ export function CreateCollectionDialog({ open, onOpenChange }: CreateCollectionD
                 ],
             },
             {
-                onSuccess: (collection) => {
+                onSuccess: () => {
                     toast.success(t("metadataSaved"));
                     handleOpenChange(false);
-                    router.push(`/cms/collections/${collection.id}`);
                 },
                 onError: () => {
                     toast.error(t("metadataError"));

--- a/frontend/src/app/[locale]/(cms)/cms/tables/edit-sheet.tsx
+++ b/frontend/src/app/[locale]/(cms)/cms/tables/edit-sheet.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -44,7 +44,19 @@ export interface EditSheetProps<TData extends { id: string } & Record<string, un
     fields: FieldDef<TData>[];
     title: string;
     description?: string;
-    onSave?: (data: TData) => void;
+    /**
+     * Called when the user clicks "Save". Must return a promise that resolves on
+     * success or rejects on failure.
+     *
+     * **UX behaviour (deliberate choice):**
+     * The sheet waits for the promise to settle before closing. While pending the
+     * save button is disabled. On rejection the sheet stays open so the user can
+     * retry or correct their input without losing context.
+     *
+     * To switch to optimistic close-immediately behaviour, change `handleSave` in
+     * `SheetFormBody` to call `onClose()` before awaiting the promise.
+     */
+    onSave?: (data: TData) => Promise<unknown>;
 }
 
 const NULL_SENTINEL = "__null__";
@@ -145,7 +157,7 @@ function FieldRow<TData>({ field, value, onChange }: FieldRowProps<TData>) {
 interface SheetFormBodyProps<TData extends { id: string } & Record<string, unknown>> {
     entity: TData;
     fields: FieldDef<TData>[];
-    onSave?: (data: TData) => void;
+    onSave?: (data: TData) => Promise<unknown>;
     onClose: () => void;
 }
 
@@ -157,14 +169,24 @@ function SheetFormBody<TData extends { id: string } & Record<string, unknown>>({
 }: SheetFormBodyProps<TData>) {
     const t = useTranslations("Cms.EditSheet");
     const [values, setValues] = useState<Partial<TData>>(() => ({ ...entity }));
+    const [isPending, setIsPending] = useState(false);
 
     const handleChange = (key: keyof TData, value: unknown) => {
         setValues((prev) => ({ ...prev, [key]: value }));
     };
 
-    const handleSave = () => {
-        onSave?.({ ...entity, ...values } as TData);
-        onClose();
+    const handleSave = async () => {
+        if (!onSave) return;
+        setIsPending(true);
+        try {
+            await onSave({ ...entity, ...values } as TData);
+            onClose();
+        } catch {
+            // Stay open on failure — the mutation hook is responsible for
+            // showing an error toast to the user.
+        } finally {
+            setIsPending(false);
+        }
     };
 
     return (
@@ -181,10 +203,10 @@ function SheetFormBody<TData extends { id: string } & Record<string, unknown>>({
             </div>
             <Separator />
             <SheetFooter className="flex-row justify-end gap-2 px-6 py-4">
-                <Button variant="outline" size="sm" onClick={onClose}>
+                <Button variant="outline" size="sm" onClick={onClose} disabled={isPending}>
                     {t("cancel")}
                 </Button>
-                <Button size="sm" onClick={handleSave}>
+                <Button size="sm" onClick={handleSave} disabled={isPending}>
                     {t("saveChanges")}
                 </Button>
             </SheetFooter>
@@ -201,10 +223,31 @@ export function EditSheet<TData extends { id: string } & Record<string, unknown>
     description,
     onSave,
 }: EditSheetProps<TData>) {
-    const formKey = entity?.id ?? null;
+    /**
+     * `openCount` forces a full remount of `SheetFormBody` every time the sheet
+     * opens. Without it, opening the same entity twice in a row (e.g. open →
+     * edit a field → close without saving → reopen) would show stale edits
+     * because React's `key` (entity ID) hasn't changed so the component keeps
+     * its old state.
+     *
+     * The counter is incremented inside the `onOpenChange` callback (an event
+     * handler, not during render) to satisfy React 19's strict ref/setState
+     * rules.
+     */
+    const [openCount, setOpenCount] = useState(0);
+
+    const handleOpenChange = useCallback(
+        (next: boolean) => {
+            if (next) setOpenCount((c) => c + 1);
+            onOpenChange(next);
+        },
+        [onOpenChange]
+    );
+
+    const formKey = entity ? `${entity.id}-${openCount}` : null;
 
     return (
-        <Sheet open={open} onOpenChange={onOpenChange}>
+        <Sheet open={open} onOpenChange={handleOpenChange}>
             <SheetContent className="flex flex-col gap-0 p-0 sm:max-w-md">
                 <SheetHeader className="px-6 pt-6 pb-4">
                     <SheetTitle>{title}</SheetTitle>

--- a/frontend/src/app/[locale]/(cms)/cms/tables/locations/columns.tsx
+++ b/frontend/src/app/[locale]/(cms)/cms/tables/locations/columns.tsx
@@ -1,10 +1,14 @@
 "use client";
 
 import { ColumnDef } from "@tanstack/react-table";
+import { SquarePen } from "lucide-react";
+import { toast } from "sonner";
+import { useTranslations } from "next-intl";
 import { makeActionsColumn } from "../actions-column";
 import { BooleanCell } from "../boolean-cell";
 import type { FieldDef } from "../edit-sheet";
 import { CollectionPickerSubmenu } from "@/components/cms/collection-picker-submenu";
+import { Action, ActionDisplay } from "@/types/cms/actions";
 import type { Location, LocationUpdateInput } from "@/types/models/location.types";
 
 export const locationFields: FieldDef<Location>[] = [
@@ -46,7 +50,46 @@ export function toLocationUpdateInput(entity: Location): LocationUpdateInput {
 
 export function makeLocationColumns(options: {
     onEdit: (entity: Location) => void;
+    t: ReturnType<typeof useTranslations<"Cms.ActionsColumn">>;
 }): ColumnDef<Location>[] {
+    const { onEdit, t } = options;
+
+    const actions: Action<Location>[] = [
+        {
+            key: "edit",
+            label: t("edit", { label: "location" }),
+            icon: SquarePen,
+            display: ActionDisplay.Inline,
+            onClick: onEdit,
+        },
+        {
+            key: "copy-name",
+            label: t("copy", { key: "name" }),
+            onClick: async (location) => {
+                const value = location.name ?? "";
+                try {
+                    await navigator.clipboard.writeText(value);
+                    toast.success(t("copied", { key: "name" }));
+                } catch {
+                    toast.error(t("copyFailed"));
+                }
+            },
+        },
+        {
+            key: "add-to-collection",
+            render: (location, closeMenu) => (
+                <CollectionPickerSubmenu
+                    item={{
+                        contentId: location.id,
+                        contentType: "location",
+                        label: location.name || location.address || location.id,
+                    }}
+                    onComplete={closeMenu}
+                />
+            ),
+        },
+    ];
+
     return [
         { accessorKey: "name", header: "Name" },
         { accessorKey: "code", header: "Code" },
@@ -57,20 +100,6 @@ export function makeLocationColumns(options: {
             header: "Owned",
             cell: ({ getValue }) => <BooleanCell value={getValue<boolean | null>()} />,
         },
-        makeActionsColumn<Location>({
-            label: "location",
-            copyKey: "name",
-            onEdit: options.onEdit,
-            extraMenuItems: (location, closeMenu) => (
-                <CollectionPickerSubmenu
-                    item={{
-                        contentId: location.id,
-                        contentType: "location",
-                        label: location.name || location.address || location.id,
-                    }}
-                    onComplete={closeMenu}
-                />
-            ),
-        }),
+        makeActionsColumn<Location>({ actions }),
     ];
 }

--- a/frontend/src/app/[locale]/(cms)/cms/tables/locations/hall-columns.tsx
+++ b/frontend/src/app/[locale]/(cms)/cms/tables/locations/hall-columns.tsx
@@ -1,9 +1,13 @@
 "use client";
 
 import { ColumnDef } from "@tanstack/react-table";
+import { SquarePen } from "lucide-react";
+import { toast } from "sonner";
+import { useTranslations } from "next-intl";
 import { makeActionsColumn } from "../actions-column";
 import { BooleanCell } from "../boolean-cell";
 import type { FieldDef } from "../edit-sheet";
+import { Action, ActionDisplay } from "@/types/cms/actions";
 import type { Hall, HallUpdateInput } from "@/types/models/hall.types";
 
 export const hallFields: FieldDef<Hall>[] = [
@@ -33,7 +37,35 @@ export function toHallUpdateInput(entity: Hall): HallUpdateInput {
     };
 }
 
-export function makeHallColumns(options: { onEdit: (entity: Hall) => void }): ColumnDef<Hall>[] {
+export function makeHallColumns(options: {
+    onEdit: (entity: Hall) => void;
+    t: ReturnType<typeof useTranslations<"Cms.ActionsColumn">>;
+}): ColumnDef<Hall>[] {
+    const { onEdit, t } = options;
+
+    const actions: Action<Hall>[] = [
+        {
+            key: "edit",
+            label: t("edit", { label: "hall" }),
+            icon: SquarePen,
+            display: ActionDisplay.Inline,
+            onClick: onEdit,
+        },
+        {
+            key: "copy-name",
+            label: t("copy", { key: "name" }),
+            onClick: async (hall) => {
+                const value = hall.name ?? "";
+                try {
+                    await navigator.clipboard.writeText(value);
+                    toast.success(t("copied", { key: "name" }));
+                } catch {
+                    toast.error(t("copyFailed"));
+                }
+            },
+        },
+    ];
+
     return [
         { accessorKey: "name", header: "Name" },
         {
@@ -46,6 +78,6 @@ export function makeHallColumns(options: { onEdit: (entity: Hall) => void }): Co
             header: "Open seating",
             cell: ({ getValue }) => <BooleanCell value={getValue<boolean | null>()} />,
         },
-        makeActionsColumn<Hall>({ label: "hall", copyKey: "name", onEdit: options.onEdit }),
+        makeActionsColumn<Hall>({ actions }),
     ];
 }

--- a/frontend/src/app/[locale]/(cms)/cms/tables/locations/locations-table.tsx
+++ b/frontend/src/app/[locale]/(cms)/cms/tables/locations/locations-table.tsx
@@ -52,12 +52,17 @@ export function LocationsTable() {
         clearSelection,
     } = useParentChildSelection<Location>(hallsBySpace);
 
+    const tActions = useTranslations("Cms.ActionsColumn");
+
     const locationCols = useMemo(
-        () => [selectColumn, ...makeLocationColumns({ onEdit: setEditLocation })],
-        [selectColumn]
+        () => [selectColumn, ...makeLocationColumns({ onEdit: setEditLocation, t: tActions })],
+        [selectColumn, tActions]
     );
 
-    const hallCols = useMemo(() => makeHallColumns({ onEdit: setEditHall }), []);
+    const hallCols = useMemo(
+        () => makeHallColumns({ onEdit: setEditHall, t: tActions }),
+        [tActions]
+    );
 
     const expanderLabels = useMemo(() => ({ show: t("showHalls"), hide: t("hideHalls") }), [t]);
 
@@ -115,17 +120,16 @@ export function LocationsTable() {
                                 count: selectedLocationCount,
                                 inlineActions: [
                                     {
+                                        key: "add-locations-to-collection",
                                         label: tCollections("addToCollection"),
                                         onClick: () => setLocationDialogOpen(true),
                                     },
                                 ],
-                                overflowActions: [],
                             },
                             {
                                 countKey: "hallsSelected",
                                 count: selectedHallCount,
                                 inlineActions: [],
-                                overflowActions: [],
                             },
                         ]}
                         onClear={clearSelection}
@@ -150,7 +154,7 @@ export function LocationsTable() {
                 entity={editLocation}
                 fields={locationFields}
                 title={t("editLocation")}
-                onSave={(data) => updateLocation.mutate(toLocationUpdateInput(data))}
+                onSave={(data) => updateLocation.mutateAsync(toLocationUpdateInput(data))}
             />
             <EditSheet
                 open={!!editHall}
@@ -158,7 +162,7 @@ export function LocationsTable() {
                 entity={editHall}
                 fields={hallFields}
                 title={t("editHall")}
-                onSave={(data) => updateHall.mutate(toHallUpdateInput(data))}
+                onSave={(data) => updateHall.mutateAsync(toHallUpdateInput(data))}
             />
         </>
     );

--- a/frontend/src/app/[locale]/(cms)/cms/tables/productions/columns.tsx
+++ b/frontend/src/app/[locale]/(cms)/cms/tables/productions/columns.tsx
@@ -1,9 +1,13 @@
 "use client";
 
 import { ColumnDef } from "@tanstack/react-table";
+import { SquarePen } from "lucide-react";
+import { toast } from "sonner";
+import { useTranslations } from "next-intl";
 import { makeActionsColumn } from "../actions-column";
 import type { FieldDef } from "../edit-sheet";
 import { CollectionPickerSubmenu } from "@/components/cms/collection-picker-submenu";
+import { Action, ActionDisplay } from "@/types/cms/actions";
 import type {
     Production,
     ProductionRow,
@@ -135,7 +139,48 @@ export function toProductionUpdateInput(row: ProductionRow): ProductionUpdateInp
 
 export function makeProductionColumns(options: {
     onEdit: (row: ProductionRow) => void;
+    t: ReturnType<typeof useTranslations<"Cms.ActionsColumn">>;
 }): ColumnDef<Production>[] {
+    const { onEdit, t } = options;
+
+    const actions: Action<Production>[] = [
+        {
+            key: "edit",
+            label: t("edit", { label: "production" }),
+            icon: SquarePen,
+            display: ActionDisplay.Inline,
+            onClick: (p) => onEdit(toProductionRow(p)),
+        },
+        {
+            key: "copy-slug",
+            label: t("copy", { key: "slug" }),
+            onClick: async (p) => {
+                try {
+                    await navigator.clipboard.writeText(p.slug);
+                    toast.success(t("copied", { key: "slug" }));
+                } catch {
+                    toast.error(t("copyFailed"));
+                }
+            },
+        },
+        {
+            key: "add-to-collection",
+            render: (production, closeMenu) => (
+                <CollectionPickerSubmenu
+                    item={{
+                        contentId: production.id,
+                        contentType: "production",
+                        label:
+                            production.translations.find((t) => t.languageCode === "nl")?.title ??
+                            production.translations.find((t) => t.languageCode === "en")?.title ??
+                            production.slug,
+                    }}
+                    onComplete={closeMenu}
+                />
+            ),
+        },
+    ];
+
     return [
         {
             id: "titleNl",
@@ -154,23 +199,6 @@ export function makeProductionColumns(options: {
                 row.translations.find((t) => t.languageCode === "nl")?.artist ?? "",
         },
         { accessorKey: "slug", header: "Slug" },
-        makeActionsColumn<Production>({
-            label: "production",
-            copyKey: "slug",
-            onEdit: (p) => options.onEdit(toProductionRow(p)),
-            extraMenuItems: (production, closeMenu) => (
-                <CollectionPickerSubmenu
-                    item={{
-                        contentId: production.id,
-                        contentType: "production",
-                        label:
-                            production.translations.find((t) => t.languageCode === "nl")?.title ??
-                            production.translations.find((t) => t.languageCode === "en")?.title ??
-                            production.slug,
-                    }}
-                    onComplete={closeMenu}
-                />
-            ),
-        }),
+        makeActionsColumn<Production>({ actions }),
     ];
 }

--- a/frontend/src/app/[locale]/(cms)/cms/tables/productions/event-columns.tsx
+++ b/frontend/src/app/[locale]/(cms)/cms/tables/productions/event-columns.tsx
@@ -1,9 +1,13 @@
 "use client";
 
 import { ColumnDef } from "@tanstack/react-table";
+import { SquarePen } from "lucide-react";
+import { toast } from "sonner";
+import { useTranslations } from "next-intl";
 import { makeActionsColumn } from "../actions-column";
 import type { FieldDef } from "../edit-sheet";
 import { CollectionPickerSubmenu } from "@/components/cms/collection-picker-submenu";
+import { Action, ActionDisplay } from "@/types/cms/actions";
 import type { Event, EventUpdateInput } from "@/types/models/event.types";
 
 function formatDateTime(iso: string | null): string {
@@ -45,7 +49,48 @@ export function toEventUpdateInput(entity: Event): EventUpdateInput {
     };
 }
 
-export function makeEventColumns(options: { onEdit: (entity: Event) => void }): ColumnDef<Event>[] {
+export function makeEventColumns(options: {
+    onEdit: (entity: Event) => void;
+    t: ReturnType<typeof useTranslations<"Cms.ActionsColumn">>;
+}): ColumnDef<Event>[] {
+    const { onEdit, t } = options;
+
+    const actions: Action<Event>[] = [
+        {
+            key: "edit",
+            label: t("edit", { label: "event" }),
+            icon: SquarePen,
+            display: ActionDisplay.Inline,
+            onClick: onEdit,
+        },
+        {
+            key: "copy-id",
+            label: t("copy", { key: "ID" }),
+            onClick: async (e) => {
+                try {
+                    await navigator.clipboard.writeText(e.id);
+                    toast.success(t("copied", { key: "ID" }));
+                } catch {
+                    toast.error(t("copyFailed"));
+                }
+            },
+        },
+        {
+            key: "add-to-collection",
+            render: (event, closeMenu) => (
+                <CollectionPickerSubmenu
+                    item={{
+                        contentId: event.id,
+                        contentType: "event",
+                        label: formatDateTime(event.startsAt),
+                        parentProductionId: event.productionId,
+                    }}
+                    onComplete={closeMenu}
+                />
+            ),
+        },
+    ];
+
     return [
         {
             accessorKey: "startsAt",
@@ -59,21 +104,6 @@ export function makeEventColumns(options: { onEdit: (entity: Event) => void }): 
         },
         { accessorKey: "status", header: "Status" },
         { accessorKey: "hallId", header: "Hall" },
-        makeActionsColumn<Event>({
-            label: "event",
-            copyKey: "id",
-            onEdit: options.onEdit,
-            extraMenuItems: (event, closeMenu) => (
-                <CollectionPickerSubmenu
-                    item={{
-                        contentId: event.id,
-                        contentType: "event",
-                        label: formatDateTime(event.startsAt),
-                        parentProductionId: event.productionId,
-                    }}
-                    onComplete={closeMenu}
-                />
-            ),
-        }),
+        makeActionsColumn<Event>({ actions }),
     ];
 }

--- a/frontend/src/app/[locale]/(cms)/cms/tables/productions/productions-table.tsx
+++ b/frontend/src/app/[locale]/(cms)/cms/tables/productions/productions-table.tsx
@@ -53,12 +53,17 @@ export function ProductionsTable() {
         clearSelection,
     } = useParentChildSelection<Production>(eventsByProduction);
 
+    const tActions = useTranslations("Cms.ActionsColumn");
+
     const productionCols = useMemo(
-        () => [selectColumn, ...makeProductionColumns({ onEdit: setEditProduction })],
-        [selectColumn]
+        () => [selectColumn, ...makeProductionColumns({ onEdit: setEditProduction, t: tActions })],
+        [selectColumn, tActions]
     );
 
-    const eventCols = useMemo(() => makeEventColumns({ onEdit: setEditEvent }), []);
+    const eventCols = useMemo(
+        () => makeEventColumns({ onEdit: setEditEvent, t: tActions }),
+        [tActions]
+    );
 
     const expanderLabels = useMemo(() => ({ show: t("showEvents"), hide: t("hideEvents") }), [t]);
 
@@ -139,22 +144,22 @@ export function ProductionsTable() {
                                 count: selectedProductionCount,
                                 inlineActions: [
                                     {
+                                        key: "add-productions-to-collection",
                                         label: tCollections("addToCollection"),
                                         onClick: () => setProductionDialogOpen(true),
                                     },
                                 ],
-                                overflowActions: [],
                             },
                             {
                                 countKey: "eventsSelected",
                                 count: selectedEventCount,
                                 inlineActions: [
                                     {
+                                        key: "add-events-to-collection",
                                         label: tCollections("addToCollection"),
                                         onClick: () => setEventDialogOpen(true),
                                     },
                                 ],
-                                overflowActions: [],
                             },
                         ]}
                         onClear={clearSelection}
@@ -196,7 +201,7 @@ export function ProductionsTable() {
                 entity={editProduction}
                 fields={productionFields}
                 title={t("editProduction")}
-                onSave={(data) => updateProduction.mutate(toProductionUpdateInput(data))}
+                onSave={(data) => updateProduction.mutateAsync(toProductionUpdateInput(data))}
             />
             <EditSheet
                 open={!!editEvent}
@@ -204,7 +209,7 @@ export function ProductionsTable() {
                 entity={editEvent}
                 fields={eventFields}
                 title={t("editEvent")}
-                onSave={(data) => updateEvent.mutate(toEventUpdateInput(data))}
+                onSave={(data) => updateEvent.mutateAsync(toEventUpdateInput(data))}
             />
         </>
     );

--- a/frontend/src/app/[locale]/(cms)/cms/tables/selection-toolbar.tsx
+++ b/frontend/src/app/[locale]/(cms)/cms/tables/selection-toolbar.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { ReactNode } from "react";
 import { useTranslations } from "next-intl";
 import { X, MoreHorizontal } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -10,25 +9,13 @@ import {
     DropdownMenuItem,
     DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-
-export interface BulkAction {
-    label: string;
-    icon?: ReactNode;
-    onClick: () => void;
-    variant?: "default" | "destructive";
-}
-
-export type SelectionToolbarCountKey =
-    | "productionsSelected"
-    | "eventsSelected"
-    | "locationsSelected"
-    | "hallsSelected";
+import { ActionVariant, type BulkAction } from "@/types/cms/actions";
 
 export interface EntitySelectionGroup {
-    countKey: SelectionToolbarCountKey;
+    countKey: string;
     count: number;
     inlineActions: BulkAction[];
-    overflowActions: BulkAction[];
+    overflowActions?: BulkAction[];
 }
 
 interface SelectionToolbarProps {
@@ -44,50 +31,61 @@ export function SelectionToolbar({ groups, onClear }: SelectionToolbarProps) {
     // Always render so the toolbar area reserves space and the table never shifts.
     return (
         <div className="flex min-h-8 flex-wrap items-center gap-2">
-            {activeGroups.map((group, i) => (
-                <div key={group.countKey} className="contents">
-                    {i > 0 && <div className="bg-border h-5 w-px shrink-0" />}
-                    <span className="text-muted-foreground text-sm">
-                        {t(group.countKey, { count: group.count })}
-                    </span>
-                    {group.inlineActions.map((action) => (
-                        <Button
-                            key={action.label}
-                            variant={action.variant === "destructive" ? "destructive" : "outline"}
-                            size="sm"
-                            onClick={action.onClick}
-                        >
-                            {action.icon}
-                            {action.label}
-                        </Button>
-                    ))}
-                    {group.overflowActions.length > 0 && (
-                        <DropdownMenu>
-                            <DropdownMenuTrigger asChild>
-                                <Button variant="outline" size="sm" aria-label={t("moreActions")}>
-                                    <MoreHorizontal className="h-4 w-4" />
-                                </Button>
-                            </DropdownMenuTrigger>
-                            <DropdownMenuContent align="start">
-                                {group.overflowActions.map((action) => (
-                                    <DropdownMenuItem
-                                        key={action.label}
-                                        onClick={action.onClick}
-                                        className={
-                                            action.variant === "destructive"
-                                                ? "text-destructive"
-                                                : undefined
-                                        }
+            {activeGroups.map((group, i) => {
+                const overflow = group.overflowActions ?? [];
+                return (
+                    <div key={group.countKey} className="contents">
+                        {i > 0 && <div className="bg-border h-5 w-px shrink-0" />}
+                        <span className="text-muted-foreground text-sm">
+                            {t(group.countKey, { count: group.count })}
+                        </span>
+                        {group.inlineActions.map((action) => (
+                            <Button
+                                key={action.key}
+                                variant={
+                                    action.variant === ActionVariant.Destructive
+                                        ? "destructive"
+                                        : "outline"
+                                }
+                                size="sm"
+                                onClick={action.onClick}
+                            >
+                                {action.icon}
+                                {action.label}
+                            </Button>
+                        ))}
+                        {overflow.length > 0 && (
+                            <DropdownMenu>
+                                <DropdownMenuTrigger asChild>
+                                    <Button
+                                        variant="outline"
+                                        size="sm"
+                                        aria-label={t("moreActions")}
                                     >
-                                        {action.icon}
-                                        {action.label}
-                                    </DropdownMenuItem>
-                                ))}
-                            </DropdownMenuContent>
-                        </DropdownMenu>
-                    )}
-                </div>
-            ))}
+                                        <MoreHorizontal className="h-4 w-4" />
+                                    </Button>
+                                </DropdownMenuTrigger>
+                                <DropdownMenuContent align="start">
+                                    {overflow.map((action) => (
+                                        <DropdownMenuItem
+                                            key={action.key}
+                                            onClick={action.onClick}
+                                            className={
+                                                action.variant === ActionVariant.Destructive
+                                                    ? "text-destructive"
+                                                    : undefined
+                                            }
+                                        >
+                                            {action.icon}
+                                            {action.label}
+                                        </DropdownMenuItem>
+                                    ))}
+                                </DropdownMenuContent>
+                            </DropdownMenu>
+                        )}
+                    </div>
+                );
+            })}
             <Button variant="ghost" size="sm" onClick={onClear} className="ml-auto">
                 <X className="h-4 w-4" />
                 {t("clearSelection")}

--- a/frontend/src/types/cms/actions.ts
+++ b/frontend/src/types/cms/actions.ts
@@ -23,11 +23,20 @@ export type Action<T> =
     | {
           key: string;
           label: string;
+          icon: ComponentType<{ className?: string }>;
+          onClick: (entity: T) => void | Promise<void>;
+          variant?: ActionVariant;
+          /** Inline actions render as icon-only buttons and require an icon. */
+          display: ActionDisplay.Inline;
+      }
+    | {
+          key: string;
+          label: string;
           icon?: ComponentType<{ className?: string }>;
-          onClick: (entity: T) => void;
+          onClick: (entity: T) => void | Promise<void>;
           variant?: ActionVariant;
           /** Where to display the action. Defaults to `ActionDisplay.Menu`. */
-          display?: ActionDisplay;
+          display?: ActionDisplay.Menu;
       }
     | {
           key: string;

--- a/frontend/src/types/cms/actions.ts
+++ b/frontend/src/types/cms/actions.ts
@@ -1,0 +1,44 @@
+import type { ComponentType, ReactNode } from "react";
+
+export enum ActionDisplay {
+    Inline = "inline",
+    Menu = "menu",
+}
+
+export enum ActionVariant {
+    Default = "default",
+    Destructive = "destructive",
+}
+
+/**
+ * Discriminated union for row-level actions.
+ *
+ * - **Simple action**: has `label` + `onClick`. Rendered as a `DropdownMenuItem`
+ *   (default) or an icon button when `display: ActionDisplay.Inline`.
+ * - **Custom render action**: has `render`. The render function replaces the
+ *   `DropdownMenuItem` entirely, useful for complex UI like submenus.
+ *   Always rendered inside the dropdown menu.
+ */
+export type Action<T> =
+    | {
+          key: string;
+          label: string;
+          icon?: ComponentType<{ className?: string }>;
+          onClick: (entity: T) => void;
+          variant?: ActionVariant;
+          /** Where to display the action. Defaults to `ActionDisplay.Menu`. */
+          display?: ActionDisplay;
+      }
+    | {
+          key: string;
+          /** Custom render function for complex actions (e.g. submenus). */
+          render: (entity: T, closeMenu: () => void) => ReactNode;
+      };
+
+export interface BulkAction {
+    key: string;
+    label: string;
+    icon?: ReactNode;
+    onClick: () => void;
+    variant?: ActionVariant;
+}


### PR DESCRIPTION
Replaces the ad-hoc props on `makeActionsColumn` (`label`, `copyKey`, `onEdit`, `promotedActions`, `extraMenuItems`) with a single typed `Action<T>` discriminated union. Actions can be simple (label + onClick) or custom-rendered (for submenus), and can opt into inline display as icon buttons.

- New `Action<T>` and `BulkAction` types in `frontend/src/types/cms/actions.ts` with `ActionDisplay` and `ActionVariant` enums
- Migrated all entity tables (articles, collections, locations, halls, productions, events) to the new actions API
- Collections table now uses the shared `makeActionsColumn` instead of a one-off `CollectionActionsCell`
- `EditSheet.onSave` is now async: the sheet waits for the promise before closing and stays open on failure
- `EditSheet` forces a remount via `openCount` so reopening the same entity resets form state
- `SelectionToolbar` simplified: `overflowActions` is optional, `countKey` is a plain string
- Creating a new collection no longer auto-navigates to its detail page

**Related Issue**
Fixes #160 

**Developer Checklist:**
- [x] I have performed a self-review of my own code.
- [x] I have left comments in hard-to-understand areas of my code.
- [x] My changes generate no new warnings or console errors.
- [ ] I have updated the documentation (if applicable).

**Screenshots / Video (if UI/UX changed):**