### PR TITLE
feat(backend): add series schema and endpoints

### DIFF
--- a/backend/database/src/lib.rs
+++ b/backend/database/src/lib.rs
@@ -7,8 +7,8 @@ use crate::{
         article::ArticleRepo, artist::ArtistRepo, collection::CollectionRepo,
         event::EventRepo, hall::HallRepo, internal_state::InternalStateRepo,
         location::LocationRepo, media::MediaRepo, media_variant::MediaVariantRepo,
-        production::ProductionRepo, sessions::SessionRepo, space::SpaceRepo, tag::TagRepo,
-        user::UserRepo,
+        production::ProductionRepo, series::SeriesRepo, sessions::SessionRepo,
+        space::SpaceRepo, tag::TagRepo, user::UserRepo,
     },
 };
 
@@ -27,6 +27,7 @@ pub mod models {
     pub mod media;
     pub mod media_variant;
     pub mod production;
+    pub mod series;
     pub mod session;
     pub mod space;
     pub mod tag;
@@ -45,6 +46,7 @@ pub mod repos {
     pub mod media;
     pub mod media_variant;
     pub mod production;
+    pub mod series;
     pub mod sessions;
     pub mod space;
     pub mod tag;
@@ -124,6 +126,10 @@ impl Database {
 
     pub fn collections<'a>(&'a self) -> CollectionRepo<'a> {
         CollectionRepo::new(&self.db)
+    }
+
+    pub fn series<'a>(&'a self) -> SeriesRepo<'a> {
+        SeriesRepo::new(&self.db)
     }
 
     pub fn media<'a>(&'a self) -> MediaRepo<'a> {

--- a/backend/database/src/models/entity_type.rs
+++ b/backend/database/src/models/entity_type.rs
@@ -11,6 +11,7 @@ pub enum EntityType {
     Media,
     Location,
     Event,
+    Series,
 }
 
 impl EntityType {
@@ -21,6 +22,7 @@ impl EntityType {
             Self::Artist => Some("articles_about_artists"),
             Self::Location => Some("articles_about_locations"),
             Self::Event => Some("articles_about_events"),
+            Self::Series => Some("articles_about_series"),
             _ => None,
         }
     }
@@ -32,6 +34,7 @@ impl EntityType {
             Self::Artist => Some("artist_id"),
             Self::Location => Some("location_id"),
             Self::Event => Some("event_id"),
+            Self::Series => Some("series_id"),
             _ => None,
         }
     }

--- a/backend/database/src/models/series.rs
+++ b/backend/database/src/models/series.rs
@@ -1,0 +1,43 @@
+use chrono::{DateTime, Utc};
+use sqlx::FromRow;
+use uuid::Uuid;
+
+#[derive(Debug, FromRow, PartialEq)]
+pub struct Series {
+    pub id: Uuid,
+    pub slug: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+pub struct SeriesCreate {
+    pub slug: String,
+}
+
+#[derive(Debug, FromRow, PartialEq, Clone)]
+pub struct SeriesTranslation {
+    pub series_id: Uuid,
+    pub language_code: String,
+    pub name: String,
+    pub subtitle: String,
+    pub description: String,
+}
+
+pub struct SeriesTranslationData {
+    pub language_code: String,
+    pub name: String,
+    pub subtitle: String,
+    pub description: String,
+}
+
+pub struct SeriesWithTranslations {
+    pub series: Series,
+    pub translations: Vec<SeriesTranslation>,
+}
+
+#[derive(Debug, FromRow)]
+pub struct SeriesDerivedPeriod {
+    pub series_id: Uuid,
+    pub period_start: Option<DateTime<Utc>>,
+    pub period_end: Option<DateTime<Utc>>,
+}

--- a/backend/database/src/repos/series.rs
+++ b/backend/database/src/repos/series.rs
@@ -1,0 +1,339 @@
+use std::collections::HashMap;
+
+use sqlx::{FromRow, PgPool};
+use uuid::Uuid;
+
+use crate::{
+    error::DatabaseError,
+    models::series::{
+        Series, SeriesCreate, SeriesDerivedPeriod, SeriesTranslation, SeriesTranslationData,
+        SeriesWithTranslations,
+    },
+};
+
+#[derive(FromRow)]
+struct SeriesProductionRow {
+    series_id: Uuid,
+    production_id: Uuid,
+}
+
+pub struct SeriesRepo<'a> {
+    db: &'a PgPool,
+}
+
+impl<'a> SeriesRepo<'a> {
+    pub fn new(db: &'a PgPool) -> Self {
+        Self { db }
+    }
+
+    pub async fn all(&self) -> Result<Vec<SeriesWithTranslations>, DatabaseError> {
+        let all_series =
+            sqlx::query_as::<_, Series>("SELECT * FROM series ORDER BY created_at DESC")
+                .fetch_all(self.db)
+                .await?;
+
+        if all_series.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let ids: Vec<Uuid> = all_series.iter().map(|s| s.id).collect();
+        let all_translations = sqlx::query_as::<_, SeriesTranslation>(
+            "SELECT * FROM series_translations WHERE series_id = ANY($1)",
+        )
+        .bind(&ids[..])
+        .fetch_all(self.db)
+        .await?;
+
+        let mut translation_map: HashMap<Uuid, Vec<SeriesTranslation>> = HashMap::new();
+        for t in all_translations {
+            translation_map.entry(t.series_id).or_default().push(t);
+        }
+
+        Ok(all_series
+            .into_iter()
+            .map(|s| {
+                let translations = translation_map.remove(&s.id).unwrap_or_default();
+                SeriesWithTranslations {
+                    series: s,
+                    translations,
+                }
+            })
+            .collect())
+    }
+
+    pub async fn by_slug(
+        &self,
+        slug: &str,
+    ) -> Result<Option<SeriesWithTranslations>, DatabaseError> {
+        let Some(series) =
+            sqlx::query_as::<_, Series>("SELECT * FROM series WHERE slug = $1")
+                .bind(slug)
+                .fetch_optional(self.db)
+                .await?
+        else {
+            return Ok(None);
+        };
+
+        let translations = self.fetch_translations_for(series.id).await?;
+
+        Ok(Some(SeriesWithTranslations {
+            series,
+            translations,
+        }))
+    }
+
+    pub async fn insert(
+        &self,
+        data: SeriesCreate,
+        translations: Vec<SeriesTranslationData>,
+    ) -> Result<SeriesWithTranslations, DatabaseError> {
+        let series =
+            sqlx::query_as::<_, Series>("INSERT INTO series (slug) VALUES ($1) RETURNING *")
+                .bind(data.slug)
+                .fetch_one(self.db)
+                .await?;
+
+        self.upsert_translations(series.id, &translations).await?;
+        let translations = self.fetch_translations_for(series.id).await?;
+
+        Ok(SeriesWithTranslations {
+            series,
+            translations,
+        })
+    }
+
+    pub async fn update(
+        &self,
+        id: Uuid,
+        data: SeriesCreate,
+        translations: Vec<SeriesTranslationData>,
+    ) -> Result<Option<SeriesWithTranslations>, DatabaseError> {
+        let Some(series) = sqlx::query_as::<_, Series>(
+            "UPDATE series SET slug = $2, updated_at = NOW() WHERE id = $1 RETURNING *",
+        )
+        .bind(id)
+        .bind(data.slug)
+        .fetch_optional(self.db)
+        .await?
+        else {
+            return Ok(None);
+        };
+
+        self.upsert_translations(series.id, &translations).await?;
+        let translations = self.fetch_translations_for(series.id).await?;
+
+        Ok(Some(SeriesWithTranslations {
+            series,
+            translations,
+        }))
+    }
+
+    pub async fn delete_by_slug(&self, slug: &str) -> Result<Option<()>, DatabaseError> {
+        let res = sqlx::query("DELETE FROM series WHERE slug = $1")
+            .bind(slug)
+            .execute(self.db)
+            .await?;
+
+        if res.rows_affected() == 0 {
+            return Ok(None);
+        }
+
+        Ok(Some(()))
+    }
+
+    pub async fn production_ids_for(
+        &self,
+        series_id: Uuid,
+    ) -> Result<Vec<Uuid>, DatabaseError> {
+        let ids = sqlx::query_scalar::<_, Uuid>(
+            "SELECT production_id FROM series_productions WHERE series_id = $1",
+        )
+        .bind(series_id)
+        .fetch_all(self.db)
+        .await?;
+
+        Ok(ids)
+    }
+
+    pub async fn production_ids_for_many(
+        &self,
+        series_ids: &[Uuid],
+    ) -> Result<HashMap<Uuid, Vec<Uuid>>, DatabaseError> {
+        let rows = sqlx::query_as::<_, SeriesProductionRow>(
+            "SELECT series_id, production_id FROM series_productions WHERE series_id = ANY($1)",
+        )
+        .bind(series_ids)
+        .fetch_all(self.db)
+        .await?;
+
+        let mut map: HashMap<Uuid, Vec<Uuid>> = HashMap::new();
+        for row in rows {
+            map.entry(row.series_id)
+                .or_default()
+                .push(row.production_id);
+        }
+
+        Ok(map)
+    }
+
+    pub async fn series_for_production(
+        &self,
+        production_id: Uuid,
+    ) -> Result<Vec<SeriesWithTranslations>, DatabaseError> {
+        let all_series = sqlx::query_as::<_, Series>(
+            "SELECT s.* FROM series s
+             JOIN series_productions sp ON sp.series_id = s.id
+             WHERE sp.production_id = $1
+             ORDER BY s.created_at DESC",
+        )
+        .bind(production_id)
+        .fetch_all(self.db)
+        .await?;
+
+        if all_series.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let ids: Vec<Uuid> = all_series.iter().map(|s| s.id).collect();
+        let all_translations = sqlx::query_as::<_, SeriesTranslation>(
+            "SELECT * FROM series_translations WHERE series_id = ANY($1)",
+        )
+        .bind(&ids[..])
+        .fetch_all(self.db)
+        .await?;
+
+        let mut translation_map: HashMap<Uuid, Vec<SeriesTranslation>> = HashMap::new();
+        for t in all_translations {
+            translation_map.entry(t.series_id).or_default().push(t);
+        }
+
+        Ok(all_series
+            .into_iter()
+            .map(|s| {
+                let translations = translation_map.remove(&s.id).unwrap_or_default();
+                SeriesWithTranslations {
+                    series: s,
+                    translations,
+                }
+            })
+            .collect())
+    }
+
+    pub async fn add_productions(
+        &self,
+        series_id: Uuid,
+        production_ids: &[Uuid],
+    ) -> Result<(), DatabaseError> {
+        if production_ids.is_empty() {
+            return Ok(());
+        }
+
+        let series_ids_repeated: Vec<Uuid> = vec![series_id; production_ids.len()];
+
+        sqlx::query(
+            "INSERT INTO series_productions (series_id, production_id)
+             SELECT * FROM UNNEST($1::uuid[], $2::uuid[])
+             ON CONFLICT DO NOTHING",
+        )
+        .bind(&series_ids_repeated[..])
+        .bind(production_ids)
+        .execute(self.db)
+        .await?;
+
+        Ok(())
+    }
+
+    pub async fn remove_production(
+        &self,
+        series_id: Uuid,
+        production_id: Uuid,
+    ) -> Result<Option<()>, DatabaseError> {
+        let res = sqlx::query(
+            "DELETE FROM series_productions WHERE series_id = $1 AND production_id = $2",
+        )
+        .bind(series_id)
+        .bind(production_id)
+        .execute(self.db)
+        .await?;
+
+        if res.rows_affected() == 0 {
+            return Ok(None);
+        }
+
+        Ok(Some(()))
+    }
+
+    pub async fn derived_periods_for(
+        &self,
+        series_ids: &[Uuid],
+    ) -> Result<HashMap<Uuid, SeriesDerivedPeriod>, DatabaseError> {
+        let periods = sqlx::query_as::<_, SeriesDerivedPeriod>(
+            "SELECT sp.series_id,
+                    MIN(e.starts_at) AS period_start,
+                    MAX(COALESCE(e.ends_at, e.starts_at)) AS period_end
+             FROM series_productions sp
+             JOIN events e ON e.production_id = sp.production_id
+             WHERE sp.series_id = ANY($1)
+             GROUP BY sp.series_id",
+        )
+        .bind(series_ids)
+        .fetch_all(self.db)
+        .await?;
+
+        Ok(periods.into_iter().map(|p| (p.series_id, p)).collect())
+    }
+
+    async fn fetch_translations_for(
+        &self,
+        series_id: Uuid,
+    ) -> Result<Vec<SeriesTranslation>, DatabaseError> {
+        Ok(sqlx::query_as::<_, SeriesTranslation>(
+            "SELECT * FROM series_translations WHERE series_id = $1",
+        )
+        .bind(series_id)
+        .fetch_all(self.db)
+        .await?)
+    }
+
+    async fn upsert_translations(
+        &self,
+        series_id: Uuid,
+        translations: &[SeriesTranslationData],
+    ) -> Result<(), DatabaseError> {
+        if translations.is_empty() {
+            return Ok(());
+        }
+
+        let language_codes: Vec<&str> = translations
+            .iter()
+            .map(|t| t.language_code.as_str())
+            .collect();
+        let names: Vec<&str> = translations.iter().map(|t| t.name.as_str()).collect();
+        let subtitles: Vec<&str> = translations
+            .iter()
+            .map(|t| t.subtitle.as_str())
+            .collect();
+        let descriptions: Vec<&str> = translations
+            .iter()
+            .map(|t| t.description.as_str())
+            .collect();
+
+        sqlx::query(
+            "INSERT INTO series_translations (series_id, language_code, name, subtitle, description)
+             SELECT $1, * FROM UNNEST($2::text[], $3::text[], $4::text[], $5::text[])
+             ON CONFLICT (series_id, language_code) DO UPDATE SET
+                 name        = EXCLUDED.name,
+                 subtitle    = EXCLUDED.subtitle,
+                 description = EXCLUDED.description",
+        )
+        .bind(series_id)
+        .bind(&language_codes[..])
+        .bind(&names[..])
+        .bind(&subtitles[..])
+        .bind(&descriptions[..])
+        .execute(self.db)
+        .await?;
+
+        Ok(())
+    }
+}

--- a/backend/database/src/repos/series.rs
+++ b/backend/database/src/repos/series.rs
@@ -128,6 +128,29 @@ impl<'a> SeriesRepo<'a> {
         }))
     }
 
+    pub async fn slug_exists(&self, slug: &str) -> Result<bool, DatabaseError> {
+        Ok(
+            sqlx::query_scalar::<_, bool>("SELECT EXISTS(SELECT 1 FROM series WHERE slug = $1)")
+                .bind(slug)
+                .fetch_one(self.db)
+                .await?,
+        )
+    }
+
+    pub async fn slug_exists_excluding(
+        &self,
+        slug: &str,
+        exclude_id: Uuid,
+    ) -> Result<bool, DatabaseError> {
+        Ok(sqlx::query_scalar::<_, bool>(
+            "SELECT EXISTS(SELECT 1 FROM series WHERE slug = $1 AND id != $2)",
+        )
+        .bind(slug)
+        .bind(exclude_id)
+        .fetch_one(self.db)
+        .await?)
+    }
+
     pub async fn delete_by_slug(&self, slug: &str) -> Result<Option<()>, DatabaseError> {
         let res = sqlx::query("DELETE FROM series WHERE slug = $1")
             .bind(slug)
@@ -226,6 +249,19 @@ impl<'a> SeriesRepo<'a> {
     ) -> Result<(), DatabaseError> {
         if production_ids.is_empty() {
             return Ok(());
+        }
+
+        let found_count = sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM productions WHERE id = ANY($1)",
+        )
+        .bind(production_ids)
+        .fetch_one(self.db)
+        .await?;
+
+        if found_count != production_ids.len() as i64 {
+            return Err(DatabaseError::BadRequest(
+                "One or more production IDs do not exist".to_string(),
+            ));
         }
 
         let series_ids_repeated: Vec<Uuid> = vec![series_id; production_ids.len()];

--- a/backend/migrations/20260404000000_series.down.sql
+++ b/backend/migrations/20260404000000_series.down.sql
@@ -1,0 +1,5 @@
+DROP TABLE IF EXISTS articles_about_series;
+DROP TABLE IF EXISTS series_productions;
+DROP TABLE IF EXISTS series_translations;
+DROP TABLE IF EXISTS series;
+-- Note: PostgreSQL cannot remove enum values. 'series' in entity_type remains unused.

--- a/backend/migrations/20260404000000_series.down.sql
+++ b/backend/migrations/20260404000000_series.down.sql
@@ -1,5 +1,4 @@
-DROP TABLE IF EXISTS articles_about_series;
-DROP TABLE IF EXISTS series_productions;
-DROP TABLE IF EXISTS series_translations;
-DROP TABLE IF EXISTS series;
--- Note: PostgreSQL cannot remove enum values. 'series' in entity_type remains unused.
+DROP TABLE articles_about_series;
+DROP TABLE series_productions;
+DROP TABLE series_translations;
+DROP TABLE series;

--- a/backend/migrations/20260404000000_series.up.sql
+++ b/backend/migrations/20260404000000_series.up.sql
@@ -1,0 +1,38 @@
+-- series table
+CREATE TABLE series (
+    id         UUID PRIMARY KEY DEFAULT uuidv7(),
+    slug       TEXT NOT NULL UNIQUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- translations (follows collection_translations pattern)
+CREATE TABLE series_translations (
+    series_id     UUID NOT NULL REFERENCES series(id) ON DELETE CASCADE,
+    language_code TEXT NOT NULL REFERENCES languages(code),
+    name          TEXT NOT NULL DEFAULT '',
+    subtitle      TEXT NOT NULL DEFAULT '',
+    description   TEXT NOT NULL DEFAULT '',
+    PRIMARY KEY (series_id, language_code)
+);
+CREATE INDEX ON series_translations (series_id);
+
+-- many-to-many join (no position — ordering by event dates)
+CREATE TABLE series_productions (
+    series_id     UUID NOT NULL REFERENCES series(id)      ON DELETE CASCADE,
+    production_id UUID NOT NULL REFERENCES productions(id) ON DELETE CASCADE,
+    PRIMARY KEY (series_id, production_id)
+);
+CREATE INDEX ON series_productions (production_id);
+
+-- article relation (follows articles_about_productions pattern)
+CREATE TABLE articles_about_series (
+    article_id UUID NOT NULL REFERENCES articles(id) ON DELETE CASCADE,
+    series_id  UUID NOT NULL REFERENCES series(id)    ON DELETE CASCADE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (article_id, series_id)
+);
+CREATE INDEX ON articles_about_series (series_id);
+
+-- extend entity_type enum for media support
+ALTER TYPE entity_type ADD VALUE IF NOT EXISTS 'series';

--- a/backend/migrations/20260404000000_series.up.sql
+++ b/backend/migrations/20260404000000_series.up.sql
@@ -1,4 +1,3 @@
--- series table
 CREATE TABLE series (
     id         UUID PRIMARY KEY DEFAULT uuidv7(),
     slug       TEXT NOT NULL UNIQUE,
@@ -6,7 +5,6 @@ CREATE TABLE series (
     updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
--- translations (follows collection_translations pattern)
 CREATE TABLE series_translations (
     series_id     UUID NOT NULL REFERENCES series(id) ON DELETE CASCADE,
     language_code TEXT NOT NULL REFERENCES languages(code),
@@ -17,7 +15,6 @@ CREATE TABLE series_translations (
 );
 CREATE INDEX ON series_translations (series_id);
 
--- many-to-many join (no position — ordering by event dates)
 CREATE TABLE series_productions (
     series_id     UUID NOT NULL REFERENCES series(id)      ON DELETE CASCADE,
     production_id UUID NOT NULL REFERENCES productions(id) ON DELETE CASCADE,
@@ -25,7 +22,6 @@ CREATE TABLE series_productions (
 );
 CREATE INDEX ON series_productions (production_id);
 
--- article relation (follows articles_about_productions pattern)
 CREATE TABLE articles_about_series (
     article_id UUID NOT NULL REFERENCES articles(id) ON DELETE CASCADE,
     series_id  UUID NOT NULL REFERENCES series(id)    ON DELETE CASCADE,
@@ -34,5 +30,4 @@ CREATE TABLE articles_about_series (
 );
 CREATE INDEX ON articles_about_series (series_id);
 
--- extend entity_type enum for media support
 ALTER TYPE entity_type ADD VALUE IF NOT EXISTS 'series';

--- a/backend/src/dto/mod.rs
+++ b/backend/src/dto/mod.rs
@@ -8,4 +8,5 @@ pub mod location;
 pub mod paginated;
 pub mod media;
 pub mod production;
+pub mod series;
 pub mod space;

--- a/backend/src/dto/series.rs
+++ b/backend/src/dto/series.rs
@@ -158,6 +158,17 @@ impl SeriesPayload {
     }
 
     pub async fn update(self, db: &Database) -> Result<Self, AppError> {
+        if db
+            .series()
+            .slug_exists_excluding(&self.slug, self.id)
+            .await?
+        {
+            return Err(AppError::Conflict(format!(
+                "slug '{}' is already taken",
+                self.slug
+            )));
+        }
+
         let translations = translations_to_data(&self.translations);
         let swt = db
             .series()
@@ -188,6 +199,13 @@ impl SeriesPayload {
 
 impl SeriesPostPayload {
     pub async fn create(self, db: &Database) -> Result<SeriesPayload, AppError> {
+        if db.series().slug_exists(&self.slug).await? {
+            return Err(AppError::Conflict(format!(
+                "slug '{}' is already taken",
+                self.slug
+            )));
+        }
+
         let translations = translations_to_data(&self.translations);
         let swt = db
             .series()

--- a/backend/src/dto/series.rs
+++ b/backend/src/dto/series.rs
@@ -1,0 +1,198 @@
+use chrono::{DateTime, Utc};
+use database::{
+    Database,
+    models::series::{SeriesCreate, SeriesTranslationData, SeriesWithTranslations},
+};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use crate::error::AppError;
+
+#[derive(Serialize, Deserialize, ToSchema)]
+pub struct SeriesTranslationPayload {
+    pub language_code: String,
+    pub name: String,
+    pub subtitle: String,
+    pub description: String,
+}
+
+#[derive(Serialize, Deserialize, ToSchema)]
+pub struct SeriesPayload {
+    pub id: Uuid,
+    pub slug: String,
+    pub translations: Vec<SeriesTranslationPayload>,
+    pub production_ids: Vec<Uuid>,
+    pub period_start: Option<DateTime<Utc>>,
+    pub period_end: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Serialize, Deserialize, ToSchema)]
+pub struct SeriesPostPayload {
+    pub slug: String,
+    pub translations: Vec<SeriesTranslationPayload>,
+}
+
+#[derive(Serialize, Deserialize, ToSchema)]
+pub struct SeriesProductionsPayload {
+    pub production_ids: Vec<Uuid>,
+}
+
+fn translations_to_data(translations: &[SeriesTranslationPayload]) -> Vec<SeriesTranslationData> {
+    translations
+        .iter()
+        .map(|t| SeriesTranslationData {
+            language_code: t.language_code.clone(),
+            name: t.name.clone(),
+            subtitle: t.subtitle.clone(),
+            description: t.description.clone(),
+        })
+        .collect()
+}
+
+fn build_payload(
+    swt: SeriesWithTranslations,
+    production_ids: Vec<Uuid>,
+    period_start: Option<DateTime<Utc>>,
+    period_end: Option<DateTime<Utc>>,
+) -> SeriesPayload {
+    SeriesPayload {
+        id: swt.series.id,
+        slug: swt.series.slug,
+        translations: swt
+            .translations
+            .into_iter()
+            .map(|t| SeriesTranslationPayload {
+                language_code: t.language_code,
+                name: t.name,
+                subtitle: t.subtitle,
+                description: t.description,
+            })
+            .collect(),
+        production_ids,
+        period_start,
+        period_end,
+        created_at: swt.series.created_at,
+        updated_at: swt.series.updated_at,
+    }
+}
+
+impl SeriesPayload {
+    pub async fn all(db: &Database) -> Result<Vec<Self>, AppError> {
+        let all_series = db.series().all().await?;
+
+        if all_series.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let ids: Vec<Uuid> = all_series.iter().map(|s| s.series.id).collect();
+        let mut production_map = db.series().production_ids_for_many(&ids).await?;
+        let mut period_map = db.series().derived_periods_for(&ids).await?;
+
+        Ok(all_series
+            .into_iter()
+            .map(|swt| {
+                let id = swt.series.id;
+                let prod_ids = production_map.remove(&id).unwrap_or_default();
+                let period = period_map.remove(&id);
+                build_payload(
+                    swt,
+                    prod_ids,
+                    period.as_ref().and_then(|p| p.period_start),
+                    period.as_ref().and_then(|p| p.period_end),
+                )
+            })
+            .collect())
+    }
+
+    pub async fn by_slug(db: &Database, slug: &str) -> Result<Self, AppError> {
+        let swt = db
+            .series()
+            .by_slug(slug)
+            .await?
+            .ok_or(AppError::NotFound)?;
+
+        let id = swt.series.id;
+        let production_ids = db.series().production_ids_for(id).await?;
+        let period_map = db.series().derived_periods_for(&[id]).await?;
+        let period = period_map.get(&id);
+
+        Ok(build_payload(
+            swt,
+            production_ids,
+            period.and_then(|p| p.period_start),
+            period.and_then(|p| p.period_end),
+        ))
+    }
+
+    pub async fn for_production(
+        db: &Database,
+        production_id: Uuid,
+    ) -> Result<Vec<Self>, AppError> {
+        let all_series = db.series().series_for_production(production_id).await?;
+
+        if all_series.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let ids: Vec<Uuid> = all_series.iter().map(|s| s.series.id).collect();
+        let mut production_map = db.series().production_ids_for_many(&ids).await?;
+        let mut period_map = db.series().derived_periods_for(&ids).await?;
+
+        Ok(all_series
+            .into_iter()
+            .map(|swt| {
+                let id = swt.series.id;
+                let prod_ids = production_map.remove(&id).unwrap_or_default();
+                let period = period_map.remove(&id);
+                build_payload(
+                    swt,
+                    prod_ids,
+                    period.as_ref().and_then(|p| p.period_start),
+                    period.as_ref().and_then(|p| p.period_end),
+                )
+            })
+            .collect())
+    }
+
+    pub async fn update(self, db: &Database) -> Result<Self, AppError> {
+        let translations = translations_to_data(&self.translations);
+        let swt = db
+            .series()
+            .update(self.id, SeriesCreate { slug: self.slug }, translations)
+            .await?
+            .ok_or(AppError::NotFound)?;
+
+        let id = swt.series.id;
+        let production_ids = db.series().production_ids_for(id).await?;
+        let period_map = db.series().derived_periods_for(&[id]).await?;
+        let period = period_map.get(&id);
+
+        Ok(build_payload(
+            swt,
+            production_ids,
+            period.and_then(|p| p.period_start),
+            period.and_then(|p| p.period_end),
+        ))
+    }
+
+    pub async fn delete(db: &Database, slug: &str) -> Result<(), AppError> {
+        db.series()
+            .delete_by_slug(slug)
+            .await?
+            .ok_or(AppError::NotFound)
+    }
+}
+
+impl SeriesPostPayload {
+    pub async fn create(self, db: &Database) -> Result<SeriesPayload, AppError> {
+        let translations = translations_to_data(&self.translations);
+        let swt = db
+            .series()
+            .insert(SeriesCreate { slug: self.slug }, translations)
+            .await?;
+        Ok(build_payload(swt, vec![], None, None))
+    }
+}

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -14,6 +14,7 @@ pub mod hall;
 pub mod location;
 pub mod media;
 pub mod production;
+pub mod series;
 pub mod space;
 pub mod taxonomy;
 pub mod version;

--- a/backend/src/handlers/series.rs
+++ b/backend/src/handlers/series.rs
@@ -1,0 +1,197 @@
+use axum::{Json, extract::Path, http::StatusCode};
+use database::Database;
+use uuid::Uuid;
+
+use crate::{
+    dto::series::{SeriesPayload, SeriesPostPayload, SeriesProductionsPayload},
+    error::{AppError, ErrorResponse},
+    handlers::{IntoApiResponse, JsonResponse, JsonStatusResponse, StatusResponse},
+};
+
+#[utoipa::path(
+    method(get),
+    path = "/series",
+    tag = "Series",
+    operation_id = "get_all_series",
+    description = "Return all series with translations, production IDs, and derived period. Public endpoint, no authentication required.",
+    responses(
+        (status = 200, description = "Success", body = [SeriesPayload])
+    )
+)]
+pub async fn get_all(db: Database) -> JsonResponse<Vec<SeriesPayload>> {
+    SeriesPayload::all(&db).await?.json()
+}
+
+#[utoipa::path(
+    method(get),
+    path = "/series/{slug}",
+    tag = "Series",
+    operation_id = "get_one_series",
+    description = "Return a single series by its slug, including translations, production IDs, and derived period. Public endpoint, no authentication required.",
+    params(
+        ("slug" = String, Path, description = "Series slug")
+    ),
+    responses(
+        (status = 200, description = "Success", body = SeriesPayload),
+        (status = 404, description = "Not found")
+    )
+)]
+pub async fn get_one(db: Database, Path(slug): Path<String>) -> JsonResponse<SeriesPayload> {
+    SeriesPayload::by_slug(&db, &slug).await?.json()
+}
+
+#[utoipa::path(
+    method(get),
+    path = "/productions/{id}/series",
+    tag = "Series",
+    operation_id = "get_series_for_production",
+    description = "Return all series that contain the given production. Public endpoint, no authentication required.",
+    params(
+        ("id" = Uuid, Path, description = "Production UUID")
+    ),
+    responses(
+        (status = 200, description = "Success", body = [SeriesPayload])
+    )
+)]
+pub async fn get_for_production(
+    db: Database,
+    Path(id): Path<Uuid>,
+) -> JsonResponse<Vec<SeriesPayload>> {
+    SeriesPayload::for_production(&db, id).await?.json()
+}
+
+#[utoipa::path(
+    method(post),
+    path = "/series",
+    tag = "Series",
+    operation_id = "create_series",
+    description = "Create a new series. Requires editor authentication. Supply a slug and per-language translations (name, subtitle, description). Productions are added separately via POST /series/{slug}/productions.",
+    responses(
+        (status = 201, description = "Created", body = SeriesPayload),
+        (status = 401, description = "Unauthorized", body = ErrorResponse)
+    ),
+    security(
+        ("cookie_auth" = [])
+    )
+)]
+pub async fn post(
+    db: Database,
+    Json(series): Json<SeriesPostPayload>,
+) -> JsonStatusResponse<SeriesPayload> {
+    series.create(&db).await?.json_created()
+}
+
+#[utoipa::path(
+    method(put),
+    path = "/series",
+    tag = "Series",
+    operation_id = "update_series",
+    description = "Update the metadata (slug, translations) of an existing series. Requires editor authentication. Does not affect production membership.",
+    responses(
+        (status = 200, description = "Success", body = SeriesPayload),
+        (status = 404, description = "Not found"),
+        (status = 401, description = "Unauthorized", body = ErrorResponse)
+    ),
+    security(
+        ("cookie_auth" = [])
+    )
+)]
+pub async fn put(db: Database, Json(series): Json<SeriesPayload>) -> JsonResponse<SeriesPayload> {
+    series.update(&db).await?.json()
+}
+
+#[utoipa::path(
+    method(delete),
+    path = "/series/{slug}",
+    tag = "Series",
+    operation_id = "delete_series",
+    description = "Permanently delete a series. Requires editor authentication. Productions are not affected.",
+    params(
+        ("slug" = String, Path, description = "Series slug")
+    ),
+    responses(
+        (status = 204, description = "No Content"),
+        (status = 404, description = "Not found"),
+        (status = 401, description = "Unauthorized", body = ErrorResponse)
+    ),
+    security(
+        ("cookie_auth" = [])
+    )
+)]
+pub async fn delete(db: Database, Path(slug): Path<String>) -> StatusResponse {
+    SeriesPayload::delete(&db, &slug).await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+#[utoipa::path(
+    method(post),
+    path = "/series/{slug}/productions",
+    tag = "Series",
+    operation_id = "add_productions_to_series",
+    description = "Add one or more productions to a series. Requires editor authentication. Duplicates are silently ignored.",
+    params(
+        ("slug" = String, Path, description = "Series slug")
+    ),
+    responses(
+        (status = 200, description = "Success", body = SeriesPayload),
+        (status = 404, description = "Not found"),
+        (status = 401, description = "Unauthorized", body = ErrorResponse)
+    ),
+    security(
+        ("cookie_auth" = [])
+    )
+)]
+pub async fn add_productions(
+    db: Database,
+    Path(slug): Path<String>,
+    Json(payload): Json<SeriesProductionsPayload>,
+) -> JsonResponse<SeriesPayload> {
+    let swt = db
+        .series()
+        .by_slug(&slug)
+        .await?
+        .ok_or(AppError::NotFound)?;
+
+    db.series()
+        .add_productions(swt.series.id, &payload.production_ids)
+        .await?;
+
+    SeriesPayload::by_slug(&db, &slug).await?.json()
+}
+
+#[utoipa::path(
+    method(delete),
+    path = "/series/{slug}/productions/{production_id}",
+    tag = "Series",
+    operation_id = "remove_production_from_series",
+    description = "Remove a production from a series. Requires editor authentication. The production itself is not deleted.",
+    params(
+        ("slug" = String, Path, description = "Series slug"),
+        ("production_id" = Uuid, Path, description = "Production UUID")
+    ),
+    responses(
+        (status = 204, description = "No Content"),
+        (status = 404, description = "Not found"),
+        (status = 401, description = "Unauthorized", body = ErrorResponse)
+    ),
+    security(
+        ("cookie_auth" = [])
+    )
+)]
+pub async fn remove_production(
+    db: Database,
+    Path((slug, production_id)): Path<(String, Uuid)>,
+) -> StatusResponse {
+    let swt = db
+        .series()
+        .by_slug(&slug)
+        .await?
+        .ok_or(AppError::NotFound)?;
+
+    db.series()
+        .remove_production(swt.series.id, production_id)
+        .await?
+        .ok_or(AppError::NotFound)?;
+
+    Ok(StatusCode::NO_CONTENT)
+}

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -22,8 +22,8 @@ use utoipa_swagger_ui::{Config, SwaggerUi};
 use crate::config::AppConfig;
 use crate::error::AppError;
 use crate::handlers::{
-    admin, article, artist, auth, collection, event, hall, location, media, production, space,
-    taxonomy, version,
+    admin, article, artist, auth, collection, event, hall, location, media, production, series,
+    space, taxonomy, version,
 };
 
 pub mod config;
@@ -45,7 +45,8 @@ pub struct AppState {
     components(schemas(EntityType, Facet)),
     tags(
         (name = "viernulvier_api", description = "API Endpoints"),
-        (name = "Collections", description = "A saved, titled selection of archive items with a shareable URL. No login required to view.")
+        (name = "Collections", description = "A saved, titled selection of archive items with a shareable URL. No login required to view."),
+        (name = "Series", description = "Thematic/programmatic groupings of productions.")
     )
 )]
 pub struct ApiDoc;
@@ -243,6 +244,10 @@ fn public_routes() -> OpenApiRouter<AppState> {
         // collections
         .routes(routes!(collection::get_all))
         .routes(routes!(collection::get_one))
+        // series
+        .routes(routes!(series::get_all))
+        .routes(routes!(series::get_one))
+        .routes(routes!(series::get_for_production))
         // artists
         .routes(routes!(artist::get_all))
         // articles (public: published only, filterable)
@@ -282,6 +287,12 @@ fn editor_routes(state: AppState) -> OpenApiRouter<AppState> {
         .routes(routes!(collection::post_item))
         .routes(routes!(collection::put_items))
         .routes(routes!(collection::delete_item))
+        // Series
+        .routes(routes!(series::post))
+        .routes(routes!(series::put))
+        .routes(routes!(series::delete))
+        .routes(routes!(series::add_productions))
+        .routes(routes!(series::remove_production))
         // Media
         .routes(routes!(media::generate_upload_url))
         .routes(routes!(media::put))

--- a/backend/tests/fixtures/series.sql
+++ b/backend/tests/fixtures/series.sql
@@ -1,0 +1,14 @@
+INSERT INTO series (id, slug) VALUES
+('a0000000-0000-0000-0000-000000000001', 'palmarium'),
+('a0000000-0000-0000-0000-000000000002', 'fresh-juice');
+
+INSERT INTO series_translations (series_id, language_code, name, subtitle, description) VALUES
+('a0000000-0000-0000-0000-000000000001', 'nl', 'Palmarium', 'Concertreeks in de plantentuin', 'De jaarlijkse concertreeks.'),
+('a0000000-0000-0000-0000-000000000001', 'en', 'Palmarium', 'Concert series in the botanical garden', 'The annual concert series.'),
+('a0000000-0000-0000-0000-000000000002', 'nl', 'Fresh Juice', 'Nieuw talent', ''),
+('a0000000-0000-0000-0000-000000000002', 'en', 'Fresh Juice', 'New talent', '');
+
+INSERT INTO series_productions (series_id, production_id) VALUES
+('a0000000-0000-0000-0000-000000000001', '11111111-1111-1111-1111-111111111111'),
+('a0000000-0000-0000-0000-000000000001', '22222222-2222-2222-2222-222222222222'),
+('a0000000-0000-0000-0000-000000000002', '11111111-1111-1111-1111-111111111111');

--- a/backend/tests/series.rs
+++ b/backend/tests/series.rs
@@ -1,0 +1,492 @@
+use axum::http::StatusCode;
+use serde_json::json;
+use sqlx::PgPool;
+use uuid::Uuid;
+use viernulvier_api::dto::series::{SeriesPayload, SeriesPostPayload, SeriesProductionsPayload};
+
+use crate::common::{into_struct::IntoStruct, router::TestRouter};
+
+mod common;
+
+// ── GET /series ─────────────────────────────────────────────────────
+
+#[sqlx::test(fixtures("events", "series"))]
+#[test_log::test]
+async fn get_all(db: PgPool) {
+    let app = TestRouter::new(db);
+    let response = app.get("/series").await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let data: Vec<SeriesPayload> = response.into_struct().await;
+    assert_eq!(data.len(), 2);
+
+    for series in &data {
+        assert!(!series.translations.is_empty());
+        assert_eq!(series.translations.len(), 2);
+        assert!(!series.production_ids.is_empty());
+        assert!(series.period_start.is_some());
+        assert!(series.period_end.is_some());
+    }
+}
+
+// ── GET /series/{slug} ──────────────────────────────────────────────
+
+#[sqlx::test(fixtures("events", "series"))]
+#[test_log::test]
+async fn get_one_success(db: PgPool) {
+    let app = TestRouter::new(db);
+    let response = app.get("/series/palmarium").await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let data: SeriesPayload = response.into_struct().await;
+    assert_eq!(data.slug, "palmarium");
+    assert_eq!(data.production_ids.len(), 2);
+
+    let nl = data
+        .translations
+        .iter()
+        .find(|t| t.language_code == "nl")
+        .expect("Dutch translation not found");
+    assert_eq!(nl.name, "Palmarium");
+    assert_eq!(nl.subtitle, "Concertreeks in de plantentuin");
+
+    assert!(data.period_start.is_some());
+    assert!(data.period_end.is_some());
+}
+
+#[sqlx::test]
+#[test_log::test]
+async fn get_one_not_found(db: PgPool) {
+    let app = TestRouter::new(db);
+    let response = app.get("/series/nonexistent").await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+// ── GET /productions/{id}/series ────────────────────────────────────
+
+#[sqlx::test(fixtures("events", "series"))]
+#[test_log::test]
+async fn get_series_for_production(db: PgPool) {
+    let app = TestRouter::new(db);
+    let production_id = "11111111-1111-1111-1111-111111111111";
+
+    let response = app
+        .get(&format!("/productions/{production_id}/series"))
+        .await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let data: Vec<SeriesPayload> = response.into_struct().await;
+    assert_eq!(data.len(), 2);
+
+    let mut slugs: Vec<&str> = data.iter().map(|s| s.slug.as_str()).collect();
+    slugs.sort();
+    assert_eq!(slugs, vec!["fresh-juice", "palmarium"]);
+}
+
+#[sqlx::test(fixtures("events", "series"))]
+#[test_log::test]
+async fn get_series_for_production_empty(db: PgPool) {
+    let app = TestRouter::new(db);
+    let response = app
+        .get(&format!("/productions/{}/series", Uuid::nil()))
+        .await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let data: Vec<SeriesPayload> = response.into_struct().await;
+    assert!(data.is_empty());
+}
+
+// ── POST /series ────────────────────────────────────────────────────
+
+#[sqlx::test]
+#[test_log::test]
+async fn post_success(db: PgPool) {
+    let unauthenticated_app = TestRouter::new(db.clone());
+    let payload = mock_post_payload();
+
+    let unauthenticated_response = unauthenticated_app.post("/series", &payload).await;
+    assert_eq!(unauthenticated_response.status(), StatusCode::UNAUTHORIZED);
+
+    let app = TestRouter::as_editor(db).await;
+
+    let response = app.post("/series", &payload).await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let data: SeriesPayload = response.into_struct().await;
+    assert_eq!(data.slug, "test-reeks");
+    assert!(data.production_ids.is_empty());
+    assert!(data.period_start.is_none());
+    assert!(data.period_end.is_none());
+    assert!(!data.id.is_nil());
+
+    let nl = data
+        .translations
+        .iter()
+        .find(|t| t.language_code == "nl")
+        .expect("Dutch translation not found");
+    assert_eq!(nl.name, "Test Reeks");
+    assert_eq!(nl.subtitle, "Ondertitel");
+}
+
+// ── PUT /series ─────────────────────────────────────────────────────
+
+#[sqlx::test(fixtures("events", "series"))]
+#[test_log::test]
+async fn put_success(db: PgPool) {
+    let unauthenticated_app = TestRouter::new(db.clone());
+
+    let get_response = unauthenticated_app.get("/series/palmarium").await;
+    let original: SeriesPayload = get_response.into_struct().await;
+
+    let app = TestRouter::as_editor(db).await;
+
+    let update_payload: SeriesPayload = serde_json::from_value(json!({
+        "id": original.id,
+        "slug": "palmarium-updated",
+        "translations": [
+            { "language_code": "nl", "name": "Palmarium (bijgewerkt)", "subtitle": "", "description": "" },
+            { "language_code": "en", "name": "Palmarium (updated)", "subtitle": "", "description": "" }
+        ],
+        "production_ids": [],
+        "period_start": null,
+        "period_end": null,
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-01-01T00:00:00Z"
+    }))
+    .expect("Failed to deserialize SeriesPayload");
+
+    let unauthenticated_response = unauthenticated_app.put("/series", &update_payload).await;
+    assert_eq!(unauthenticated_response.status(), StatusCode::UNAUTHORIZED);
+
+    let response = app.put("/series", &update_payload).await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let data: SeriesPayload = response.into_struct().await;
+    assert_eq!(data.slug, "palmarium-updated");
+    let nl = data
+        .translations
+        .iter()
+        .find(|t| t.language_code == "nl")
+        .expect("Dutch translation not found");
+    assert_eq!(nl.name, "Palmarium (bijgewerkt)");
+
+    assert_eq!(data.production_ids.len(), 2);
+    assert!(data.period_start.is_some());
+}
+
+#[sqlx::test]
+#[test_log::test]
+async fn put_not_found(db: PgPool) {
+    let app = TestRouter::as_editor(db).await;
+
+    let missing: SeriesPayload = serde_json::from_value(json!({
+        "id": Uuid::nil(),
+        "slug": "missing",
+        "translations": [
+            { "language_code": "nl", "name": "Missing", "subtitle": "", "description": "" }
+        ],
+        "production_ids": [],
+        "period_start": null,
+        "period_end": null,
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-01-01T00:00:00Z"
+    }))
+    .expect("Failed to deserialize SeriesPayload");
+
+    let response = app.put("/series", &missing).await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+// ── DELETE /series/{slug} ───────────────────────────────────────────
+
+#[sqlx::test(fixtures("events", "series"))]
+#[test_log::test]
+async fn delete_success(db: PgPool) {
+    let unauthenticated_app = TestRouter::new(db.clone());
+    let unauthenticated_response = unauthenticated_app.delete("/series/palmarium").await;
+    assert_eq!(unauthenticated_response.status(), StatusCode::UNAUTHORIZED);
+
+    let app = TestRouter::as_editor(db).await;
+
+    let response = app.delete("/series/palmarium").await;
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+    let verify_res = app.get("/series/palmarium").await;
+    assert_eq!(verify_res.status(), StatusCode::NOT_FOUND);
+}
+
+#[sqlx::test]
+#[test_log::test]
+async fn delete_not_found(db: PgPool) {
+    let app = TestRouter::as_editor(db).await;
+    let response = app.delete("/series/nonexistent").await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+// ── POST /series/{slug}/productions ─────────────────────────────────
+
+#[sqlx::test(fixtures("events", "series"))]
+#[test_log::test]
+async fn add_productions_success(db: PgPool) {
+    let unauthenticated_app = TestRouter::new(db.clone());
+    let app = TestRouter::as_editor(db).await;
+
+    let payload: SeriesProductionsPayload = serde_json::from_value(json!({
+        "production_ids": ["22222222-2222-2222-2222-222222222222"]
+    }))
+    .expect("Failed to deserialize");
+
+    let unauthenticated_response = unauthenticated_app
+        .post("/series/fresh-juice/productions", &payload)
+        .await;
+    assert_eq!(unauthenticated_response.status(), StatusCode::UNAUTHORIZED);
+
+    let response = app.post("/series/fresh-juice/productions", &payload).await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let data: SeriesPayload = response.into_struct().await;
+    assert_eq!(data.production_ids.len(), 2);
+}
+
+#[sqlx::test(fixtures("events", "series"))]
+#[test_log::test]
+async fn add_productions_not_found_series(db: PgPool) {
+    let app = TestRouter::as_editor(db).await;
+
+    let payload: SeriesProductionsPayload = serde_json::from_value(json!({
+        "production_ids": ["11111111-1111-1111-1111-111111111111"]
+    }))
+    .expect("Failed to deserialize");
+
+    let response = app
+        .post("/series/nonexistent/productions", &payload)
+        .await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[sqlx::test(fixtures("events", "series"))]
+#[test_log::test]
+async fn add_productions_invalid_production_id(db: PgPool) {
+    let app = TestRouter::as_editor(db).await;
+
+    let payload: SeriesProductionsPayload = serde_json::from_value(json!({
+        "production_ids": ["00000000-0000-0000-0000-000000000000"]
+    }))
+    .expect("Failed to deserialize");
+
+    let response = app
+        .post("/series/palmarium/productions", &payload)
+        .await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+// ── DELETE /series/{slug}/productions/{production_id} ───────────────
+
+#[sqlx::test(fixtures("events", "series"))]
+#[test_log::test]
+async fn remove_production_success(db: PgPool) {
+    let unauthenticated_app = TestRouter::new(db.clone());
+    let app = TestRouter::as_editor(db).await;
+    let production_id = "11111111-1111-1111-1111-111111111111";
+
+    let unauthenticated_response = unauthenticated_app
+        .delete(&format!("/series/palmarium/productions/{production_id}"))
+        .await;
+    assert_eq!(unauthenticated_response.status(), StatusCode::UNAUTHORIZED);
+
+    let response = app
+        .delete(&format!("/series/palmarium/productions/{production_id}"))
+        .await;
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+    let verify_res = app.get("/series/palmarium").await;
+    let data: SeriesPayload = verify_res.into_struct().await;
+    assert_eq!(data.production_ids.len(), 1);
+}
+
+#[sqlx::test(fixtures("events", "series"))]
+#[test_log::test]
+async fn remove_production_not_found(db: PgPool) {
+    let app = TestRouter::as_editor(db).await;
+
+    let response = app
+        .delete(&format!(
+            "/series/palmarium/productions/{}",
+            Uuid::nil()
+        ))
+        .await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+// ── Derived period ──────────────────────────────────────────────────
+
+#[sqlx::test(fixtures("events", "series"))]
+#[test_log::test]
+async fn derived_period_from_events(db: PgPool) {
+    let app = TestRouter::new(db);
+    let response = app.get("/series/palmarium").await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let data: SeriesPayload = response.into_struct().await;
+    let start = data.period_start.expect("period_start should be set");
+    let end = data.period_end.expect("period_end should be set");
+
+    assert_eq!(start.date_naive().to_string(), "2026-05-01");
+    assert_eq!(end.date_naive().to_string(), "2026-06-01");
+    assert!(start < end);
+}
+
+#[sqlx::test]
+#[test_log::test]
+async fn empty_series_has_null_period(db: PgPool) {
+    let app = TestRouter::as_editor(db).await;
+
+    let payload = mock_post_payload();
+    let response = app.post("/series", &payload).await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let data: SeriesPayload = response.into_struct().await;
+    assert!(data.period_start.is_none());
+    assert!(data.period_end.is_none());
+}
+
+// ── Edge cases ──────────────────────────────────────────────────
+
+#[sqlx::test(fixtures("events", "series"))]
+#[test_log::test]
+async fn post_duplicate_slug(db: PgPool) {
+    let app = TestRouter::as_editor(db).await;
+
+    let payload: SeriesPostPayload = serde_json::from_value(json!({
+        "slug": "palmarium",
+        "translations": [
+            { "language_code": "nl", "name": "Dup", "subtitle": "", "description": "" }
+        ]
+    }))
+    .expect("Failed to deserialize");
+
+    let response = app.post("/series", &payload).await;
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+}
+
+#[sqlx::test(fixtures("events", "series"))]
+#[test_log::test]
+async fn put_slug_conflict(db: PgPool) {
+    let unauthenticated_app = TestRouter::new(db.clone());
+    let app = TestRouter::as_editor(db).await;
+
+    let get_response = unauthenticated_app.get("/series/fresh-juice").await;
+    let original: SeriesPayload = get_response.into_struct().await;
+
+    let update_payload: SeriesPayload = serde_json::from_value(json!({
+        "id": original.id,
+        "slug": "palmarium",
+        "translations": [
+            { "language_code": "nl", "name": "Stolen slug", "subtitle": "", "description": "" }
+        ],
+        "production_ids": [],
+        "period_start": null,
+        "period_end": null,
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-01-01T00:00:00Z"
+    }))
+    .expect("Failed to deserialize");
+
+    let response = app.put("/series", &update_payload).await;
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+}
+
+#[sqlx::test(fixtures("events", "series"))]
+#[test_log::test]
+async fn put_same_slug_no_conflict(db: PgPool) {
+    let unauthenticated_app = TestRouter::new(db.clone());
+    let app = TestRouter::as_editor(db).await;
+
+    let get_response = unauthenticated_app.get("/series/palmarium").await;
+    let original: SeriesPayload = get_response.into_struct().await;
+
+    let update_payload: SeriesPayload = serde_json::from_value(json!({
+        "id": original.id,
+        "slug": "palmarium",
+        "translations": [
+            { "language_code": "nl", "name": "Updated name", "subtitle": "", "description": "" },
+            { "language_code": "en", "name": "Updated name EN", "subtitle": "", "description": "" }
+        ],
+        "production_ids": [],
+        "period_start": null,
+        "period_end": null,
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-01-01T00:00:00Z"
+    }))
+    .expect("Failed to deserialize");
+
+    let response = app.put("/series", &update_payload).await;
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[sqlx::test(fixtures("events", "series"))]
+#[test_log::test]
+async fn add_productions_idempotent(db: PgPool) {
+    let app = TestRouter::as_editor(db).await;
+
+    let payload: SeriesProductionsPayload = serde_json::from_value(json!({
+        "production_ids": ["11111111-1111-1111-1111-111111111111"]
+    }))
+    .expect("Failed to deserialize");
+
+    let response = app.post("/series/palmarium/productions", &payload).await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let data: SeriesPayload = response.into_struct().await;
+    assert_eq!(data.production_ids.len(), 2);
+}
+
+#[sqlx::test(fixtures("events", "series"))]
+#[test_log::test]
+async fn remove_production_nonexistent_series(db: PgPool) {
+    let app = TestRouter::as_editor(db).await;
+
+    let response = app
+        .delete("/series/nonexistent/productions/11111111-1111-1111-1111-111111111111")
+        .await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[sqlx::test(fixtures("events", "series"))]
+#[test_log::test]
+async fn delete_series_cascades_join_rows(db: PgPool) {
+    let app = TestRouter::as_editor(db).await;
+    let production_id = "11111111-1111-1111-1111-111111111111";
+
+    let before = app
+        .get(&format!("/productions/{production_id}/series"))
+        .await;
+    let before_data: Vec<SeriesPayload> = before.into_struct().await;
+    assert_eq!(before_data.len(), 2);
+
+    let response = app.delete("/series/palmarium").await;
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+    let after = app
+        .get(&format!("/productions/{production_id}/series"))
+        .await;
+    let after_data: Vec<SeriesPayload> = after.into_struct().await;
+    assert_eq!(after_data.len(), 1);
+    assert_eq!(after_data[0].slug, "fresh-juice");
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+fn mock_post_payload() -> SeriesPostPayload {
+    serde_json::from_value(json!({
+        "slug": "test-reeks",
+        "translations": [
+            { "language_code": "nl", "name": "Test Reeks", "subtitle": "Ondertitel", "description": "" },
+            { "language_code": "en", "name": "Test Series", "subtitle": "Subtitle", "description": "" }
+        ]
+    }))
+    .expect("Failed to deserialize mock SeriesPostPayload")
+}

--- a/frontend/src/types/api/generated.ts
+++ b/frontend/src/types/api/generated.ts
@@ -570,6 +570,94 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/productions/{id}/series": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Return all series that contain the given production. Public endpoint, no authentication required. */
+        get: operations["get_series_for_production"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/series": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Return all series with translations, production IDs, and derived period. Public endpoint, no authentication required. */
+        get: operations["get_all_series"];
+        /** @description Update the metadata (slug, translations) of an existing series. Requires editor authentication. Does not affect production membership. */
+        put: operations["update_series"];
+        /** @description Create a new series. Requires editor authentication. Supply a slug and per-language translations (name, subtitle, description). Productions are added separately via POST /series/{slug}/productions. */
+        post: operations["create_series"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/series/{slug}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Return a single series by its slug, including translations, production IDs, and derived period. Public endpoint, no authentication required. */
+        get: operations["get_one_series"];
+        put?: never;
+        post?: never;
+        /** @description Permanently delete a series. Requires editor authentication. Productions are not affected. */
+        delete: operations["delete_series"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/series/{slug}/productions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** @description Add one or more productions to a series. Requires editor authentication. Duplicates are silently ignored. */
+        post: operations["add_productions_to_series"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/series/{slug}/productions/{production_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** @description Remove a production from a series. Requires editor authentication. The production itself is not deleted. */
+        delete: operations["remove_production_from_series"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/spaces": {
         parameters: {
             query?: never;
@@ -852,7 +940,7 @@ export interface components {
             role: components["schemas"]["UserRole"];
         };
         /** @enum {string} */
-        EntityType: "production" | "artist" | "article" | "media" | "location" | "event";
+        EntityType: "production" | "artist" | "article" | "media" | "location" | "event" | "series";
         ErrorResponse: {
             /** @example An error occurred during processing */
             message: string;
@@ -1198,6 +1286,34 @@ export interface components {
             missing_in_db: string[];
             missing_in_s3: string[];
             s3_key_count: number;
+        };
+        SeriesPayload: {
+            /** Format: date-time */
+            created_at: string;
+            /** Format: uuid */
+            id: string;
+            /** Format: date-time */
+            period_end?: string | null;
+            /** Format: date-time */
+            period_start?: string | null;
+            production_ids: string[];
+            slug: string;
+            translations: components["schemas"]["SeriesTranslationPayload"][];
+            /** Format: date-time */
+            updated_at: string;
+        };
+        SeriesPostPayload: {
+            slug: string;
+            translations: components["schemas"]["SeriesTranslationPayload"][];
+        };
+        SeriesProductionsPayload: {
+            production_ids: string[];
+        };
+        SeriesTranslationPayload: {
+            description: string;
+            language_code: string;
+            name: string;
+            subtitle: string;
         };
         SpacePayload: {
             /** Format: uuid */
@@ -2965,6 +3081,271 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["EventPayload"][];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    get_series_for_production: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Production UUID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Success */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SeriesPayload"][];
+                };
+            };
+        };
+    };
+    get_all_series: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Success */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SeriesPayload"][];
+                };
+            };
+        };
+    };
+    update_series: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SeriesPayload"];
+            };
+        };
+        responses: {
+            /** @description Success */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SeriesPayload"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    create_series: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SeriesPostPayload"];
+            };
+        };
+        responses: {
+            /** @description Created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SeriesPayload"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    get_one_series: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Series slug */
+                slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Success */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SeriesPayload"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    delete_series: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Series slug */
+                slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description No Content */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    add_productions_to_series: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Series slug */
+                slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SeriesProductionsPayload"];
+            };
+        };
+        responses: {
+            /** @description Success */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SeriesPayload"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    remove_production_from_series: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Series slug */
+                slug: string;
+                /** @description Production UUID */
+                production_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description No Content */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
             /** @description Not found */


### PR DESCRIPTION
Adds the series entity to the backend. A series groups productions into thematic/programmatic groupings (e.g. "Palmarium", "Fresh Juice") via a many-to-many relationship.

**Schema:**
- `series` table with slug, timestamps
- `series_translations` for bilingual name, subtitle, description
- `series_productions` join table (no position column, ordering derived from event dates)
- `articles_about_series` join table for article linking
- `entity_type` enum extended with `series` for media attachment support

**API endpoints:**
- `GET /series`, `GET /series/{slug}` — public, returns translations + production UUIDs + derived period (min/max event dates)
- `GET /productions/{id}/series` — reverse lookup
- `POST /series`, `PUT /series`, `DELETE /series/{slug}` — editor CRUD
- `POST /series/{slug}/productions`, `DELETE /series/{slug}/productions/{production_id}` — manage production membership