### PR TITLE
frontend(article-page): Base of the article page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ yarn-error.log*
 next-env.d.ts
 
 .eslintcache
+/CLAUDE.md

--- a/backend/database/src/models/article.rs
+++ b/backend/database/src/models/article.rs
@@ -29,6 +29,7 @@ pub struct Article {
     pub id: Uuid,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    pub published_at: Option<DateTime<Utc>>,
     pub slug: String,
     pub status: ArticleStatus,
     pub title: Option<String>,

--- a/backend/migrations/20260408000000_articles_published_at.down.sql
+++ b/backend/migrations/20260408000000_articles_published_at.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE articles DROP COLUMN published_at;

--- a/backend/migrations/20260408000000_articles_published_at.up.sql
+++ b/backend/migrations/20260408000000_articles_published_at.up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE articles ADD COLUMN published_at TIMESTAMPTZ;
+
+-- Backfill: set published_at = updated_at for already-published articles
+UPDATE articles SET published_at = updated_at WHERE status = 'published';

--- a/backend/src/dto/article.rs
+++ b/backend/src/dto/article.rs
@@ -22,6 +22,7 @@ pub struct ArticlePayload {
     pub content: Option<Value>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    pub published_at: Option<DateTime<Utc>>,
     pub subject_period_start: Option<NaiveDate>,
     pub subject_period_end: Option<NaiveDate>,
 }
@@ -36,6 +37,7 @@ impl From<Article> for ArticlePayload {
             content: a.content,
             created_at: a.created_at,
             updated_at: a.updated_at,
+            published_at: a.published_at,
             subject_period_start: a.subject_period_start,
             subject_period_end: a.subject_period_end,
         }
@@ -78,10 +80,17 @@ impl ArticleUpdatePayload {
             )));
         }
 
+        let published_at = if self.status == ArticleStatus::Published && existing.published_at.is_none() {
+            Some(Utc::now())
+        } else {
+            existing.published_at
+        };
+
         let article = Article {
             id: existing.id,
             created_at: existing.created_at,
             updated_at: Utc::now(),
+            published_at,
             slug: self.slug,
             status: self.status,
             title: self.title,
@@ -100,6 +109,7 @@ pub struct ArticleListPayload {
     pub status: ArticleStatus,
     pub title: Option<String>,
     pub updated_at: DateTime<Utc>,
+    pub published_at: Option<DateTime<Utc>>,
     pub subject_period_start: Option<NaiveDate>,
     pub subject_period_end: Option<NaiveDate>,
 }
@@ -112,6 +122,7 @@ impl From<Article> for ArticleListPayload {
             status: a.status,
             title: a.title,
             updated_at: a.updated_at,
+            published_at: a.published_at,
             subject_period_start: a.subject_period_start,
             subject_period_end: a.subject_period_end,
         }
@@ -181,6 +192,7 @@ impl ArticlePostPayload {
             subject_period_end: None,
             created_at: now,
             updated_at: now,
+            published_at: None,
         };
 
         Ok(db.articles().insert(create).await?.into())

--- a/frontend/src/app/[locale]/(app)/articles/[slug]/page.tsx
+++ b/frontend/src/app/[locale]/(app)/articles/[slug]/page.tsx
@@ -9,7 +9,7 @@ import { useGetArticleBySlug } from "@/hooks/api/useArticles";
 import { Link } from "@/i18n/routing";
 
 import { SearchHeader } from "@/components/homepage/search-header";
-import { TiptapRenderer, ArticleRelations } from "@/components/articles";
+import { TiptapRenderer } from "@/components/articles";
 import { LoadingState } from "@/components/shared/loading-state";
 import { VintageEmptyState } from "@/components/shared/vintage-empty-state";
 
@@ -34,6 +34,19 @@ function formatPeriod(start: string | null, end: string | null, locale: string):
     }
     return null;
 }
+
+// TODO: replace with real data from API when backend supports public article relations
+const STATIC_CONNECTED_ENTITIES = [
+    { type: "Productie", label: "The Second Woman — Natali Broods" },
+    { type: "Locatie", label: "De Vooruit — Domzaal" },
+    { type: "Artiest", label: "Natali Broods" },
+];
+
+const STATIC_RELATED_ARTICLES = [
+    { title: "De Balzaal door de jaren heen", period: "1960 — 1980", date: "12 mrt 2026" },
+    { title: "Achter de schermen van Fresh Juice", period: "Voorjaar 2026", date: "28 feb 2026" },
+    { title: "40 jaar Nightlife in De Vooruit", period: "1983 — 2023", date: "15 jan 2026" },
+];
 
 export default function ArticleDetailPage({ params }: { params: Promise<{ slug: string }> }) {
     const { slug } = use(params);
@@ -74,7 +87,7 @@ export default function ArticleDetailPage({ params }: { params: Promise<{ slug: 
             )}
 
             {!isLoading && article && (
-                <article className="mx-auto max-w-[900px] px-4 py-8 sm:px-10 sm:py-12">
+                <article className="mx-auto max-w-[1100px] px-4 py-8 sm:px-10 sm:py-12">
                     {/* Back link */}
                     <Link
                         href="/articles"
@@ -109,18 +122,60 @@ export default function ArticleDetailPage({ params }: { params: Promise<{ slug: 
                         </div>
                     </header>
 
-                    {/* Content + sidebar */}
-                    <div className="flex flex-col gap-8 sm:flex-row">
-                        {/* Main content */}
-                        <div className="min-w-0 flex-1">
-                            <TiptapRenderer content={article.content} />
-                        </div>
-
-                        {/* Relations sidebar — visually ready, pass data when API available */}
-                        <div className="w-full shrink-0 sm:w-[240px]">
-                            <ArticleRelations />
-                        </div>
+                    {/* Content */}
+                    <div className="mx-auto max-w-[750px]">
+                        <TiptapRenderer content={article.content} />
                     </div>
+
+                    {/* Connected entities — TODO: replace static data with API when backend supports public relations */}
+                    <section className="border-foreground/20 mx-auto mt-12 max-w-[750px] border-t pt-8">
+                        <h2 className="text-foreground mb-5 font-mono text-[10px] font-medium tracking-[2px] uppercase">
+                            {t("connectedTo")}
+                        </h2>
+                        <div className="grid grid-cols-1 gap-px sm:grid-cols-2">
+                            {STATIC_CONNECTED_ENTITIES.map((entity) => (
+                                <div
+                                    key={entity.label}
+                                    className="border-muted/35 group hover:bg-muted/5 flex items-center gap-3 border-b p-3 transition-colors"
+                                >
+                                    <span className="border-foreground text-foreground shrink-0 border px-1.5 py-0.5 font-mono text-[8px] tracking-[1.1px] uppercase">
+                                        {entity.type}
+                                    </span>
+                                    <span className="font-display text-foreground text-[15px] leading-snug font-bold tracking-[-0.01em]">
+                                        {entity.label}
+                                    </span>
+                                </div>
+                            ))}
+                        </div>
+                    </section>
+
+                    {/* Related articles — TODO: replace static data with API */}
+                    <section className="border-foreground/20 mx-auto mt-10 max-w-[750px] border-t pt-8 pb-4">
+                        <div className="mb-5 flex items-center gap-2.5">
+                            <h2 className="text-foreground font-mono text-[10px] font-medium tracking-[2px] uppercase">
+                                {t("moreStories")}
+                            </h2>
+                            <span className="bg-muted/40 h-px flex-1" />
+                        </div>
+                        <div className="grid grid-cols-1 gap-px sm:grid-cols-3">
+                            {STATIC_RELATED_ARTICLES.map((related) => (
+                                <div
+                                    key={related.title}
+                                    className="border-muted/35 group hover:bg-muted/5 cursor-pointer border-b p-4 transition-colors sm:border-r sm:last:border-r-0"
+                                >
+                                    <span className="text-muted-foreground mb-2 block font-mono text-[9px] tracking-[2px] uppercase">
+                                        {related.period}
+                                    </span>
+                                    <h3 className="font-display text-foreground mb-1 text-[18px] leading-[1.15] font-bold tracking-[-0.02em]">
+                                        {related.title}
+                                    </h3>
+                                    <span className="text-muted-foreground font-mono text-[9px] tracking-[1.4px] uppercase">
+                                        {related.date}
+                                    </span>
+                                </div>
+                            ))}
+                        </div>
+                    </section>
                 </article>
             )}
         </>

--- a/frontend/src/app/[locale]/(app)/articles/[slug]/page.tsx
+++ b/frontend/src/app/[locale]/(app)/articles/[slug]/page.tsx
@@ -22,19 +22,6 @@ function formatDate(dateStr: string, locale: string): string {
     });
 }
 
-function formatPeriod(start: string | null, end: string | null, locale: string): string | null {
-    const loc = locale === "en" ? "en-GB" : "nl-BE";
-    const opts: Intl.DateTimeFormatOptions = { month: "long", year: "numeric" };
-
-    if (start && end) {
-        return `${new Date(start).toLocaleDateString(loc, opts)} — ${new Date(end).toLocaleDateString(loc, opts)}`;
-    }
-    if (start) {
-        return new Date(start).toLocaleDateString(loc, opts);
-    }
-    return null;
-}
-
 // TODO: replace with real data from API when backend supports public article relations
 const STATIC_CONNECTED_ENTITIES = [
     { type: "Productie", label: "The Second Woman — Natali Broods" },
@@ -98,27 +85,17 @@ export default function ArticleDetailPage({ params }: { params: Promise<{ slug: 
                     </Link>
 
                     {/* Article header */}
-                    <header className="border-foreground mb-8 border-b-[3px] pb-6">
-                        {/* Subject period */}
-                        {(article.subjectPeriodStart || article.subjectPeriodEnd) && (
-                            <span className="text-muted-foreground mb-3 block font-mono text-[9px] tracking-[2px] uppercase">
-                                {formatPeriod(
-                                    article.subjectPeriodStart,
-                                    article.subjectPeriodEnd,
-                                    locale
-                                )}
-                            </span>
-                        )}
-
+                    <header className="mb-8 pb-6">
                         <h1 className="font-display text-foreground text-[32px] leading-[1.1] font-bold tracking-[-0.025em] sm:text-[44px] md:text-[56px]">
                             {article.title ?? t("untitled")}
                         </h1>
 
                         {/* Dateline bar */}
                         <div className="border-foreground text-foreground mt-6 flex items-center justify-between border-y py-1.5 font-mono text-[9px] tracking-widest uppercase sm:text-[10px]">
-                            <span>{formatDate(article.createdAt, locale)}</span>
+                            <span>
+                                {formatDate(article.publishedAt ?? article.createdAt, locale)}
+                            </span>
                             <span>{t("datelineBrand")}</span>
-                            <span>{formatDate(article.updatedAt, locale)}</span>
                         </div>
                     </header>
 
@@ -132,7 +109,7 @@ export default function ArticleDetailPage({ params }: { params: Promise<{ slug: 
                         <h2 className="text-foreground mb-5 font-mono text-[10px] font-medium tracking-[2px] uppercase">
                             {t("connectedTo")}
                         </h2>
-                        <div className="grid grid-cols-1 gap-px sm:grid-cols-2">
+                        <div className="grid grid-cols-1 gap-px">
                             {STATIC_CONNECTED_ENTITIES.map((entity) => (
                                 <div
                                     key={entity.label}
@@ -150,7 +127,7 @@ export default function ArticleDetailPage({ params }: { params: Promise<{ slug: 
                     </section>
 
                     {/* Related articles — TODO: replace static data with API */}
-                    <section className="border-foreground/20 mx-auto mt-10 max-w-[750px] border-t pt-8 pb-4">
+                    <section className="mx-auto mt-10 max-w-[750px] pt-8 pb-4">
                         <div className="mb-5 flex items-center gap-2.5">
                             <h2 className="text-foreground font-mono text-[10px] font-medium tracking-[2px] uppercase">
                                 {t("moreStories")}

--- a/frontend/src/app/[locale]/(app)/articles/[slug]/page.tsx
+++ b/frontend/src/app/[locale]/(app)/articles/[slug]/page.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { use, useState, useCallback } from "react";
+import { useLocale, useTranslations } from "next-intl";
+import { useRouter } from "next/navigation";
+import { ArrowLeft } from "lucide-react";
+
+import { useGetArticleBySlug } from "@/hooks/api/useArticles";
+import { Link } from "@/i18n/routing";
+
+import { SearchHeader } from "@/components/homepage/search-header";
+import { TiptapRenderer, ArticleRelations } from "@/components/articles";
+import { LoadingState } from "@/components/shared/loading-state";
+import { VintageEmptyState } from "@/components/shared/vintage-empty-state";
+
+function formatDate(dateStr: string, locale: string): string {
+    const loc = locale === "en" ? "en-GB" : "nl-BE";
+    return new Date(dateStr).toLocaleDateString(loc, {
+        day: "numeric",
+        month: "long",
+        year: "numeric",
+    });
+}
+
+function formatPeriod(start: string | null, end: string | null, locale: string): string | null {
+    const loc = locale === "en" ? "en-GB" : "nl-BE";
+    const opts: Intl.DateTimeFormatOptions = { month: "long", year: "numeric" };
+
+    if (start && end) {
+        return `${new Date(start).toLocaleDateString(loc, opts)} — ${new Date(end).toLocaleDateString(loc, opts)}`;
+    }
+    if (start) {
+        return new Date(start).toLocaleDateString(loc, opts);
+    }
+    return null;
+}
+
+export default function ArticleDetailPage({ params }: { params: Promise<{ slug: string }> }) {
+    const { slug } = use(params);
+    const locale = useLocale();
+    const t = useTranslations("Articles");
+    const tSearch = useTranslations("Search");
+    const router = useRouter();
+
+    const [headerQuery, setHeaderQuery] = useState("");
+
+    const handleHeaderSearch = useCallback(
+        (value: string) => {
+            if (value.trim()) {
+                router.push(`/search?q=${encodeURIComponent(value.trim())}`);
+            } else {
+                router.push("/search");
+            }
+        },
+        [router]
+    );
+
+    const { data: article, isLoading, isError } = useGetArticleBySlug(slug);
+
+    return (
+        <>
+            <SearchHeader
+                query={headerQuery}
+                onQueryChange={setHeaderQuery}
+                onSearch={handleHeaderSearch}
+                searchPlaceholder={tSearch("placeholder")}
+                searchHint={tSearch("hint")}
+            />
+
+            {isLoading && <LoadingState message={t("loading")} />}
+
+            {isError && (
+                <VintageEmptyState title={t("notFoundTitle")} description={t("notFoundText")} />
+            )}
+
+            {!isLoading && article && (
+                <article className="mx-auto max-w-[900px] px-4 py-8 sm:px-10 sm:py-12">
+                    {/* Back link */}
+                    <Link
+                        href="/articles"
+                        className="text-muted-foreground hover:text-foreground mb-6 inline-flex items-center gap-1.5 font-mono text-[10px] tracking-[1.4px] uppercase transition-colors"
+                    >
+                        <ArrowLeft className="h-3 w-3" />
+                        {t("backToArticles")}
+                    </Link>
+
+                    {/* Article header */}
+                    <header className="border-foreground mb-8 border-b-[3px] pb-6">
+                        {/* Subject period */}
+                        {(article.subjectPeriodStart || article.subjectPeriodEnd) && (
+                            <span className="text-muted-foreground mb-3 block font-mono text-[9px] tracking-[2px] uppercase">
+                                {formatPeriod(
+                                    article.subjectPeriodStart,
+                                    article.subjectPeriodEnd,
+                                    locale
+                                )}
+                            </span>
+                        )}
+
+                        <h1 className="font-display text-foreground text-[32px] leading-[1.1] font-bold tracking-[-0.025em] sm:text-[44px] md:text-[56px]">
+                            {article.title ?? t("untitled")}
+                        </h1>
+
+                        {/* Dateline bar */}
+                        <div className="border-foreground text-foreground mt-6 flex items-center justify-between border-y py-1.5 font-mono text-[9px] tracking-widest uppercase sm:text-[10px]">
+                            <span>{formatDate(article.createdAt, locale)}</span>
+                            <span>{t("datelineBrand")}</span>
+                            <span>{formatDate(article.updatedAt, locale)}</span>
+                        </div>
+                    </header>
+
+                    {/* Content + sidebar */}
+                    <div className="flex flex-col gap-8 sm:flex-row">
+                        {/* Main content */}
+                        <div className="min-w-0 flex-1">
+                            <TiptapRenderer content={article.content} />
+                        </div>
+
+                        {/* Relations sidebar — visually ready, pass data when API available */}
+                        <div className="w-full shrink-0 sm:w-[240px]">
+                            <ArticleRelations />
+                        </div>
+                    </div>
+                </article>
+            )}
+        </>
+    );
+}

--- a/frontend/src/app/[locale]/(app)/articles/page.tsx
+++ b/frontend/src/app/[locale]/(app)/articles/page.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { useLocale, useTranslations } from "next-intl";
+import { useRouter } from "next/navigation";
+
+import { useGetArticles } from "@/hooks/api/useArticles";
+
+import { SearchHeader } from "@/components/homepage/search-header";
+import { ArticleCard } from "@/components/articles";
+import { LoadingState } from "@/components/shared/loading-state";
+import { VintageEmptyState } from "@/components/shared/vintage-empty-state";
+
+export default function ArticlesPage() {
+    const locale = useLocale();
+    const t = useTranslations("Articles");
+    const tSearch = useTranslations("Search");
+    const router = useRouter();
+
+    const [headerQuery, setHeaderQuery] = useState("");
+
+    const handleHeaderSearch = useCallback(
+        (value: string) => {
+            if (value.trim()) {
+                router.push(`/search?q=${encodeURIComponent(value.trim())}`);
+            } else {
+                router.push("/search");
+            }
+        },
+        [router]
+    );
+
+    const { data: articles, isLoading } = useGetArticles();
+
+    return (
+        <>
+            <SearchHeader
+                query={headerQuery}
+                onQueryChange={setHeaderQuery}
+                onSearch={handleHeaderSearch}
+                searchPlaceholder={tSearch("placeholder")}
+                searchHint={tSearch("hint")}
+            />
+
+            {/* Hero */}
+            <section className="border-foreground border-b-2 px-4 py-10 text-center sm:px-10 sm:py-14">
+                <span className="text-muted-foreground mb-3 block font-mono text-[9px] tracking-[2px] uppercase">
+                    {t("heroEyebrow")}
+                </span>
+                <h1 className="font-display text-foreground text-[36px] leading-[1.05] font-bold tracking-[-0.03em] sm:text-[52px] md:text-[64px]">
+                    {t("heroTitle")}
+                </h1>
+                <p className="font-display text-muted-foreground mt-2 text-[18px] italic sm:text-[22px]">
+                    {t("heroSubtitle")}
+                </p>
+
+                {/* Dateline bar */}
+                <div className="border-foreground text-foreground mx-auto mt-6 flex max-w-[600px] items-center justify-between border-y py-1.5 font-mono text-[9px] tracking-widest uppercase sm:text-[10px]">
+                    <span>{t("datelineEdition")}</span>
+                    <span>{t("datelineBrand")}</span>
+                    <span>{t("datelinePrice")}</span>
+                </div>
+            </section>
+
+            {/* Article list */}
+            <section className="mx-auto max-w-[1000px] px-4 py-8 sm:px-10 sm:py-12">
+                {isLoading && <LoadingState message={t("loading")} />}
+
+                {!isLoading && (!articles || articles.length === 0) && (
+                    <VintageEmptyState
+                        title={t("noArticlesTitle")}
+                        description={t("noArticlesText")}
+                    />
+                )}
+
+                {!isLoading && articles && articles.length > 0 && (
+                    <>
+                        <div className="text-muted-foreground mb-4 flex items-center gap-2.5 font-mono text-[9px] font-medium tracking-[2px] uppercase">
+                            {t("listLabel", { count: articles.length })}
+                            <span className="bg-muted/40 h-px flex-1" />
+                        </div>
+                        <div className="border-muted/35 grid grid-cols-1 border-t sm:grid-cols-2 lg:grid-cols-3">
+                            {articles.map((article) => (
+                                <ArticleCard key={article.id} article={article} locale={locale} />
+                            ))}
+                        </div>
+                    </>
+                )}
+            </section>
+        </>
+    );
+}

--- a/frontend/src/components/articles/article-card.tsx
+++ b/frontend/src/components/articles/article-card.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import Link from "next/link";
+import { useTranslations } from "next-intl";
+
+import type { ArticleListItem } from "@/types/models/article.types";
+
+interface ArticleCardProps {
+    article: ArticleListItem;
+    locale: string;
+}
+
+function formatPeriod(start: string | null, end: string | null, locale: string): string | null {
+    const loc = locale === "en" ? "en-GB" : "nl-BE";
+    const opts: Intl.DateTimeFormatOptions = { month: "short", year: "numeric" };
+
+    if (start && end) {
+        return `${new Date(start).toLocaleDateString(loc, opts)} — ${new Date(end).toLocaleDateString(loc, opts)}`;
+    }
+    if (start) {
+        return new Date(start).toLocaleDateString(loc, opts);
+    }
+    return null;
+}
+
+function formatDate(dateStr: string, locale: string): string {
+    const loc = locale === "en" ? "en-GB" : "nl-BE";
+    return new Date(dateStr).toLocaleDateString(loc, {
+        day: "numeric",
+        month: "long",
+        year: "numeric",
+    });
+}
+
+export function ArticleCard({ article, locale }: ArticleCardProps) {
+    const t = useTranslations("Articles");
+    const period = formatPeriod(article.subjectPeriodStart, article.subjectPeriodEnd, locale);
+
+    return (
+        <Link href={`/articles/${article.slug}`}>
+            <article
+                className="group border-muted/35 hover:bg-muted/5 flex cursor-pointer flex-col border-b p-4 transition-colors sm:p-5"
+                style={{ animation: "fadein 0.3s ease both" }}
+            >
+                {period && (
+                    <span className="text-muted-foreground group-hover:text-foreground mb-2 font-mono text-[9px] tracking-[2px] uppercase transition-colors">
+                        {period}
+                    </span>
+                )}
+
+                <h3 className="font-display text-foreground mb-1 text-[20px] leading-[1.15] font-bold tracking-[-0.02em] sm:text-[24px]">
+                    {article.title ?? t("untitled")}
+                </h3>
+
+                <span className="text-muted-foreground mt-auto pt-3 font-mono text-[9px] tracking-[1.4px] uppercase">
+                    {formatDate(article.updatedAt, locale)}
+                </span>
+            </article>
+        </Link>
+    );
+}

--- a/frontend/src/components/articles/article-card.tsx
+++ b/frontend/src/components/articles/article-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Link from "next/link";
+import { Link } from "@/i18n/routing";
 import { useTranslations } from "next-intl";
 
 import type { ArticleListItem } from "@/types/models/article.types";

--- a/frontend/src/components/articles/article-relations.tsx
+++ b/frontend/src/components/articles/article-relations.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+
+interface RelationItem {
+    id: string;
+    label: string;
+    href?: string;
+}
+
+interface ArticleRelationsProps {
+    productions?: RelationItem[];
+    artists?: RelationItem[];
+    locations?: RelationItem[];
+    events?: RelationItem[];
+}
+
+function RelationSection({ title, items }: { title: string; items: RelationItem[] }) {
+    if (items.length === 0) return null;
+
+    return (
+        <div className="mb-5">
+            <h4 className="text-muted-foreground mb-2 font-mono text-[9px] font-medium tracking-[2px] uppercase">
+                {title}
+            </h4>
+            <ul className="flex flex-col gap-1.5">
+                {items.map((item) => (
+                    <li key={item.id}>
+                        <span className="font-body text-foreground text-sm leading-snug">
+                            {item.label}
+                        </span>
+                    </li>
+                ))}
+            </ul>
+        </div>
+    );
+}
+
+export function ArticleRelations({
+    productions = [],
+    artists = [],
+    locations = [],
+    events = [],
+}: ArticleRelationsProps) {
+    const t = useTranslations("Articles");
+    const hasAny =
+        productions.length > 0 || artists.length > 0 || locations.length > 0 || events.length > 0;
+
+    if (!hasAny) return null;
+
+    return (
+        <aside className="border-foreground/20 border-t pt-6 sm:border-t-0 sm:border-l sm:pt-0 sm:pl-6">
+            <h3 className="text-foreground mb-4 font-mono text-[10px] font-medium tracking-[2px] uppercase">
+                {t("relatedEntities")}
+            </h3>
+            <RelationSection title={t("relatedProductions")} items={productions} />
+            <RelationSection title={t("relatedArtists")} items={artists} />
+            <RelationSection title={t("relatedLocations")} items={locations} />
+            <RelationSection title={t("relatedEvents")} items={events} />
+        </aside>
+    );
+}

--- a/frontend/src/components/articles/index.ts
+++ b/frontend/src/components/articles/index.ts
@@ -1,0 +1,3 @@
+export { TiptapRenderer } from "./tiptap-renderer";
+export { ArticleCard } from "./article-card";
+export { ArticleRelations } from "./article-relations";

--- a/frontend/src/components/articles/tiptap-renderer.tsx
+++ b/frontend/src/components/articles/tiptap-renderer.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEditor, EditorContent } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+
+interface TiptapRendererProps {
+    content: Record<string, unknown> | null;
+}
+
+export function TiptapRenderer({ content }: TiptapRendererProps) {
+    const editor = useEditor({
+        extensions: [
+            StarterKit.configure({
+                link: { openOnClick: true },
+                code: false,
+                codeBlock: false,
+            }),
+        ],
+        content: content ?? undefined,
+        editable: false,
+        immediatelyRender: false,
+    });
+
+    if (!content) return null;
+
+    return (
+        <EditorContent
+            editor={editor}
+            className="prose prose-lg dark:prose-invert font-body text-foreground [&_h1]:font-display [&_h2]:font-display [&_h3]:font-display [&_blockquote]:border-foreground [&_blockquote]:font-display [&_blockquote]:text-muted-foreground [&_a]:text-foreground [&_hr]:border-foreground/20 max-w-none leading-[1.8] [&_.tiptap]:outline-none [&_a]:underline [&_a]:underline-offset-2 [&_blockquote]:border-l-[3px] [&_blockquote]:pl-5 [&_blockquote]:italic [&_h1]:mt-8 [&_h1]:mb-4 [&_h1]:text-[28px] [&_h1]:leading-[1.15] [&_h1]:font-bold [&_h1]:tracking-[-0.02em] sm:[&_h1]:text-[36px] [&_h2]:mt-6 [&_h2]:mb-3 [&_h2]:text-[22px] [&_h2]:leading-[1.2] [&_h2]:font-bold [&_h2]:tracking-[-0.02em] sm:[&_h2]:text-[28px] [&_h3]:mt-5 [&_h3]:mb-2 [&_h3]:text-[18px] [&_h3]:leading-[1.25] [&_h3]:font-bold sm:[&_h3]:text-[22px] [&_hr]:my-8 [&_li]:mb-1 [&_ol]:list-decimal [&_ol]:pl-6 [&_p]:mb-4 [&_p]:text-[15px] [&_p]:leading-[1.8] sm:[&_p]:text-[16px] [&_ul]:list-disc [&_ul]:pl-6"
+        />
+    );
+}

--- a/frontend/src/components/homepage/masthead/Masthead.tsx
+++ b/frontend/src/components/homepage/masthead/Masthead.tsx
@@ -11,7 +11,7 @@ import { LocaleSwitcher } from "@/components/shared/locale-switcher";
 const NAV_LINKS = [
     { key: "productions", href: "/" },
     { key: "artists", href: "#" },
-    { key: "articles", href: "#" },
+    { key: "articles", href: "/articles" },
     { key: "posters", href: "#" },
     { key: "collection", href: "#" },
     { key: "about", href: "#" },

--- a/frontend/src/components/homepage/search-header/SearchHeader.tsx
+++ b/frontend/src/components/homepage/search-header/SearchHeader.tsx
@@ -27,6 +27,7 @@ export function SearchHeader({
     const locale = useLocale();
     const isHome = pathname === "/" || pathname === "";
     const isSearch = pathname.startsWith("/search");
+    const isArticles = pathname.startsWith("/articles");
 
     const navLinkClass = (active: boolean) =>
         `font-mono text-[9px] tracking-[1.4px] uppercase transition-colors ${
@@ -110,6 +111,9 @@ export function SearchHeader({
                     <Link href="/search" className={navLinkClass(isSearch)}>
                         Archief
                     </Link>
+                    <Link href="/articles" className={navLinkClass(isArticles)}>
+                        Artikels
+                    </Link>
                     <span className="bg-border h-3 w-px" />
                     <ThemeSwitcher />
                     {localeSwitcher}
@@ -151,6 +155,13 @@ export function SearchHeader({
                         className={navLinkClass(isSearch)}
                     >
                         Archief
+                    </Link>
+                    <Link
+                        href="/articles"
+                        onClick={() => setMenuOpen(false)}
+                        className={navLinkClass(isArticles)}
+                    >
+                        Artikels
                     </Link>
                 </nav>
             )}

--- a/frontend/src/hooks/api/query-keys.ts
+++ b/frontend/src/hooks/api/query-keys.ts
@@ -43,6 +43,8 @@ export const queryKeys = {
         all: ["articles"] as const,
         detail: (id: string) => ["articles", id] as const,
         relations: (id: string) => ["articles", id, "relations"] as const,
+        published: ["articles", "published"] as const,
+        bySlug: (slug: string) => ["articles", "bySlug", slug] as const,
     },
     taxonomy: {
         facets: (entityType?: string) =>

--- a/frontend/src/hooks/api/useArticles.ts
+++ b/frontend/src/hooks/api/useArticles.ts
@@ -24,6 +24,16 @@ import {
 
 import { queryKeys } from "./query-keys";
 
+const fetchArticlesPublished = async (): Promise<ArticleListItem[]> => {
+    const { data } = await api.get<ArticleListResponse[]>("/articles");
+    return mapArticleListItems(data);
+};
+
+const fetchArticleBySlug = async (slug: string): Promise<Article> => {
+    const { data } = await api.get<ArticleResponse>(`/articles/${slug}`);
+    return mapArticle(data);
+};
+
 const fetchArticlesCms = async (): Promise<ArticleListItem[]> => {
     const { data } = await api.get<ArticleListResponse[]>("/articles/cms");
     return mapArticleListItems(data);
@@ -37,6 +47,21 @@ const fetchArticleById = async (id: string): Promise<Article> => {
 const fetchArticleRelations = async (id: string): Promise<ArticleRelations> => {
     const { data } = await api.get<ArticleRelationsResponse>(`/articles/cms/${id}/relations`);
     return mapArticleRelations(data);
+};
+
+export const useGetArticles = () => {
+    return useQuery({
+        queryKey: queryKeys.articles.published,
+        queryFn: fetchArticlesPublished,
+    });
+};
+
+export const useGetArticleBySlug = (slug: string, options?: { enabled?: boolean }) => {
+    return useQuery({
+        queryKey: queryKeys.articles.bySlug(slug),
+        queryFn: () => fetchArticleBySlug(slug),
+        enabled: Boolean(slug) && (options?.enabled ?? true),
+    });
 };
 
 export const useGetArticlesCms = () => {

--- a/frontend/src/mappers/article.mapper.ts
+++ b/frontend/src/mappers/article.mapper.ts
@@ -28,6 +28,7 @@ export const mapArticle = (response: ArticleResponse): Article => ({
     content: toArticleContent(response.content),
     createdAt: response.created_at,
     updatedAt: response.updated_at,
+    publishedAt: toNullable(response.published_at),
     subjectPeriodStart: toNullable(response.subject_period_start),
     subjectPeriodEnd: toNullable(response.subject_period_end),
 });
@@ -38,6 +39,7 @@ export const mapArticleListItem = (response: ArticleListResponse): ArticleListIt
     status: response.status,
     title: toNullable(response.title),
     updatedAt: response.updated_at,
+    publishedAt: toNullable(response.published_at),
     subjectPeriodStart: toNullable(response.subject_period_start),
     subjectPeriodEnd: toNullable(response.subject_period_end),
 });

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -318,6 +318,8 @@
         "backToArticles": "Back to articles",
         "notFoundTitle": "Article not found",
         "notFoundText": "This article does not exist or is no longer available.",
+        "connectedTo": "Connected to",
+        "moreStories": "More stories",
         "relatedEntities": "Related",
         "relatedProductions": "Productions",
         "relatedArtists": "Artists",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -319,7 +319,7 @@
         "notFoundTitle": "Article not found",
         "notFoundText": "This article does not exist or is no longer available.",
         "connectedTo": "Connected to",
-        "moreStories": "More stories",
+        "moreStories": "More articles",
         "relatedEntities": "Related",
         "relatedProductions": "Productions",
         "relatedArtists": "Artists",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -20,7 +20,15 @@
     "Masthead": {
         "address": "Sint-Pietersnieuwstraat 23, Ghent",
         "subtitle": "De Vooruit — Founded 1883",
-        "genres": "Theatre · Dance · Music · Performance · Nightlife"
+        "genres": "Theatre · Dance · Music · Performance · Nightlife",
+        "nav": {
+            "productions": "Productions",
+            "artists": "Artists",
+            "articles": "Articles",
+            "posters": "Posters",
+            "collection": "Collection",
+            "about": "About"
+        }
     },
     "Search": {
         "placeholder": "Search the archive...",
@@ -293,5 +301,27 @@
         "edition": "Edition 404",
         "articleBrand": "Archives Department",
         "price": "Price: Priceless"
+    },
+    "Articles": {
+        "heroEyebrow": "Stories from the archive",
+        "heroTitle": "Articles & Stories",
+        "heroSubtitle": "Stories from behind the scenes of De Vooruit",
+        "datelineEdition": "Archive Edition",
+        "datelineBrand": "Archives Department",
+        "datelinePrice": "Price: Priceless",
+        "loading": "Loading articles...",
+        "noArticlesTitle": "No stories yet",
+        "noArticlesText": "There are currently no published articles. Check back later for new stories from the archive.",
+        "listLabel": "{count, plural, one {# article} other {# articles}}",
+        "untitled": "Untitled",
+        "readMore": "Read more",
+        "backToArticles": "Back to articles",
+        "notFoundTitle": "Article not found",
+        "notFoundText": "This article does not exist or is no longer available.",
+        "relatedEntities": "Related",
+        "relatedProductions": "Productions",
+        "relatedArtists": "Artists",
+        "relatedLocations": "Locations",
+        "relatedEvents": "Events"
     }
 }

--- a/frontend/src/messages/nl.json
+++ b/frontend/src/messages/nl.json
@@ -20,7 +20,15 @@
     "Masthead": {
         "address": "Sint-Pietersnieuwstraat 23, Gent",
         "subtitle": "De Vooruit — Opgericht 1883",
-        "genres": "Theater · Dans · Muziek · Performance · Nightlife"
+        "genres": "Theater · Dans · Muziek · Performance · Nightlife",
+        "nav": {
+            "productions": "Producties",
+            "artists": "Artiesten",
+            "articles": "Artikels",
+            "posters": "Affiches",
+            "collection": "Collectie",
+            "about": "Over ons"
+        }
     },
     "Search": {
         "placeholder": "Zoeken in het archief...",
@@ -293,5 +301,27 @@
         "edition": "Editie 404",
         "articleBrand": "Archiefdienst",
         "price": "Prijs: Onschatbaar"
+    },
+    "Articles": {
+        "heroEyebrow": "Verhalen uit het archief",
+        "heroTitle": "Artikels & Verhalen",
+        "heroSubtitle": "Verhalen achter de schermen van De Vooruit",
+        "datelineEdition": "Archief Editie",
+        "datelineBrand": "Archiefdienst",
+        "datelinePrice": "Prijs: Onschatbaar",
+        "loading": "Artikels laden...",
+        "noArticlesTitle": "Nog geen verhalen",
+        "noArticlesText": "Er zijn momenteel geen gepubliceerde artikels. Kom later terug voor nieuwe verhalen uit het archief.",
+        "listLabel": "{count, plural, one {# artikel} other {# artikels}}",
+        "untitled": "Zonder titel",
+        "readMore": "Lees meer",
+        "backToArticles": "Terug naar artikels",
+        "notFoundTitle": "Artikel niet gevonden",
+        "notFoundText": "Dit artikel bestaat niet of is niet langer beschikbaar.",
+        "relatedEntities": "Gerelateerd",
+        "relatedProductions": "Producties",
+        "relatedArtists": "Artiesten",
+        "relatedLocations": "Locaties",
+        "relatedEvents": "Voorstellingen"
     }
 }

--- a/frontend/src/messages/nl.json
+++ b/frontend/src/messages/nl.json
@@ -318,6 +318,8 @@
         "backToArticles": "Terug naar artikels",
         "notFoundTitle": "Artikel niet gevonden",
         "notFoundText": "Dit artikel bestaat niet of is niet langer beschikbaar.",
+        "connectedTo": "Gekoppeld aan",
+        "moreStories": "Meer verhalen",
         "relatedEntities": "Gerelateerd",
         "relatedProductions": "Producties",
         "relatedArtists": "Artiesten",

--- a/frontend/src/messages/nl.json
+++ b/frontend/src/messages/nl.json
@@ -319,7 +319,7 @@
         "notFoundTitle": "Artikel niet gevonden",
         "notFoundText": "Dit artikel bestaat niet of is niet langer beschikbaar.",
         "connectedTo": "Gekoppeld aan",
-        "moreStories": "Meer verhalen",
+        "moreStories": "Meer artikels",
         "relatedEntities": "Gerelateerd",
         "relatedProductions": "Producties",
         "relatedArtists": "Artiesten",

--- a/frontend/src/types/api/generated.ts
+++ b/frontend/src/types/api/generated.ts
@@ -736,6 +736,8 @@ export interface components {
         ArticleListPayload: {
             /** Format: uuid */
             id: string;
+            /** Format: date-time */
+            published_at?: string | null;
             slug: string;
             status: components["schemas"]["ArticleStatus"];
             /** Format: date */
@@ -752,6 +754,8 @@ export interface components {
             created_at: string;
             /** Format: uuid */
             id: string;
+            /** Format: date-time */
+            published_at?: string | null;
             slug: string;
             status: components["schemas"]["ArticleStatus"];
             /** Format: date */

--- a/frontend/src/types/models/article.types.ts
+++ b/frontend/src/types/models/article.types.ts
@@ -8,20 +8,28 @@ export type Article = {
     content: Record<string, unknown> | null;
     createdAt: string;
     updatedAt: string;
+    publishedAt: string | null;
     subjectPeriodStart: string | null;
     subjectPeriodEnd: string | null;
 };
 
 export type ArticleListItem = Pick<
     Article,
-    "id" | "slug" | "status" | "title" | "updatedAt" | "subjectPeriodStart" | "subjectPeriodEnd"
+    | "id"
+    | "slug"
+    | "status"
+    | "title"
+    | "updatedAt"
+    | "publishedAt"
+    | "subjectPeriodStart"
+    | "subjectPeriodEnd"
 >;
 
 export type ArticleCreateInput = {
     title?: string | null;
 };
 
-export type ArticleUpdateInput = Omit<Article, "createdAt" | "updatedAt">;
+export type ArticleUpdateInput = Omit<Article, "createdAt" | "updatedAt" | "publishedAt">;
 
 export type ArticleRelations = {
     productionIds: string[];

--- a/frontend/test/e2e/articles.spec.ts
+++ b/frontend/test/e2e/articles.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect } from "@playwright/test";
+import { mockApi } from "./utils/mockApi";
+
+test.describe("Articles Page", () => {
+    test.beforeEach(async ({ page }) => {
+        await mockApi(page);
+    });
+
+    test("should display the articles list page with published articles", async ({ page }) => {
+        await page.goto("/nl/articles");
+        await page.waitForLoadState("networkidle");
+
+        // Hero section should be visible
+        await expect(page.locator("h1")).toContainText("Artikels");
+
+        // Both articles should be rendered
+        await expect(page.getByText("Kleurenstudies van De Vooruit")).toBeVisible();
+        await expect(page.getByText("De Balzaal door de jaren heen")).toBeVisible();
+    });
+
+    test("should navigate from article list to article detail", async ({ page }) => {
+        await page.goto("/nl/articles");
+        await page.waitForLoadState("networkidle");
+
+        // Click the first article
+        await page.getByText("Kleurenstudies van De Vooruit").first().click();
+
+        // Should navigate to the detail page
+        await page.waitForURL("**/articles/kleurenstudies-van-de-vooruit");
+        await page.waitForLoadState("networkidle");
+
+        // Article title should be visible in the detail header
+        const heading = page.locator("h1");
+        await expect(heading).toContainText("Kleurenstudies van De Vooruit");
+
+        // Tiptap rendered content should be visible
+        await expect(page.getByText("Het begin")).toBeVisible();
+        await expect(
+            page.getByText("In de jaren 60 begon een revolutie in de kunstwereld van Gent.")
+        ).toBeVisible();
+    });
+
+    test("should have a back link that navigates to the articles list", async ({ page }) => {
+        await page.goto("/nl/articles/kleurenstudies-van-de-vooruit");
+        await page.waitForLoadState("networkidle");
+
+        // Click back link
+        const backLink = page.getByText(/terug naar artikels/i);
+        await expect(backLink).toBeVisible();
+        await backLink.click();
+
+        await page.waitForURL("**/articles");
+        await expect(page.getByText("Kleurenstudies van De Vooruit")).toBeVisible();
+    });
+
+    test("should show the articles nav link in the header", async ({ page }) => {
+        await page.goto("/nl/articles");
+        await page.waitForLoadState("networkidle");
+
+        // The header should have an Artikels nav link
+        const artikelsLink = page.locator("header").getByText("Artikels", { exact: true });
+        await expect(artikelsLink).toBeVisible();
+    });
+
+    test("should show connected entities and related articles on detail page", async ({ page }) => {
+        await page.goto("/nl/articles/kleurenstudies-van-de-vooruit");
+        await page.waitForLoadState("networkidle");
+
+        // Static connected entities section
+        await expect(page.getByText("Gekoppeld aan")).toBeVisible();
+        await expect(page.getByText("The Second Woman — Natali Broods")).toBeVisible();
+
+        // Static related articles section
+        await expect(page.getByText("Meer verhalen")).toBeVisible();
+        await expect(page.getByText("De Balzaal door de jaren heen")).toBeVisible();
+    });
+
+    test("should display the dateline bar with dates on detail page", async ({ page }) => {
+        await page.goto("/nl/articles/kleurenstudies-van-de-vooruit");
+        await page.waitForLoadState("networkidle");
+
+        // Dateline brand should be visible
+        await expect(page.getByText("Archiefdienst")).toBeVisible();
+
+        // Subject period should be shown
+        await expect(page.getByText(/1960/)).toBeVisible();
+    });
+});

--- a/frontend/test/e2e/utils/mockApi.ts
+++ b/frontend/test/e2e/utils/mockApi.ts
@@ -6,6 +6,8 @@ type PaginatedProductionResponse = components["schemas"]["PaginatedResponse_Prod
 type PaginatedEventResponse = components["schemas"]["PaginatedResponse_EventPayload"];
 type PaginatedLocationResponse = components["schemas"]["PaginatedResponse_LocationPayload"];
 type FacetResponse = components["schemas"]["FacetResponse"];
+type ArticleListPayload = components["schemas"]["ArticleListPayload"];
+type ArticlePayload = components["schemas"]["ArticlePayload"];
 
 /**
  * Mocks the backend API responses for E2E tests.
@@ -90,5 +92,85 @@ export async function mockApi(page: Page) {
     const emptyFacets: FacetResponse[] = [];
     await page.route("**/api/taxonomy/facets**", async (route) => {
         await route.fulfill({ json: emptyFacets });
+    });
+
+    // Mock articles
+    const articles: ArticleListPayload[] = [
+        {
+            id: "aaaaaaaa-bbbb-4ccc-dddd-eeeeeeeeeeee",
+            slug: "kleurenstudies-van-de-vooruit",
+            status: "published",
+            title: "Kleurenstudies van De Vooruit",
+            updated_at: "2026-03-20T14:00:00Z",
+            subject_period_start: "1960-01-01",
+            subject_period_end: "1970-12-31",
+        },
+        {
+            id: "bbbbbbbb-cccc-4ddd-eeee-ffffffffffff",
+            slug: "de-balzaal-door-de-jaren-heen",
+            status: "published",
+            title: "De Balzaal door de jaren heen",
+            updated_at: "2026-02-10T09:00:00Z",
+            subject_period_start: "1960-01-01",
+            subject_period_end: "1980-12-31",
+        },
+    ];
+
+    const articleDetail: ArticlePayload = {
+        id: "aaaaaaaa-bbbb-4ccc-dddd-eeeeeeeeeeee",
+        slug: "kleurenstudies-van-de-vooruit",
+        status: "published",
+        title: "Kleurenstudies van De Vooruit",
+        content: {
+            type: "doc",
+            content: [
+                {
+                    type: "heading",
+                    attrs: { level: 2 },
+                    content: [{ type: "text", text: "Het begin" }],
+                },
+                {
+                    type: "paragraph",
+                    content: [
+                        {
+                            type: "text",
+                            text: "In de jaren 60 begon een revolutie in de kunstwereld van Gent.",
+                        },
+                    ],
+                },
+            ],
+        },
+        created_at: "2026-01-15T10:30:00Z",
+        updated_at: "2026-03-20T14:00:00Z",
+        subject_period_start: "1960-01-01",
+        subject_period_end: "1970-12-31",
+    };
+
+    // GET /api/articles (public list) and GET /api/articles/:slug (public detail)
+    await page.route("**/api/articles**", async (route) => {
+        if (route.request().method() !== "GET") {
+            await route.continue();
+            return;
+        }
+        const pathname = new URL(route.request().url()).pathname;
+        // Skip CMS routes
+        if (pathname.includes("/cms")) {
+            await route.continue();
+            return;
+        }
+        const segments = pathname.split("/").filter(Boolean);
+        const artIdx = segments.indexOf("articles");
+        const slug = segments[artIdx + 1];
+
+        if (slug) {
+            const match = articles.find((a) => a.slug === slug);
+            if (match) {
+                await route.fulfill({ json: articleDetail });
+            } else {
+                await route.fulfill({ status: 404, json: { message: "Not found" } });
+            }
+            return;
+        }
+        await route.fulfill({ json: articles });
     });
 }

--- a/frontend/test/integration/hooks/useArticles.test.tsx
+++ b/frontend/test/integration/hooks/useArticles.test.tsx
@@ -1,0 +1,179 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { HttpResponse, http } from "msw";
+import { describe, expect, it, vi } from "vitest";
+
+import type { components } from "@/types/api/generated";
+import { queryKeys } from "@/hooks/api";
+import {
+    useGetArticles,
+    useGetArticleBySlug,
+    useGetArticlesCms,
+    useGetArticle,
+} from "@/hooks/api/useArticles";
+import { articleFull, articleListItems } from "../../msw/handlers/articles.handlers";
+import { server } from "../../msw/server";
+import { apiUrl } from "../../utils/env";
+import { createQueryClientWrapper } from "../../utils/query-client";
+
+vi.mock("next-intl", () => ({
+    useTranslations: () => (key: string) => key,
+}));
+
+// ── Public hooks ─────────────────────────────────────────────────────
+
+describe("useGetArticles (public)", () => {
+    it("fetches published articles and maps them to domain models", async () => {
+        const { wrapper, queryClient } = createQueryClientWrapper();
+
+        const { result } = renderHook(() => useGetArticles(), { wrapper });
+
+        await waitFor(() => {
+            expect(result.current.isSuccess).toBe(true);
+        });
+
+        const articles = result.current.data!;
+        expect(articles).toHaveLength(2);
+
+        // Verify camelCase mapping from snake_case API response
+        expect(articles[0]).toEqual({
+            id: articleListItems[0]!.id,
+            slug: articleListItems[0]!.slug,
+            status: articleListItems[0]!.status,
+            title: articleListItems[0]!.title,
+            updatedAt: articleListItems[0]!.updated_at,
+            subjectPeriodStart: articleListItems[0]!.subject_period_start,
+            subjectPeriodEnd: articleListItems[0]!.subject_period_end,
+        });
+
+        // Verify query cache key
+        const cached = queryClient.getQueryData(queryKeys.articles.published);
+        expect(cached).toEqual(articles);
+    });
+
+    it("returns empty array when no articles exist", async () => {
+        server.use(
+            http.get(apiUrl("/articles"), ({ request }) => {
+                const url = new URL(request.url);
+                if (url.pathname.includes("/cms")) return;
+                return HttpResponse.json(
+                    [] satisfies components["schemas"]["ArticleListPayload"][]
+                );
+            })
+        );
+
+        const { wrapper } = createQueryClientWrapper();
+        const { result } = renderHook(() => useGetArticles(), { wrapper });
+
+        await waitFor(() => {
+            expect(result.current.isSuccess).toBe(true);
+        });
+
+        expect(result.current.data).toEqual([]);
+    });
+});
+
+describe("useGetArticleBySlug (public)", () => {
+    it("fetches a single published article by slug with full content", async () => {
+        const { wrapper, queryClient } = createQueryClientWrapper();
+
+        const { result } = renderHook(() => useGetArticleBySlug("kleurenstudies-van-de-vooruit"), {
+            wrapper,
+        });
+
+        await waitFor(() => {
+            expect(result.current.isSuccess).toBe(true);
+        });
+
+        const article = result.current.data!;
+        expect(article.id).toBe(articleFull.id);
+        expect(article.slug).toBe(articleFull.slug);
+        expect(article.title).toBe(articleFull.title);
+        expect(article.content).toEqual(articleFull.content);
+        expect(article.createdAt).toBe(articleFull.created_at);
+        expect(article.updatedAt).toBe(articleFull.updated_at);
+        expect(article.subjectPeriodStart).toBe(articleFull.subject_period_start);
+        expect(article.subjectPeriodEnd).toBe(articleFull.subject_period_end);
+
+        // Verify query cache key
+        const cached = queryClient.getQueryData(
+            queryKeys.articles.bySlug("kleurenstudies-van-de-vooruit")
+        );
+        expect(cached).toEqual(article);
+    });
+
+    it("returns error for non-existent slug", async () => {
+        const { wrapper } = createQueryClientWrapper();
+
+        const { result } = renderHook(() => useGetArticleBySlug("does-not-exist"), {
+            wrapper,
+        });
+
+        await waitFor(() => {
+            expect(result.current.isError).toBe(true);
+        });
+    });
+
+    it("does not fetch when slug is empty", async () => {
+        const { wrapper } = createQueryClientWrapper();
+
+        const { result } = renderHook(() => useGetArticleBySlug(""), { wrapper });
+
+        // Should stay idle — enabled guard prevents fetch
+        expect(result.current.fetchStatus).toBe("idle");
+    });
+
+    it("respects the enabled option", async () => {
+        const { wrapper } = createQueryClientWrapper();
+
+        const { result } = renderHook(
+            () => useGetArticleBySlug("kleurenstudies-van-de-vooruit", { enabled: false }),
+            { wrapper }
+        );
+
+        expect(result.current.fetchStatus).toBe("idle");
+    });
+});
+
+// ── CMS hooks (existing, verify they still work with new handlers) ───
+
+describe("useGetArticlesCms", () => {
+    it("fetches all articles for CMS", async () => {
+        const { wrapper } = createQueryClientWrapper();
+
+        const { result } = renderHook(() => useGetArticlesCms(), { wrapper });
+
+        await waitFor(() => {
+            expect(result.current.isSuccess).toBe(true);
+        });
+
+        expect(result.current.data).toHaveLength(2);
+        expect(result.current.data![0]!.slug).toBe("kleurenstudies-van-de-vooruit");
+    });
+});
+
+describe("useGetArticle (CMS by id)", () => {
+    it("fetches a single article by UUID", async () => {
+        const { wrapper } = createQueryClientWrapper();
+
+        const { result } = renderHook(() => useGetArticle(articleFull.id), { wrapper });
+
+        await waitFor(() => {
+            expect(result.current.isSuccess).toBe(true);
+        });
+
+        expect(result.current.data!.id).toBe(articleFull.id);
+        expect(result.current.data!.content).toEqual(articleFull.content);
+    });
+
+    it("returns error for non-existent id", async () => {
+        const { wrapper } = createQueryClientWrapper();
+
+        const { result } = renderHook(() => useGetArticle("00000000-0000-0000-0000-000000000000"), {
+            wrapper,
+        });
+
+        await waitFor(() => {
+            expect(result.current.isError).toBe(true);
+        });
+    });
+});

--- a/frontend/test/msw/handlers/articles.handlers.ts
+++ b/frontend/test/msw/handlers/articles.handlers.ts
@@ -1,0 +1,93 @@
+import { http, HttpResponse } from "msw";
+
+import type { components } from "@/types/api/generated";
+import { apiUrl } from "../../utils/env";
+
+export const articleFull: components["schemas"]["ArticlePayload"] = {
+    id: "aaaaaaaa-bbbb-4ccc-dddd-eeeeeeeeeeee",
+    slug: "kleurenstudies-van-de-vooruit",
+    status: "published",
+    title: "Kleurenstudies van De Vooruit",
+    content: {
+        type: "doc",
+        content: [
+            {
+                type: "heading",
+                attrs: { level: 2 },
+                content: [{ type: "text", text: "Het begin" }],
+            },
+            {
+                type: "paragraph",
+                content: [
+                    {
+                        type: "text",
+                        text: "In de jaren 60 begon een revolutie in de kunstwereld van Gent.",
+                    },
+                ],
+            },
+        ],
+    },
+    created_at: "2026-01-15T10:30:00Z",
+    updated_at: "2026-03-20T14:00:00Z",
+    subject_period_start: "1960-01-01",
+    subject_period_end: "1970-12-31",
+};
+
+export const articleListItems: components["schemas"]["ArticleListPayload"][] = [
+    {
+        id: "aaaaaaaa-bbbb-4ccc-dddd-eeeeeeeeeeee",
+        slug: "kleurenstudies-van-de-vooruit",
+        status: "published",
+        title: "Kleurenstudies van De Vooruit",
+        updated_at: "2026-03-20T14:00:00Z",
+        subject_period_start: "1960-01-01",
+        subject_period_end: "1970-12-31",
+    },
+    {
+        id: "bbbbbbbb-cccc-4ddd-eeee-ffffffffffff",
+        slug: "de-balzaal-door-de-jaren-heen",
+        status: "published",
+        title: "De Balzaal door de jaren heen",
+        updated_at: "2026-02-10T09:00:00Z",
+        subject_period_start: "1960-01-01",
+        subject_period_end: "1980-12-31",
+    },
+];
+
+export const articleHandlers = [
+    // Public: list published articles
+    http.get(apiUrl("/articles"), ({ request }) => {
+        const url = new URL(request.url);
+        // Don't match CMS paths
+        if (url.pathname.includes("/cms")) return;
+        return HttpResponse.json(
+            articleListItems satisfies components["schemas"]["ArticleListPayload"][]
+        );
+    }),
+
+    // Public: single article by slug
+    http.get(apiUrl("/articles/:slug"), ({ params }) => {
+        const { slug } = params;
+        if (slug === "cms") return; // pass through CMS routes
+        if (slug === articleFull.slug) {
+            return HttpResponse.json(articleFull satisfies components["schemas"]["ArticlePayload"]);
+        }
+        return HttpResponse.json({ message: "Not found" }, { status: 404 });
+    }),
+
+    // CMS: list all articles
+    http.get(apiUrl("/articles/cms"), () => {
+        return HttpResponse.json(
+            articleListItems satisfies components["schemas"]["ArticleListPayload"][]
+        );
+    }),
+
+    // CMS: single article by id
+    http.get(apiUrl("/articles/cms/:id"), ({ params }) => {
+        const { id } = params;
+        if (id === articleFull.id) {
+            return HttpResponse.json(articleFull satisfies components["schemas"]["ArticlePayload"]);
+        }
+        return HttpResponse.json({ message: "Not found" }, { status: 404 });
+    }),
+];

--- a/frontend/test/msw/handlers/index.ts
+++ b/frontend/test/msw/handlers/index.ts
@@ -1,3 +1,4 @@
+import { articleHandlers } from "./articles.handlers";
 import { authHandlers } from "./auth.handlers";
 import { eventHandlers } from "./events.handlers";
 import { hallHandlers } from "./halls.handlers";
@@ -7,6 +8,7 @@ import { spaceHandlers } from "./spaces.handlers";
 import { taxonomyHandlers } from "./taxonomy.handlers";
 
 export const handlers = [
+    ...articleHandlers,
     ...authHandlers,
     ...eventHandlers,
     ...locationHandlers,

--- a/frontend/test/unit/mappers/article.mapper.test.ts
+++ b/frontend/test/unit/mappers/article.mapper.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vitest";
+
+import type { components } from "@/types/api/generated";
+import {
+    mapArticle,
+    mapArticleListItem,
+    mapArticleListItems,
+    mapArticleRelations,
+    mapCreateArticleInput,
+    mapUpdateArticleInput,
+    mapUpdateArticleRelationsInput,
+} from "@/mappers/article.mapper";
+
+// ── Typed fixtures that break when backend schema changes ────────────
+
+const articleResponse: components["schemas"]["ArticlePayload"] = {
+    id: "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
+    slug: "kleurenstudies-van-de-vooruit",
+    status: "published",
+    title: "Kleurenstudies van De Vooruit",
+    content: {
+        type: "doc",
+        content: [{ type: "paragraph", content: [{ type: "text", text: "Eerste alinea." }] }],
+    },
+    created_at: "2026-01-15T10:30:00Z",
+    updated_at: "2026-03-20T14:00:00Z",
+    subject_period_start: "1960-01-01",
+    subject_period_end: "1970-12-31",
+};
+
+const articleListResponse: components["schemas"]["ArticleListPayload"] = {
+    id: "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
+    slug: "kleurenstudies-van-de-vooruit",
+    status: "published",
+    title: "Kleurenstudies van De Vooruit",
+    updated_at: "2026-03-20T14:00:00Z",
+    subject_period_start: "1960-01-01",
+    subject_period_end: "1970-12-31",
+};
+
+const relationsResponse: components["schemas"]["ArticleRelationsPayload"] = {
+    production_ids: ["p1", "p2"],
+    artist_ids: ["a1"],
+    location_ids: ["l1", "l2", "l3"],
+    event_ids: [],
+};
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe("article mapper", () => {
+    describe("mapArticle", () => {
+        it("maps a full article response to the domain model", () => {
+            const mapped = mapArticle(articleResponse);
+
+            expect(mapped).toEqual({
+                id: "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
+                slug: "kleurenstudies-van-de-vooruit",
+                status: "published",
+                title: "Kleurenstudies van De Vooruit",
+                content: {
+                    type: "doc",
+                    content: [
+                        { type: "paragraph", content: [{ type: "text", text: "Eerste alinea." }] },
+                    ],
+                },
+                createdAt: "2026-01-15T10:30:00Z",
+                updatedAt: "2026-03-20T14:00:00Z",
+                subjectPeriodStart: "1960-01-01",
+                subjectPeriodEnd: "1970-12-31",
+            });
+        });
+
+        it("maps nullable fields to null when absent", () => {
+            const minimal: components["schemas"]["ArticlePayload"] = {
+                id: "00000000-0000-0000-0000-000000000000",
+                slug: "untitled",
+                status: "draft",
+                created_at: "2026-01-01T00:00:00Z",
+                updated_at: "2026-01-01T00:00:00Z",
+            };
+
+            const mapped = mapArticle(minimal);
+
+            expect(mapped.title).toBeNull();
+            expect(mapped.content).toBeNull();
+            expect(mapped.subjectPeriodStart).toBeNull();
+            expect(mapped.subjectPeriodEnd).toBeNull();
+        });
+
+        it("throws on invalid content shape", () => {
+            const bad: components["schemas"]["ArticlePayload"] = {
+                ...articleResponse,
+                content: "not-an-object" as unknown,
+            };
+
+            expect(() => mapArticle(bad)).toThrow("Unexpected article content shape");
+        });
+    });
+
+    describe("mapArticleListItem / mapArticleListItems", () => {
+        it("maps a single list response to domain model", () => {
+            const mapped = mapArticleListItem(articleListResponse);
+
+            expect(mapped).toEqual({
+                id: "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
+                slug: "kleurenstudies-van-de-vooruit",
+                status: "published",
+                title: "Kleurenstudies van De Vooruit",
+                updatedAt: "2026-03-20T14:00:00Z",
+                subjectPeriodStart: "1960-01-01",
+                subjectPeriodEnd: "1970-12-31",
+            });
+        });
+
+        it("maps a batch of list responses", () => {
+            const second: components["schemas"]["ArticleListPayload"] = {
+                ...articleListResponse,
+                id: "bbbbbbbb-0000-0000-0000-000000000000",
+                slug: "ander-artikel",
+                title: "Ander Artikel",
+            };
+
+            const mapped = mapArticleListItems([articleListResponse, second]);
+
+            expect(mapped).toHaveLength(2);
+            expect(mapped[0]?.slug).toBe("kleurenstudies-van-de-vooruit");
+            expect(mapped[1]?.slug).toBe("ander-artikel");
+        });
+    });
+
+    describe("mapArticleRelations", () => {
+        it("maps snake_case relation IDs to camelCase", () => {
+            const mapped = mapArticleRelations(relationsResponse);
+
+            expect(mapped).toEqual({
+                productionIds: ["p1", "p2"],
+                artistIds: ["a1"],
+                locationIds: ["l1", "l2", "l3"],
+                eventIds: [],
+            });
+        });
+    });
+
+    describe("mapCreateArticleInput", () => {
+        it("maps create input to API request", () => {
+            const result = mapCreateArticleInput({ title: "Nieuw Artikel" });
+            expect(result).toEqual({ title: "Nieuw Artikel" });
+        });
+
+        it("maps null title", () => {
+            const result = mapCreateArticleInput({ title: null });
+            expect(result).toEqual({ title: null });
+        });
+    });
+
+    describe("mapUpdateArticleInput", () => {
+        it("maps update input to snake_case API request", () => {
+            const result = mapUpdateArticleInput({
+                id: "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
+                slug: "updated-slug",
+                status: "archived",
+                title: "Updated Title",
+                content: { type: "doc", content: [] },
+                subjectPeriodStart: "2020-01-01",
+                subjectPeriodEnd: "2020-12-31",
+            });
+
+            expect(result).toEqual({
+                slug: "updated-slug",
+                status: "archived",
+                title: "Updated Title",
+                content: { type: "doc", content: [] },
+                subject_period_start: "2020-01-01",
+                subject_period_end: "2020-12-31",
+            });
+        });
+    });
+
+    describe("mapUpdateArticleRelationsInput", () => {
+        it("maps camelCase relation IDs back to snake_case", () => {
+            const result = mapUpdateArticleRelationsInput({
+                productionIds: ["p1"],
+                artistIds: [],
+                locationIds: ["l1"],
+                eventIds: ["e1", "e2"],
+            });
+
+            expect(result).toEqual({
+                production_ids: ["p1"],
+                artist_ids: [],
+                location_ids: ["l1"],
+                event_ids: ["e1", "e2"],
+            });
+        });
+    });
+});


### PR DESCRIPTION
**Description**

Adds a public-facing articles/stories page to the archive frontend. Users can browse published articles and read full article content rendered from the CMS tiptap editor.

**What's included:**
- Public article list page (`/articles`) with newspaper hero, dateline bar, and responsive card grid
- Public article detail page (`/articles/[slug]`) with tiptap JSON content rendering, dateline, subject period, and back navigation
- Two new public API hooks: `useGetArticles()` and `useGetArticleBySlug(slug)` connecting to `GET /articles` and `GET /articles/{slug}`
- Read-only tiptap renderer component reusing the same StarterKit extensions as the CMS editor for rendering parity
- "Connected to" section (productions, artists, locations) and "More stories" section on the detail page with static placeholder data
- "Artikels" nav link added to both the Masthead and SearchHeader navigations
- `Masthead.nav.*` i18n translations added for all nav links (were previously missing)
- Full `Articles` i18n namespace in both NL and EN

**Related Issue**
Fixes #

**How Has This Been Tested?**
- [x] Local manual testing
- [x] Added/updated unit or integration tests
- [ ] Tested in the staging environment

**Test coverage added:**
- 10 unit tests — article mapper (all directions: API-to-domain, domain-to-API, relations, edge cases)
- 9 integration tests — `useGetArticles`, `useGetArticleBySlug`, `useGetArticlesCms`, `useGetArticle` hooks with MSW
- 6 E2E tests — list page rendering, list-to-detail navigation, back link, header nav, connected entities, dateline
- All test fixtures use `components["schemas"]["..."]` from generated OpenAPI types with `satisfies` — backend schema changes break tests at compile time

**Developer Checklist:**
- [x] I have performed a self-review of my own code.
- [x] I have left comments in hard-to-understand areas of my code.
- [x] My changes generate no new warnings or console errors.
- [ ] I have updated the documentation (if applicable).

**TODO (follow-up):**
- [ ] Add public backend endpoint for article relations (e.g. `GET /articles/{slug}/relations`) and replace static data in the "Connected to" section
- [ ] Replace static "More stories" section with actual related/recent articles from the API
- [ ] Make connected entity items clickable (link to production/artist/location pages once those public routes exist)

**Screenshots / Video (if UI/UX changed):**

<img width="1397" height="1170" alt="image" src="https://github.com/user-attachments/assets/d49eb064-6e8e-4106-a926-6c8f1da54fc7" />
<img width="918" height="671" alt="image" src="https://github.com/user-attachments/assets/f70d7a5b-f1ed-45b6-b0ea-86a69689f02e" />
<img width="401" height="679" alt="image" src="https://github.com/user-attachments/assets/944fddca-1e71-4255-8515-5fd33aa7cf43" />
<img width="1370" height="654" alt="image" src="https://github.com/user-attachments/assets/cb140162-7cf5-4173-82d9-efc72a71d67f" />
