### PR TITLE
feat: published at and style updates

### DIFF
--- a/backend/database/src/models/article.rs
+++ b/backend/database/src/models/article.rs
@@ -29,6 +29,7 @@ pub struct Article {
     pub id: Uuid,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    pub published_at: Option<DateTime<Utc>>,
     pub slug: String,
     pub status: ArticleStatus,
     pub title: Option<String>,

--- a/backend/migrations/20260408000000_articles_published_at.down.sql
+++ b/backend/migrations/20260408000000_articles_published_at.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE articles DROP COLUMN published_at;

--- a/backend/migrations/20260408000000_articles_published_at.up.sql
+++ b/backend/migrations/20260408000000_articles_published_at.up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE articles ADD COLUMN published_at TIMESTAMPTZ;
+
+-- Backfill: set published_at = updated_at for already-published articles
+UPDATE articles SET published_at = updated_at WHERE status = 'published';

--- a/backend/src/dto/article.rs
+++ b/backend/src/dto/article.rs
@@ -22,6 +22,7 @@ pub struct ArticlePayload {
     pub content: Option<Value>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    pub published_at: Option<DateTime<Utc>>,
     pub subject_period_start: Option<NaiveDate>,
     pub subject_period_end: Option<NaiveDate>,
 }
@@ -36,6 +37,7 @@ impl From<Article> for ArticlePayload {
             content: a.content,
             created_at: a.created_at,
             updated_at: a.updated_at,
+            published_at: a.published_at,
             subject_period_start: a.subject_period_start,
             subject_period_end: a.subject_period_end,
         }
@@ -78,10 +80,17 @@ impl ArticleUpdatePayload {
             )));
         }
 
+        let published_at = if self.status == ArticleStatus::Published && existing.published_at.is_none() {
+            Some(Utc::now())
+        } else {
+            existing.published_at
+        };
+
         let article = Article {
             id: existing.id,
             created_at: existing.created_at,
             updated_at: Utc::now(),
+            published_at,
             slug: self.slug,
             status: self.status,
             title: self.title,
@@ -100,6 +109,7 @@ pub struct ArticleListPayload {
     pub status: ArticleStatus,
     pub title: Option<String>,
     pub updated_at: DateTime<Utc>,
+    pub published_at: Option<DateTime<Utc>>,
     pub subject_period_start: Option<NaiveDate>,
     pub subject_period_end: Option<NaiveDate>,
 }
@@ -112,6 +122,7 @@ impl From<Article> for ArticleListPayload {
             status: a.status,
             title: a.title,
             updated_at: a.updated_at,
+            published_at: a.published_at,
             subject_period_start: a.subject_period_start,
             subject_period_end: a.subject_period_end,
         }
@@ -181,6 +192,7 @@ impl ArticlePostPayload {
             subject_period_end: None,
             created_at: now,
             updated_at: now,
+            published_at: None,
         };
 
         Ok(db.articles().insert(create).await?.into())

--- a/frontend/src/app/[locale]/(app)/articles/[slug]/page.tsx
+++ b/frontend/src/app/[locale]/(app)/articles/[slug]/page.tsx
@@ -22,19 +22,6 @@ function formatDate(dateStr: string, locale: string): string {
     });
 }
 
-function formatPeriod(start: string | null, end: string | null, locale: string): string | null {
-    const loc = locale === "en" ? "en-GB" : "nl-BE";
-    const opts: Intl.DateTimeFormatOptions = { month: "long", year: "numeric" };
-
-    if (start && end) {
-        return `${new Date(start).toLocaleDateString(loc, opts)} — ${new Date(end).toLocaleDateString(loc, opts)}`;
-    }
-    if (start) {
-        return new Date(start).toLocaleDateString(loc, opts);
-    }
-    return null;
-}
-
 // TODO: replace with real data from API when backend supports public article relations
 const STATIC_CONNECTED_ENTITIES = [
     { type: "Productie", label: "The Second Woman — Natali Broods" },
@@ -98,27 +85,17 @@ export default function ArticleDetailPage({ params }: { params: Promise<{ slug: 
                     </Link>
 
                     {/* Article header */}
-                    <header className="border-foreground mb-8 border-b-[3px] pb-6">
-                        {/* Subject period */}
-                        {(article.subjectPeriodStart || article.subjectPeriodEnd) && (
-                            <span className="text-muted-foreground mb-3 block font-mono text-[9px] tracking-[2px] uppercase">
-                                {formatPeriod(
-                                    article.subjectPeriodStart,
-                                    article.subjectPeriodEnd,
-                                    locale
-                                )}
-                            </span>
-                        )}
-
+                    <header className="mb-8 pb-6">
                         <h1 className="font-display text-foreground text-[32px] leading-[1.1] font-bold tracking-[-0.025em] sm:text-[44px] md:text-[56px]">
                             {article.title ?? t("untitled")}
                         </h1>
 
                         {/* Dateline bar */}
                         <div className="border-foreground text-foreground mt-6 flex items-center justify-between border-y py-1.5 font-mono text-[9px] tracking-widest uppercase sm:text-[10px]">
-                            <span>{formatDate(article.createdAt, locale)}</span>
+                            <span>
+                                {formatDate(article.publishedAt ?? article.createdAt, locale)}
+                            </span>
                             <span>{t("datelineBrand")}</span>
-                            <span>{formatDate(article.updatedAt, locale)}</span>
                         </div>
                     </header>
 
@@ -132,7 +109,7 @@ export default function ArticleDetailPage({ params }: { params: Promise<{ slug: 
                         <h2 className="text-foreground mb-5 font-mono text-[10px] font-medium tracking-[2px] uppercase">
                             {t("connectedTo")}
                         </h2>
-                        <div className="grid grid-cols-1 gap-px sm:grid-cols-2">
+                        <div className="grid grid-cols-1 gap-px">
                             {STATIC_CONNECTED_ENTITIES.map((entity) => (
                                 <div
                                     key={entity.label}
@@ -150,7 +127,7 @@ export default function ArticleDetailPage({ params }: { params: Promise<{ slug: 
                     </section>
 
                     {/* Related articles — TODO: replace static data with API */}
-                    <section className="border-foreground/20 mx-auto mt-10 max-w-[750px] border-t pt-8 pb-4">
+                    <section className="mx-auto mt-10 max-w-[750px] pt-8 pb-4">
                         <div className="mb-5 flex items-center gap-2.5">
                             <h2 className="text-foreground font-mono text-[10px] font-medium tracking-[2px] uppercase">
                                 {t("moreStories")}

--- a/frontend/src/mappers/article.mapper.ts
+++ b/frontend/src/mappers/article.mapper.ts
@@ -28,6 +28,7 @@ export const mapArticle = (response: ArticleResponse): Article => ({
     content: toArticleContent(response.content),
     createdAt: response.created_at,
     updatedAt: response.updated_at,
+    publishedAt: toNullable(response.published_at),
     subjectPeriodStart: toNullable(response.subject_period_start),
     subjectPeriodEnd: toNullable(response.subject_period_end),
 });
@@ -38,6 +39,7 @@ export const mapArticleListItem = (response: ArticleListResponse): ArticleListIt
     status: response.status,
     title: toNullable(response.title),
     updatedAt: response.updated_at,
+    publishedAt: toNullable(response.published_at),
     subjectPeriodStart: toNullable(response.subject_period_start),
     subjectPeriodEnd: toNullable(response.subject_period_end),
 });

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -319,7 +319,7 @@
         "notFoundTitle": "Article not found",
         "notFoundText": "This article does not exist or is no longer available.",
         "connectedTo": "Connected to",
-        "moreStories": "More stories",
+        "moreStories": "More articles",
         "relatedEntities": "Related",
         "relatedProductions": "Productions",
         "relatedArtists": "Artists",

--- a/frontend/src/messages/nl.json
+++ b/frontend/src/messages/nl.json
@@ -319,7 +319,7 @@
         "notFoundTitle": "Artikel niet gevonden",
         "notFoundText": "Dit artikel bestaat niet of is niet langer beschikbaar.",
         "connectedTo": "Gekoppeld aan",
-        "moreStories": "Meer verhalen",
+        "moreStories": "Meer artikels",
         "relatedEntities": "Gerelateerd",
         "relatedProductions": "Producties",
         "relatedArtists": "Artiesten",

--- a/frontend/src/types/api/generated.ts
+++ b/frontend/src/types/api/generated.ts
@@ -736,6 +736,8 @@ export interface components {
         ArticleListPayload: {
             /** Format: uuid */
             id: string;
+            /** Format: date-time */
+            published_at?: string | null;
             slug: string;
             status: components["schemas"]["ArticleStatus"];
             /** Format: date */
@@ -752,6 +754,8 @@ export interface components {
             created_at: string;
             /** Format: uuid */
             id: string;
+            /** Format: date-time */
+            published_at?: string | null;
             slug: string;
             status: components["schemas"]["ArticleStatus"];
             /** Format: date */

--- a/frontend/src/types/models/article.types.ts
+++ b/frontend/src/types/models/article.types.ts
@@ -8,20 +8,28 @@ export type Article = {
     content: Record<string, unknown> | null;
     createdAt: string;
     updatedAt: string;
+    publishedAt: string | null;
     subjectPeriodStart: string | null;
     subjectPeriodEnd: string | null;
 };
 
 export type ArticleListItem = Pick<
     Article,
-    "id" | "slug" | "status" | "title" | "updatedAt" | "subjectPeriodStart" | "subjectPeriodEnd"
+    | "id"
+    | "slug"
+    | "status"
+    | "title"
+    | "updatedAt"
+    | "publishedAt"
+    | "subjectPeriodStart"
+    | "subjectPeriodEnd"
 >;
 
 export type ArticleCreateInput = {
     title?: string | null;
 };
 
-export type ArticleUpdateInput = Omit<Article, "createdAt" | "updatedAt">;
+export type ArticleUpdateInput = Omit<Article, "createdAt" | "updatedAt" | "publishedAt">;
 
 export type ArticleRelations = {
     productionIds: string[];


### PR DESCRIPTION
Adds `published_at` timestamp to articles (full stack: migration, backend logic, frontend types) and cleans up the article detail page.

- New `published_at` column with backfill for already-published articles. Set on first publish, preserved on subsequent updates.
- Article detail page: dateline bar shows `published_at` instead of `createdAt`/`updatedAt`, removed subject period from header, removed extra dividers
- "Gekoppeld aan" section is always a single-column list instead of a grid
- Renamed "Meer verhalen" to "Meer artikels" / "More articles"

**How Has This Been Tested?**
- [x] Local manual testing
- [ ] Added/updated unit or integration tests
- [ ] Tested in the staging environment

**Developer Checklist:**
- [x] I have performed a self-review of my own code.
- [ ] I have left comments in hard-to-understand areas of my code.
- [x] My changes generate no new warnings or console errors.
- [ ] I have updated the documentation (if applicable).

**Screenshots / Video (if UI/UX changed):**