### PR TITLE
feat(backend): slug support for endpoints

### DIFF
--- a/backend/database/src/repos/collection.rs
+++ b/backend/database/src/repos/collection.rs
@@ -91,6 +91,21 @@ impl<'a> CollectionRepo<'a> {
         }))
     }
 
+    pub async fn by_slug(&self, slug: &str) -> Result<CollectionWithTranslations, DatabaseError> {
+        let collection = sqlx::query_as::<_, Collection>("SELECT * FROM collections WHERE slug = $1")
+            .bind(slug)
+            .fetch_optional(self.db)
+            .await?
+            .ok_or(DatabaseError::NotFound)?;
+
+        let translations = self.fetch_translations_for(collection.id).await?;
+
+        Ok(CollectionWithTranslations {
+            collection,
+            translations,
+        })
+    }
+
     pub async fn insert(
         &self,
         data: CollectionCreate,

--- a/backend/database/src/repos/hall.rs
+++ b/backend/database/src/repos/hall.rs
@@ -29,6 +29,15 @@ impl<'a> HallRepo<'a> {
             .ok_or(DatabaseError::NotFound)
     }
 
+    pub async fn by_slug(&self, slug: &str) -> Result<Hall, DatabaseError> {
+        Hall::select()
+            .where_("slug = $1")
+            .bind(slug)
+            .fetch_optional(self.db)
+            .await?
+            .ok_or(DatabaseError::NotFound)
+    }
+
     pub async fn all(
         &self,
         limit: u32,

--- a/backend/database/src/repos/production/mod.rs
+++ b/backend/database/src/repos/production/mod.rs
@@ -45,6 +45,20 @@ impl<'a> ProductionRepo<'a> {
         })
     }
 
+    pub async fn by_slug(&self, slug: &str) -> Result<ProductionWithTranslations, DatabaseError> {
+        let production = Production::select()
+            .where_("slug = $1")
+            .bind(slug)
+            .fetch_optional(self.db)
+            .await?
+            .ok_or(DatabaseError::NotFound)?;
+        let translations = self.fetch_translations_for(production.id).await?;
+        Ok(ProductionWithTranslations {
+            production,
+            translations,
+        })
+    }
+
     pub async fn insert(
         &self,
         production: ProductionCreate,

--- a/backend/src/dto/collection.rs
+++ b/backend/src/dto/collection.rs
@@ -182,6 +182,12 @@ impl CollectionPayload {
         Ok(build_payload(cwt, items))
     }
 
+    pub async fn by_slug(db: &Database, slug: &str) -> Result<Self, AppError> {
+        let cwt = db.collections().by_slug(slug).await?;
+        let items = db.collections().items_for(cwt.collection.id).await?;
+        Ok(build_payload(cwt, items))
+    }
+
     pub async fn update(self, db: &Database) -> Result<Self, AppError> {
         let translations = collection_translations_to_data(&self.translations);
         let cwt = db

--- a/backend/src/dto/hall.rs
+++ b/backend/src/dto/hall.rs
@@ -48,6 +48,10 @@ impl HallPayload {
         Ok(db.halls().by_id(id).await?.into())
     }
 
+    pub async fn by_slug(db: &Database, slug: &str) -> Result<Self, AppError> {
+        Ok(db.halls().by_slug(slug).await?.into())
+    }
+
     pub async fn update(self, db: &Database) -> Result<Self, AppError> {
         Ok(db.halls().update(self.into()).await?.into())
     }

--- a/backend/src/dto/production.rs
+++ b/backend/src/dto/production.rs
@@ -84,6 +84,10 @@ impl ProductionPayload {
         Ok(payload)
     }
 
+    pub async fn by_slug(db: &Database, slug: &str) -> Result<Self, AppError> {
+        Ok(db.productions().by_slug(slug).await?.into())
+    }
+
     pub async fn update(self, db: &Database) -> Result<Self, AppError> {
         let translations = translations_to_data(&self.translations);
         let production: Production = self.into();

--- a/backend/src/handlers/collection.rs
+++ b/backend/src/handlers/collection.rs
@@ -44,6 +44,24 @@ pub async fn get_one(db: Database, Path(id): Path<Uuid>) -> JsonResponse<Collect
 }
 
 #[utoipa::path(
+    method(get),
+    path = "/collections/slug/{slug}",
+    tag = "Collections",
+    operation_id = "get_collection_by_slug",
+    description = "Get a collection by slug",
+    params(
+        ("slug" = String, Path, description = "Collection slug")
+    ),
+    responses(
+        (status = 200, description = "Success", body = CollectionPayload),
+        (status = 404, description = "Not found")
+    )
+)]
+pub async fn get_one_by_slug(db: Database, Path(slug): Path<String>) -> JsonResponse<CollectionPayload> {
+    CollectionPayload::by_slug(&db, &slug).await?.json()
+}
+
+#[utoipa::path(
     method(post),
     path = "/collections",
     tag = "Collections",

--- a/backend/src/handlers/hall.rs
+++ b/backend/src/handlers/hall.rs
@@ -64,7 +64,7 @@ pub async fn get_one(db: Database, Path(id): Path<Uuid>) -> JsonResponse<HallPay
     method(get),
     path = "/halls/slug/{slug}",
     tag = "Halls",
-    operation_id = "get_one_hall_by_slug",
+    operation_id = "get_hall_by_slug",
     description = "Get a hall by slug",
     params(
         ("slug" = String, Path, description = "Hall slug")

--- a/backend/src/handlers/hall.rs
+++ b/backend/src/handlers/hall.rs
@@ -61,6 +61,24 @@ pub async fn get_one(db: Database, Path(id): Path<Uuid>) -> JsonResponse<HallPay
 }
 
 #[utoipa::path(
+    method(get),
+    path = "/halls/slug/{slug}",
+    tag = "Halls",
+    operation_id = "get_one_hall_by_slug",
+    description = "Get a hall by slug",
+    params(
+        ("slug" = String, Path, description = "Hall slug")
+    ),
+    responses(
+        (status = 200, description = "Success", body = HallPayload),
+        (status = 404, description = "Not found")
+    )
+)]
+pub async fn get_one_by_slug(db: Database, Path(slug): Path<String>) -> JsonResponse<HallPayload> {
+    HallPayload::by_slug(&db, &slug).await?.json()
+}
+
+#[utoipa::path(
     method(post),
     path = "/halls",
     tag = "Halls",

--- a/backend/src/handlers/location.rs
+++ b/backend/src/handlers/location.rs
@@ -74,7 +74,7 @@ pub async fn get_one(db: Database, Path(id): Path<Uuid>) -> JsonResponse<Locatio
         (status = 404, description = "Not found")
     )
 )]
-pub async fn get_by_slug(db: Database, Path(slug): Path<String>) -> JsonResponse<LocationPayload> {
+pub async fn get_one_by_slug(db: Database, Path(slug): Path<String>) -> JsonResponse<LocationPayload> {
     LocationPayload::by_slug(&db, &slug).await?.json()
 }
 

--- a/backend/src/handlers/location.rs
+++ b/backend/src/handlers/location.rs
@@ -65,7 +65,7 @@ pub async fn get_one(db: Database, Path(id): Path<Uuid>) -> JsonResponse<Locatio
     path = "/locations/slug/{slug}",
     tag = "Locations",
     operation_id = "get_location_by_slug",
-    description = "Get location by slug",
+    description = "Get a location by slug",
     params(
         ("slug" = String, Path, description = "Location slug")
     ),

--- a/backend/src/handlers/production.rs
+++ b/backend/src/handlers/production.rs
@@ -74,6 +74,24 @@ pub async fn get_one(
 
 #[utoipa::path(
     method(get),
+    path = "/productions/slug/{slug}",
+    tag = "Productions",
+    operation_id = "get_production_by_slug",
+    description = "Get a production by slug",
+    params(
+        ("slug" = String, Path, description = "Production slug")
+    ),
+    responses(
+        (status = 200, description = "Success", body = ProductionPayload),
+        (status = 404, description = "Not found")
+    )
+)]
+pub async fn get_one_by_slug(db: Database, Path(slug): Path<String>) -> JsonResponse<ProductionPayload> {
+    ProductionPayload::by_slug(&db, &slug).await?.json()
+}
+
+#[utoipa::path(
+    method(get),
     path = "/productions/{id}/events",
     tag = "Productions",
     operation_id = "get_events_by_production_id",

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -271,6 +271,7 @@ fn public_routes() -> OpenApiRouter<AppState> {
         // collections
         .routes(routes!(collection::get_all))
         .routes(routes!(collection::get_one))
+        .routes(routes!(collection::get_one_by_slug))
         // series
         .routes(routes!(series::get_all))
         .routes(routes!(series::get_one))

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -248,6 +248,7 @@ fn public_routes() -> OpenApiRouter<AppState> {
         // production
         .routes(routes!(production::get_all))
         .routes(routes!(production::get_one))
+        .routes(routes!(production::get_one_by_slug))
         .routes(routes!(production::get_events))
         // hall
         .routes(routes!(hall::get_all))

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -244,7 +244,7 @@ fn public_routes() -> OpenApiRouter<AppState> {
         // location
         .routes(routes!(location::get_all))
         .routes(routes!(location::get_one))
-        .routes(routes!(location::get_by_slug))
+        .routes(routes!(location::get_one_by_slug))
         // production
         .routes(routes!(production::get_all))
         .routes(routes!(production::get_one))

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -253,6 +253,7 @@ fn public_routes() -> OpenApiRouter<AppState> {
         // hall
         .routes(routes!(hall::get_all))
         .routes(routes!(hall::get_one))
+        .routes(routes!(hall::get_one_by_slug))
         // space
         .routes(routes!(space::get_all))
         .routes(routes!(space::get_one))

--- a/backend/tests/collection.rs
+++ b/backend/tests/collection.rs
@@ -57,6 +57,39 @@ async fn get_one_not_found(db: PgPool) {
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
+#[sqlx::test(fixtures("collections"))]
+#[test_log::test]
+async fn get_one_by_slug_success(db: PgPool) {
+    let app = TestRouter::new(db);
+
+    let response = app.get("/collections/slug/zomerselectie").await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let data: CollectionPayload = response.into_struct().await;
+    assert_eq!(data.slug, "zomerselectie");
+    assert_eq!(data.id.to_string(),"20000000-0000-0000-0000-000000000001");
+    let nl = data
+        .translations
+        .iter()
+        .find(|t| t.language_code == "nl")
+        .expect("Dutch translation not found");
+    assert_eq!(nl.title, "Zomerselectie");
+    assert_eq!(data.items.len(), 2);
+    let first_item = data.items.first().expect("expected first collection item");
+    assert_eq!(first_item.position, 1);
+    let second_item = data.items.get(1).expect("expected second collection item");
+    assert_eq!(second_item.position, 2);
+}
+
+#[sqlx::test]
+#[test_log::test]
+async fn get_one_by_slug_not_found(db: PgPool) {
+    let app = TestRouter::new(db);
+
+    let response = app.get("/collections/slug/does-not-exist").await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
 #[sqlx::test]
 #[test_log::test]
 async fn post_success(db: PgPool) {

--- a/backend/tests/hall.rs
+++ b/backend/tests/hall.rs
@@ -154,6 +154,29 @@ async fn get_one_not_found(db: PgPool) {
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
+#[sqlx::test(fixtures("locations", "spaces", "halls"))]
+#[test_log::test]
+async fn get_one_by_slug_success(db: PgPool) {
+    let app = TestRouter::new(db);
+
+    let response = app.get("/halls/slug/zaal-a").await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let data: HallPayload = response.into_struct().await;
+    assert_eq!(data.name, "Zaal A SEARCH");
+    assert_eq!(data.slug, "zaal-a");
+    assert_eq!(data.id.to_string(),"30000000-0000-0000-0000-000000000001");
+}
+
+#[sqlx::test]
+#[test_log::test]
+async fn get_one_by_slug_not_found(db: PgPool) {
+    let app = TestRouter::new(db);
+
+    let response = app.get("/halls/slug/does-not-exist").await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
 #[sqlx::test(fixtures("locations", "spaces"))]
 #[test_log::test]
 async fn post_success(db: PgPool) {

--- a/backend/tests/location.rs
+++ b/backend/tests/location.rs
@@ -155,9 +155,18 @@ async fn get_one_success(db: PgPool) {
     assert_eq!(data.translations.len(), 2);
 }
 
+#[sqlx::test]
+#[test_log::test]
+async fn get_one_not_found(db: PgPool) {
+    let app = TestRouter::new(db);
+
+    let response = app.get(&format!("/locations/{}", Uuid::nil())).await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
 #[sqlx::test(fixtures("locations"))]
 #[test_log::test]
-async fn get_by_slug_success(db: PgPool) {
+async fn get_one_by_slug_success(db: PgPool) {
     let app = TestRouter::new(db);
 
     let response = app.get("/locations/slug/de-vooruit").await;
@@ -167,23 +176,15 @@ async fn get_by_slug_success(db: PgPool) {
     assert_eq!(data.name.as_deref(), Some("De Vooruit SEARCH"));
     assert_eq!(data.slug.as_deref(), Some("de-vooruit"));
     assert_eq!(data.translations.len(), 2);
-}
-
-#[sqlx::test(fixtures("locations"))]
-#[test_log::test]
-async fn get_by_slug_not_found(db: PgPool) {
-    let app = TestRouter::new(db);
-
-    let response = app.get("/locations/slug/nonexistent").await;
-    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    assert_eq!(data.id.to_string(),"10000000-0000-0000-0000-000000000001");
 }
 
 #[sqlx::test]
 #[test_log::test]
-async fn get_one_not_found(db: PgPool) {
+async fn get_one_by_slug_not_found(db: PgPool) {
     let app = TestRouter::new(db);
 
-    let response = app.get(&format!("/locations/{}", Uuid::nil())).await;
+    let response = app.get("/locations/slug/does-not-exist").await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 

--- a/backend/tests/production.rs
+++ b/backend/tests/production.rs
@@ -574,6 +574,28 @@ async fn get_one_not_found(db: PgPool) {
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
+#[sqlx::test(fixtures("productions"))]
+#[test_log::test]
+async fn get_one_by_slug_success(db: PgPool) {
+    let app = TestRouter::new(db);
+
+    let response = app.get("/productions/slug/heavy-metal-knitting-2026").await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let data: ProductionPayload = response.into_struct().await;
+    assert_eq!(data.slug, "heavy-metal-knitting-2026");
+    assert_eq!(data.id.to_string(), "11111111-1111-1111-1111-111111111111");
+}
+
+#[sqlx::test]
+#[test_log::test]
+async fn get_one_by_slug_not_found(db: PgPool) {
+    let app = TestRouter::new(db);
+
+    let response = app.get("/productions/slug/does-not-exist").await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
 #[sqlx::test]
 #[test_log::test]
 async fn post_success(db: PgPool) {


### PR DESCRIPTION
**Description**
Adds slug-based lookup endpoints for productions, halls, locations and collections.
* `GET /productions/slug/{slug}`
* `GET /halls/slug/{slug}`
* `GET /locations/slug/{slug}`
* `GET /collections/slug/{slug}` 

Each endpoint follows the existing `by_id` pattern with a new `by_slug` method in the repo and DTO.
I'm going to implement this for artists once #269 is merged.

**Related Issue**
Fixes #

**How Has This Been Tested?**
- [x] Local manual testing
- [ ] Added/updated unit or integration tests
- [ ] Tested in the staging environment

**Developer Checklist:**
- [x] I have performed a self-review of my own code.
- [ ] I have left comments in hard-to-understand areas of my code.
- [x] My changes generate no new warnings or console errors.
- [ ] I have updated the documentation (if applicable).

**Screenshots / Video (if UI/UX changed):**