### PR TITLE
feat: gatekeep preview with labelke

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -2,7 +2,7 @@ name: PR Preview
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, closed]
+    types: [opened, synchronize, reopened, closed, labeled, unlabeled]
 
 concurrency:
   group: preview-${{ github.ref }}
@@ -28,7 +28,10 @@ jobs:
     secrets: inherit
 
   preview:
-    if: github.event.action != 'closed'
+    if: >-
+      github.event.action != 'closed' &&
+      github.event.action != 'unlabeled' &&
+      contains(github.event.pull_request.labels.*.name, 'preview')
     runs-on: self-hosted
     environment: preview
     needs: [run_backend_tests, run_frontend_tests]
@@ -130,7 +133,11 @@ jobs:
             });
 
   cleanup:
-    if: github.event.action == 'closed'
+    if: >-
+      (github.event.action == 'closed' &&
+       contains(github.event.pull_request.labels.*.name, 'preview')) ||
+      (github.event.action == 'unlabeled' &&
+       github.event.label.name == 'preview')
     runs-on: self-hosted
     environment: preview
     steps:


### PR DESCRIPTION
Make the per-PR preview deploy opt-in via a `preview` label on the PR, so the self-hosted runner only spins up a stack when explicitly requested.

- Add `labeled` and `unlabeled` to the `pull_request` trigger types
- Gate the `preview` job on the `preview` label being present (and skip on `closed`/`unlabeled` events)
- Gate the `cleanup` job on either PR close while labeled, or removal of the `preview` label

**Related Issue**
Fixes #

**How Has This Been Tested?**
- [ ] Local manual testing
- [ ] Added/updated unit or integration tests
- [ ] Tested in the staging environment

**Developer Checklist:**
- [ ] I have performed a self-review of my own code.
- [ ] I have left comments in hard-to-understand areas of my code.
- [ ] My changes generate no new warnings or console errors.
- [ ] I have updated the documentation (if applicable).

**Screenshots / Video (if UI/UX changed):**