### PR TITLE
chore(backend): split importer and fetch

### DIFF
--- a/backend/api/src/insert/event_prices.rs
+++ b/backend/api/src/insert/event_prices.rs
@@ -4,60 +4,58 @@ use tracing::warn;
 use crate::helper::{extract_source_id, parse_amount_cents};
 use crate::models::event_price::ApiEventPrice;
 
-pub async fn insert_event_price(
-    db: &Database,
-    event_price: ApiEventPrice,
-) -> Result<(), DatabaseError> {
-    let Some(amount_cents) = parse_amount_cents(&event_price.amount) else {
-        warn!(
-            "EventPrices: invalid amount '{}' for event price {}, skipping",
-            event_price.amount, event_price.id
-        );
-        return Ok(());
-    };
+impl ApiEventPrice {
+    pub async fn insert(self, db: &Database) -> Result<(), DatabaseError> {
+        let Some(amount_cents) = parse_amount_cents(&self.amount) else {
+            warn!(
+                "EventPrices: invalid amount '{}' for event price {}, skipping",
+                self.amount, self.id
+            );
+            return Ok(());
+        };
 
-    let Some(event_source_id) = extract_source_id(&event_price.event) else {
-        warn!("EventPrices: event_price has no event source_id, skipping");
-        return Ok(());
-    };
+        let Some(event_source_id) = extract_source_id(&self.event) else {
+            warn!("EventPrices: event_price has no event source_id, skipping");
+            return Ok(());
+        };
 
-    let Some(price_source_id) = extract_source_id(&event_price.price) else {
-        warn!("EventPrices: event_price has no price source_id, skipping");
-        return Ok(());
-    };
+        let Some(price_source_id) = extract_source_id(&self.price) else {
+            warn!("EventPrices: event_price has no price source_id, skipping");
+            return Ok(());
+        };
 
-    let Some(rank_source_id) = extract_source_id(&event_price.rank) else {
-        warn!("EventPrices: event_price has no rank source_id, skipping");
-        return Ok(());
-    };
+        let Some(rank_source_id) = extract_source_id(&self.rank) else {
+            warn!("EventPrices: event_price has no rank source_id, skipping");
+            return Ok(());
+        };
 
-    let Some(event) = db.events().by_source_id(event_source_id).await? else {
-        warn!("EventPrices: event source_id {event_source_id} not found in db, skipping");
-        return Ok(());
-    };
+        let Some(event) = db.events().by_source_id(event_source_id).await? else {
+            warn!("EventPrices: event source_id {event_source_id} not found in db, skipping");
+            return Ok(());
+        };
 
-    let Some(price) = db.prices().by_source_id(price_source_id).await? else {
-        warn!("EventPrices: price source_id {price_source_id} not found in db, skipping");
-        return Ok(());
-    };
+        let Some(price) = db.prices().by_source_id(price_source_id).await? else {
+            warn!("EventPrices: price source_id {price_source_id} not found in db, skipping");
+            return Ok(());
+        };
 
-    let Some(rank) = db.price_ranks().by_source_id(rank_source_id).await? else {
-        warn!("EventPrices: rank source_id {rank_source_id} not found in db, skipping");
-        return Ok(());
-    };
+        let Some(rank) = db.price_ranks().by_source_id(rank_source_id).await? else {
+            warn!("EventPrices: rank source_id {rank_source_id} not found in db, skipping");
+            return Ok(());
+        };
 
-    let source_id = extract_source_id(&event_price.id);
+        let source_id = extract_source_id(&self.id);
 
-    if let Some(source_id) = source_id
-        && let Some(existing) = db.event_prices().by_source_id(source_id).await?
-    {
-        let model =
-            event_price.to_model(existing.id, event.id, price.id, rank.id, amount_cents);
-        db.event_prices().update(model).await?;
-        return Ok(());
+        if let Some(source_id) = source_id
+            && let Some(existing) = db.event_prices().by_source_id(source_id).await?
+        {
+            let model = self.to_model(existing.id, event.id, price.id, rank.id, amount_cents);
+            db.event_prices().update(model).await?;
+            return Ok(());
+        }
+
+        let event_price_create = self.to_create(event.id, price.id, rank.id, amount_cents);
+        db.event_prices().insert(event_price_create).await?;
+        Ok(())
     }
-
-    let event_price_create = event_price.to_create(event.id, price.id, rank.id, amount_cents);
-    db.event_prices().insert(event_price_create).await?;
-    Ok(())
 }

--- a/backend/api/src/insert/event_prices.rs
+++ b/backend/api/src/insert/event_prices.rs
@@ -1,0 +1,63 @@
+use database::{Database, error::DatabaseError};
+use tracing::warn;
+
+use crate::helper::{extract_source_id, parse_amount_cents};
+use crate::models::event_price::ApiEventPrice;
+
+pub async fn insert_event_price(
+    db: &Database,
+    event_price: ApiEventPrice,
+) -> Result<(), DatabaseError> {
+    let Some(amount_cents) = parse_amount_cents(&event_price.amount) else {
+        warn!(
+            "EventPrices: invalid amount '{}' for event price {}, skipping",
+            event_price.amount, event_price.id
+        );
+        return Ok(());
+    };
+
+    let Some(event_source_id) = extract_source_id(&event_price.event) else {
+        warn!("EventPrices: event_price has no event source_id, skipping");
+        return Ok(());
+    };
+
+    let Some(price_source_id) = extract_source_id(&event_price.price) else {
+        warn!("EventPrices: event_price has no price source_id, skipping");
+        return Ok(());
+    };
+
+    let Some(rank_source_id) = extract_source_id(&event_price.rank) else {
+        warn!("EventPrices: event_price has no rank source_id, skipping");
+        return Ok(());
+    };
+
+    let Some(event) = db.events().by_source_id(event_source_id).await? else {
+        warn!("EventPrices: event source_id {event_source_id} not found in db, skipping");
+        return Ok(());
+    };
+
+    let Some(price) = db.prices().by_source_id(price_source_id).await? else {
+        warn!("EventPrices: price source_id {price_source_id} not found in db, skipping");
+        return Ok(());
+    };
+
+    let Some(rank) = db.price_ranks().by_source_id(rank_source_id).await? else {
+        warn!("EventPrices: rank source_id {rank_source_id} not found in db, skipping");
+        return Ok(());
+    };
+
+    let source_id = extract_source_id(&event_price.id);
+
+    if let Some(source_id) = source_id
+        && let Some(existing) = db.event_prices().by_source_id(source_id).await?
+    {
+        let model =
+            event_price.to_model(existing.id, event.id, price.id, rank.id, amount_cents);
+        db.event_prices().update(model).await?;
+        return Ok(());
+    }
+
+    let event_price_create = event_price.to_create(event.id, price.id, rank.id, amount_cents);
+    db.event_prices().insert(event_price_create).await?;
+    Ok(())
+}

--- a/backend/api/src/insert/events.rs
+++ b/backend/api/src/insert/events.rs
@@ -1,0 +1,30 @@
+use database::{Database, error::DatabaseError};
+use tracing::warn;
+
+use crate::models::event::ApiEvent;
+
+pub async fn insert_event(db: &Database, event: ApiEvent) -> Result<(), DatabaseError> {
+    let Some(prod_source_id) = event.production_source_id() else {
+        warn!("Events: event has no production source_id, skipping");
+        return Ok(());
+    };
+
+    let Some(production) = db.productions().by_source_id(prod_source_id).await? else {
+        warn!("Events: production source_id {prod_source_id} not found in db, skipping");
+        return Ok(());
+    };
+
+    let hall_uuid = if let Some(hall_source_id) = event.hall_source_id() {
+        let hall_opt = db.halls().by_source_id(hall_source_id).await?;
+        if hall_opt.is_none() {
+            warn!("Events: hall source_id {hall_source_id} not found in db");
+        }
+        hall_opt.map(|h| h.id)
+    } else {
+        None
+    };
+
+    let event_create = event.to_create(production.production.id, hall_uuid);
+    db.events().insert(event_create).await?;
+    Ok(())
+}

--- a/backend/api/src/insert/events.rs
+++ b/backend/api/src/insert/events.rs
@@ -3,28 +3,30 @@ use tracing::warn;
 
 use crate::models::event::ApiEvent;
 
-pub async fn insert_event(db: &Database, event: ApiEvent) -> Result<(), DatabaseError> {
-    let Some(prod_source_id) = event.production_source_id() else {
-        warn!("Events: event has no production source_id, skipping");
-        return Ok(());
-    };
+impl ApiEvent {
+    pub async fn insert(self, db: &Database) -> Result<(), DatabaseError> {
+        let Some(prod_source_id) = self.production_source_id() else {
+            warn!("Events: event has no production source_id, skipping");
+            return Ok(());
+        };
 
-    let Some(production) = db.productions().by_source_id(prod_source_id).await? else {
-        warn!("Events: production source_id {prod_source_id} not found in db, skipping");
-        return Ok(());
-    };
+        let Some(production) = db.productions().by_source_id(prod_source_id).await? else {
+            warn!("Events: production source_id {prod_source_id} not found in db, skipping");
+            return Ok(());
+        };
 
-    let hall_uuid = if let Some(hall_source_id) = event.hall_source_id() {
-        let hall_opt = db.halls().by_source_id(hall_source_id).await?;
-        if hall_opt.is_none() {
-            warn!("Events: hall source_id {hall_source_id} not found in db");
-        }
-        hall_opt.map(|h| h.id)
-    } else {
-        None
-    };
+        let hall_uuid = if let Some(hall_source_id) = self.hall_source_id() {
+            let hall_opt = db.halls().by_source_id(hall_source_id).await?;
+            if hall_opt.is_none() {
+                warn!("Events: hall source_id {hall_source_id} not found in db");
+            }
+            hall_opt.map(|h| h.id)
+        } else {
+            None
+        };
 
-    let event_create = event.to_create(production.production.id, hall_uuid);
-    db.events().insert(event_create).await?;
-    Ok(())
+        let event_create = self.to_create(production.production.id, hall_uuid);
+        db.events().insert(event_create).await?;
+        Ok(())
+    }
 }

--- a/backend/api/src/insert/halls.rs
+++ b/backend/api/src/insert/halls.rs
@@ -4,20 +4,22 @@ use tracing::warn;
 use crate::helper::extract_source_id;
 use crate::models::hall::ApiHall;
 
-pub async fn insert_hall(db: &Database, hall: ApiHall) -> Result<(), DatabaseError> {
-    let source_id = hall.space.as_deref().and_then(extract_source_id);
-    let space_uuid = match source_id {
-        Some(id) => {
-            let db_uuid = db.spaces().by_source_id(id).await?.map(|s| s.id);
-            if db_uuid.is_none() {
-                warn!("Halls: Space source_id {id} expected but not found in db");
+impl ApiHall {
+    pub async fn insert(self, db: &Database) -> Result<(), DatabaseError> {
+        let source_id = self.space.as_deref().and_then(extract_source_id);
+        let space_uuid = match source_id {
+            Some(id) => {
+                let db_uuid = db.spaces().by_source_id(id).await?.map(|s| s.id);
+                if db_uuid.is_none() {
+                    warn!("Halls: Space source_id {id} expected but not found in db");
+                }
+                db_uuid
             }
-            db_uuid
-        }
-        None => None,
-    };
+            None => None,
+        };
 
-    let hall_create = hall.to_create(space_uuid);
-    db.halls().insert(hall_create).await?;
-    Ok(())
+        let hall_create = self.to_create(space_uuid);
+        db.halls().insert(hall_create).await?;
+        Ok(())
+    }
 }

--- a/backend/api/src/insert/halls.rs
+++ b/backend/api/src/insert/halls.rs
@@ -1,0 +1,23 @@
+use database::{Database, error::DatabaseError};
+use tracing::warn;
+
+use crate::helper::extract_source_id;
+use crate::models::hall::ApiHall;
+
+pub async fn insert_hall(db: &Database, hall: ApiHall) -> Result<(), DatabaseError> {
+    let source_id = hall.space.as_deref().and_then(extract_source_id);
+    let space_uuid = match source_id {
+        Some(id) => {
+            let db_uuid = db.spaces().by_source_id(id).await?.map(|s| s.id);
+            if db_uuid.is_none() {
+                warn!("Halls: Space source_id {id} expected but not found in db");
+            }
+            db_uuid
+        }
+        None => None,
+    };
+
+    let hall_create = hall.to_create(space_uuid);
+    db.halls().insert(hall_create).await?;
+    Ok(())
+}

--- a/backend/api/src/insert/locations.rs
+++ b/backend/api/src/insert/locations.rs
@@ -2,7 +2,9 @@ use database::{Database, error::DatabaseError};
 
 use crate::models::location::ApiLocation;
 
-pub async fn insert_location(db: &Database, location: ApiLocation) -> Result<(), DatabaseError> {
-    db.locations().insert(location.into(), vec![]).await?;
-    Ok(())
+impl ApiLocation {
+    pub async fn insert(self, db: &Database) -> Result<(), DatabaseError> {
+        db.locations().insert(self.into(), vec![]).await?;
+        Ok(())
+    }
 }

--- a/backend/api/src/insert/locations.rs
+++ b/backend/api/src/insert/locations.rs
@@ -1,0 +1,8 @@
+use database::{Database, error::DatabaseError};
+
+use crate::models::location::ApiLocation;
+
+pub async fn insert_location(db: &Database, location: ApiLocation) -> Result<(), DatabaseError> {
+    db.locations().insert(location.into(), vec![]).await?;
+    Ok(())
+}

--- a/backend/api/src/insert/mod.rs
+++ b/backend/api/src/insert/mod.rs
@@ -1,7 +1,5 @@
-//! Per-entity DB insert logic extracted from `ApiImporter`.
-//!
-//! each function takes a `&Database` plus one already-parsed `Api*` struct and performs the FK lookups + insert
-//! Shared between the live importer (HTTP-driven) and the offline seed binary
+//! each submodule provides an inherent `insert` method on its `Api*` struct
+//! that performs the FK lookups + insert. Shared between the live importer
 
 pub mod event_prices;
 pub mod events;

--- a/backend/api/src/insert/mod.rs
+++ b/backend/api/src/insert/mod.rs
@@ -1,0 +1,15 @@
+//! Per-entity DB insert logic extracted from `ApiImporter`.
+//!
+//! Each function takes a `&Database` plus one already-parsed `Api*` struct and
+//! performs the FK lookups + insert the live importer used to do inline.
+//! Shared between the live importer (HTTP-driven) and the offline seed binary
+//! (disk-driven). No HTTP, no S3.
+
+pub mod event_prices;
+pub mod events;
+pub mod halls;
+pub mod locations;
+pub mod price_ranks;
+pub mod prices;
+pub mod productions;
+pub mod spaces;

--- a/backend/api/src/insert/mod.rs
+++ b/backend/api/src/insert/mod.rs
@@ -1,9 +1,7 @@
 //! Per-entity DB insert logic extracted from `ApiImporter`.
 //!
-//! Each function takes a `&Database` plus one already-parsed `Api*` struct and
-//! performs the FK lookups + insert the live importer used to do inline.
+//! each function takes a `&Database` plus one already-parsed `Api*` struct and performs the FK lookups + insert
 //! Shared between the live importer (HTTP-driven) and the offline seed binary
-//! (disk-driven). No HTTP, no S3.
 
 pub mod event_prices;
 pub mod events;

--- a/backend/api/src/insert/price_ranks.rs
+++ b/backend/api/src/insert/price_ranks.rs
@@ -3,17 +3,19 @@ use database::{Database, error::DatabaseError};
 use crate::helper::extract_source_id;
 use crate::models::price_rank::ApiPriceRank;
 
-pub async fn insert_price_rank(db: &Database, rank: ApiPriceRank) -> Result<(), DatabaseError> {
-    let source_id = extract_source_id(&rank.id);
+impl ApiPriceRank {
+    pub async fn insert(self, db: &Database) -> Result<(), DatabaseError> {
+        let source_id = extract_source_id(&self.id);
 
-    if let Some(source_id) = source_id
-        && let Some(existing) = db.price_ranks().by_source_id(source_id).await?
-    {
-        let model = rank.to_model(existing.id);
-        db.price_ranks().update(model).await?;
-        return Ok(());
+        if let Some(source_id) = source_id
+            && let Some(existing) = db.price_ranks().by_source_id(source_id).await?
+        {
+            let model = self.to_model(existing.id);
+            db.price_ranks().update(model).await?;
+            return Ok(());
+        }
+
+        db.price_ranks().insert(self.into()).await?;
+        Ok(())
     }
-
-    db.price_ranks().insert(rank.into()).await?;
-    Ok(())
 }

--- a/backend/api/src/insert/price_ranks.rs
+++ b/backend/api/src/insert/price_ranks.rs
@@ -1,0 +1,19 @@
+use database::{Database, error::DatabaseError};
+
+use crate::helper::extract_source_id;
+use crate::models::price_rank::ApiPriceRank;
+
+pub async fn insert_price_rank(db: &Database, rank: ApiPriceRank) -> Result<(), DatabaseError> {
+    let source_id = extract_source_id(&rank.id);
+
+    if let Some(source_id) = source_id
+        && let Some(existing) = db.price_ranks().by_source_id(source_id).await?
+    {
+        let model = rank.to_model(existing.id);
+        db.price_ranks().update(model).await?;
+        return Ok(());
+    }
+
+    db.price_ranks().insert(rank.into()).await?;
+    Ok(())
+}

--- a/backend/api/src/insert/prices.rs
+++ b/backend/api/src/insert/prices.rs
@@ -3,17 +3,19 @@ use database::{Database, error::DatabaseError};
 use crate::helper::extract_source_id;
 use crate::models::price::ApiPrice;
 
-pub async fn insert_price(db: &Database, price: ApiPrice) -> Result<(), DatabaseError> {
-    let source_id = extract_source_id(&price.id);
+impl ApiPrice {
+    pub async fn insert(self, db: &Database) -> Result<(), DatabaseError> {
+        let source_id = extract_source_id(&self.id);
 
-    if let Some(source_id) = source_id
-        && let Some(existing) = db.prices().by_source_id(source_id).await?
-    {
-        let model = price.to_model(existing.id);
-        db.prices().update(model).await?;
-        return Ok(());
+        if let Some(source_id) = source_id
+            && let Some(existing) = db.prices().by_source_id(source_id).await?
+        {
+            let model = self.to_model(existing.id);
+            db.prices().update(model).await?;
+            return Ok(());
+        }
+
+        db.prices().insert(self.into()).await?;
+        Ok(())
     }
-
-    db.prices().insert(price.into()).await?;
-    Ok(())
 }

--- a/backend/api/src/insert/prices.rs
+++ b/backend/api/src/insert/prices.rs
@@ -1,0 +1,19 @@
+use database::{Database, error::DatabaseError};
+
+use crate::helper::extract_source_id;
+use crate::models::price::ApiPrice;
+
+pub async fn insert_price(db: &Database, price: ApiPrice) -> Result<(), DatabaseError> {
+    let source_id = extract_source_id(&price.id);
+
+    if let Some(source_id) = source_id
+        && let Some(existing) = db.prices().by_source_id(source_id).await?
+    {
+        let model = price.to_model(existing.id);
+        db.prices().update(model).await?;
+        return Ok(());
+    }
+
+    db.prices().insert(price.into()).await?;
+    Ok(())
+}

--- a/backend/api/src/insert/productions.rs
+++ b/backend/api/src/insert/productions.rs
@@ -2,24 +2,21 @@ use database::{Database, error::DatabaseError};
 
 use crate::models::production::{ApiProduction, ProductionImportData};
 
-/// Inserts a production + translations.
-///
-/// Returns the 404 API source_id so the live importer can drive per-production
-/// gallery fetches. The seed binary ignores this.
-pub async fn insert_production(
-    db: &Database,
-    production: ApiProduction,
-) -> Result<Option<i32>, DatabaseError> {
-    let source_id = production
-        .id
-        .split('/')
-        .next_back()
-        .and_then(|s| s.parse::<i32>().ok());
+impl ApiProduction {
+    /// returns the 404 API source_id so the live importer can drive per-production
+    /// gallery fetches. seed binary ignores this.
+    pub async fn insert(self, db: &Database) -> Result<Option<i32>, DatabaseError> {
+        let source_id = self
+            .id
+            .split('/')
+            .next_back()
+            .and_then(|s| s.parse::<i32>().ok());
 
-    let data: ProductionImportData = production.into();
-    db.productions()
-        .insert(data.production, data.translations)
-        .await?;
+        let data: ProductionImportData = self.into();
+        db.productions()
+            .insert(data.production, data.translations)
+            .await?;
 
-    Ok(source_id)
+        Ok(source_id)
+    }
 }

--- a/backend/api/src/insert/productions.rs
+++ b/backend/api/src/insert/productions.rs
@@ -1,16 +1,13 @@
 use database::{Database, error::DatabaseError};
 
+use crate::helper::extract_source_id;
 use crate::models::production::{ApiProduction, ProductionImportData};
 
 impl ApiProduction {
     /// returns the 404 API source_id so the live importer can drive per-production
     /// gallery fetches. seed binary ignores this.
     pub async fn insert(self, db: &Database) -> Result<Option<i32>, DatabaseError> {
-        let source_id = self
-            .id
-            .split('/')
-            .next_back()
-            .and_then(|s| s.parse::<i32>().ok());
+        let source_id = extract_source_id(&self.id);
 
         let data: ProductionImportData = self.into();
         db.productions()

--- a/backend/api/src/insert/productions.rs
+++ b/backend/api/src/insert/productions.rs
@@ -1,0 +1,25 @@
+use database::{Database, error::DatabaseError};
+
+use crate::models::production::{ApiProduction, ProductionImportData};
+
+/// Inserts a production + translations.
+///
+/// Returns the 404 API source_id so the live importer can drive per-production
+/// gallery fetches. The seed binary ignores this.
+pub async fn insert_production(
+    db: &Database,
+    production: ApiProduction,
+) -> Result<Option<i32>, DatabaseError> {
+    let source_id = production
+        .id
+        .split('/')
+        .next_back()
+        .and_then(|s| s.parse::<i32>().ok());
+
+    let data: ProductionImportData = production.into();
+    db.productions()
+        .insert(data.production, data.translations)
+        .await?;
+
+    Ok(source_id)
+}

--- a/backend/api/src/insert/spaces.rs
+++ b/backend/api/src/insert/spaces.rs
@@ -3,14 +3,16 @@ use database::{Database, error::DatabaseError};
 use crate::helper::extract_source_id;
 use crate::models::space::ApiSpace;
 
-pub async fn insert_space(db: &Database, space: ApiSpace) -> Result<(), DatabaseError> {
-    let location_source_id = extract_source_id(&space.location).unwrap();
-    let location = db
-        .locations()
-        .by_source_id(location_source_id)
-        .await?
-        .unwrap();
-    let space_create = space.to_create(location.location.id);
-    db.spaces().insert(space_create).await?;
-    Ok(())
+impl ApiSpace {
+    pub async fn insert(self, db: &Database) -> Result<(), DatabaseError> {
+        let location_source_id = extract_source_id(&self.location).unwrap();
+        let location = db
+            .locations()
+            .by_source_id(location_source_id)
+            .await?
+            .unwrap();
+        let space_create = self.to_create(location.location.id);
+        db.spaces().insert(space_create).await?;
+        Ok(())
+    }
 }

--- a/backend/api/src/insert/spaces.rs
+++ b/backend/api/src/insert/spaces.rs
@@ -1,0 +1,16 @@
+use database::{Database, error::DatabaseError};
+
+use crate::helper::extract_source_id;
+use crate::models::space::ApiSpace;
+
+pub async fn insert_space(db: &Database, space: ApiSpace) -> Result<(), DatabaseError> {
+    let location_source_id = extract_source_id(&space.location).unwrap();
+    let location = db
+        .locations()
+        .by_source_id(location_source_id)
+        .await?
+        .unwrap();
+    let space_create = space.to_create(location.location.id);
+    db.spaces().insert(space_create).await?;
+    Ok(())
+}

--- a/backend/api/src/lib.rs
+++ b/backend/api/src/lib.rs
@@ -193,10 +193,7 @@ impl ApiImporter {
                     (production.poster_gallery.clone(), "poster"),
                 ];
 
-                let production_source_id =
-                    crate::insert::productions::insert_production(&self.db, production)
-                        .await
-                        .unwrap();
+                let production_source_id = production.insert(&self.db).await.unwrap();
 
                 let Some(source_id) = production_source_id else {
                     continue;
@@ -232,9 +229,7 @@ impl ApiImporter {
             let amt = locations.len();
             info!("Locations: got {amt} from api");
             for location in locations {
-                crate::insert::locations::insert_location(&self.db, location)
-                    .await
-                    .unwrap();
+                location.insert(&self.db).await.unwrap();
             }
             info!("Locations: inserted {amt} into db");
         }
@@ -253,9 +248,7 @@ impl ApiImporter {
             let amt = spaces.len();
             info!("Spaces: got {amt} from api");
             for space in spaces {
-                crate::insert::spaces::insert_space(&self.db, space)
-                    .await
-                    .unwrap();
+                space.insert(&self.db).await.unwrap();
             }
             info!("Spaces: inserted {amt} into db");
         }
@@ -274,9 +267,7 @@ impl ApiImporter {
             let amt = halls.len();
             info!("Halls: got {amt} from api");
             for hall in halls {
-                crate::insert::halls::insert_hall(&self.db, hall)
-                    .await
-                    .unwrap();
+                hall.insert(&self.db).await.unwrap();
             }
             info!("Halls: inserted {amt} into db");
         }
@@ -295,9 +286,7 @@ impl ApiImporter {
             let amt = events.len();
             info!("Events: got {amt} from api");
             for event in events {
-                crate::insert::events::insert_event(&self.db, event)
-                    .await
-                    .unwrap();
+                event.insert(&self.db).await.unwrap();
             }
             info!("Events: inserted {amt} into db");
         }
@@ -315,9 +304,7 @@ impl ApiImporter {
             let amt = prices.len();
             info!("Prices: got {amt} from api");
             for price in prices {
-                crate::insert::prices::insert_price(&self.db, price)
-                    .await
-                    .unwrap();
+                price.insert(&self.db).await.unwrap();
             }
             info!("Prices: inserted {amt} into db");
         }
@@ -337,9 +324,7 @@ impl ApiImporter {
             let amt = ranks.len();
             info!("PriceRanks: got {amt} from api");
             for rank in ranks {
-                crate::insert::price_ranks::insert_price_rank(&self.db, rank)
-                    .await
-                    .unwrap();
+                rank.insert(&self.db).await.unwrap();
             }
             info!("PriceRanks: inserted {amt} into db");
         }
@@ -359,9 +344,7 @@ impl ApiImporter {
             let amt = event_prices.len();
             info!("EventPrices: got {amt} from api");
             for event_price in event_prices {
-                crate::insert::event_prices::insert_event_price(&self.db, event_price)
-                    .await
-                    .unwrap();
+                event_price.insert(&self.db).await.unwrap();
             }
             info!("EventPrices: inserted {amt} into db");
         }

--- a/backend/api/src/lib.rs
+++ b/backend/api/src/lib.rs
@@ -13,7 +13,7 @@ use sha2::{Digest, Sha256};
 use tracing::{info, warn};
 
 use crate::error::ImporterError;
-use crate::helper::{extract_source_id, parse_amount_cents};
+use crate::helper::extract_source_id;
 use crate::models::{
     collection::ApiCollection,
     event::ApiEvent,
@@ -23,13 +23,14 @@ use crate::models::{
     media::{ApiMediaGallery, ApiMediaItem},
     price::ApiPrice,
     price_rank::ApiPriceRank,
-    production::{ApiProduction, ProductionImportData},
+    production::ApiProduction,
     space::ApiSpace,
 };
 use uuid::Uuid;
 
 pub mod error;
 mod helper;
+pub mod insert;
 pub mod models {
     pub mod collection;
     pub mod event;
@@ -186,24 +187,16 @@ impl ApiImporter {
             let amt = productions.len();
             info!("Productions: got {amt} from api");
             for production in productions {
-                let production_source_id = production
-                    .id
-                    .split('/')
-                    .next_back()
-                    .and_then(|s| s.parse::<i32>().ok());
-
                 let galleries = [
                     (production.media_gallery.clone(), "media"),
                     (production.review_gallery.clone(), "review"),
                     (production.poster_gallery.clone(), "poster"),
                 ];
 
-                let data: ProductionImportData = production.into();
-                self.db
-                    .productions()
-                    .insert(data.production, data.translations)
-                    .await
-                    .unwrap();
+                let production_source_id =
+                    crate::insert::productions::insert_production(&self.db, production)
+                        .await
+                        .unwrap();
 
                 let Some(source_id) = production_source_id else {
                     continue;
@@ -239,7 +232,9 @@ impl ApiImporter {
             let amt = locations.len();
             info!("Locations: got {amt} from api");
             for location in locations {
-                self.db.locations().insert(location.into(), vec![]).await.unwrap();
+                crate::insert::locations::insert_location(&self.db, location)
+                    .await
+                    .unwrap();
             }
             info!("Locations: inserted {amt} into db");
         }
@@ -258,21 +253,9 @@ impl ApiImporter {
             let amt = spaces.len();
             info!("Spaces: got {amt} from api");
             for space in spaces {
-                // first load in the related location and extract its id
-                let location_source_id = extract_source_id(&space.location).unwrap();
-
-                let location = self
-                    .db
-                    .locations()
-                    .by_source_id(location_source_id)
+                crate::insert::spaces::insert_space(&self.db, space)
                     .await
-                    .unwrap()
                     .unwrap();
-
-                // construct a SpaceCreate out of it
-                let space_create = space.to_create(location.location.id);
-
-                self.db.spaces().insert(space_create).await.unwrap();
             }
             info!("Spaces: inserted {amt} into db");
         }
@@ -291,30 +274,9 @@ impl ApiImporter {
             let amt = halls.len();
             info!("Halls: got {amt} from api");
             for hall in halls {
-                let source_id = hall.space.as_deref().and_then(extract_source_id);
-                let space_uuid = match source_id {
-                    Some(id) => {
-                        // get the uuid of the space with a source id from the db
-                        let db_uuid = self
-                            .db
-                            .spaces()
-                            .by_source_id(id)
-                            .await
-                            .unwrap()
-                            .map(|s| s.id);
-
-                        if db_uuid.is_none() {
-                            warn!("Halls: Space source_id {id} expected but not found in db");
-                        }
-                        db_uuid
-                    }
-                    None => None,
-                };
-
-                // construct a HallCreate out of it
-                let hall_create = hall.to_create(space_uuid);
-
-                self.db.halls().insert(hall_create).await.unwrap();
+                crate::insert::halls::insert_hall(&self.db, hall)
+                    .await
+                    .unwrap();
             }
             info!("Halls: inserted {amt} into db");
         }
@@ -333,38 +295,9 @@ impl ApiImporter {
             let amt = events.len();
             info!("Events: got {amt} from api");
             for event in events {
-                let Some(prod_source_id) = event.production_source_id() else {
-                    warn!("Events: event has no production source_id, skipping");
-                    continue;
-                };
-
-                let Some(production) = self
-                    .db
-                    .productions()
-                    .by_source_id(prod_source_id)
+                crate::insert::events::insert_event(&self.db, event)
                     .await
-                    .unwrap()
-                else {
-                    warn!(
-                        "Events: production source_id {prod_source_id} not found in db, skipping"
-                    );
-                    continue;
-                };
-
-                let hall_uuid = if let Some(hall_source_id) = event.hall_source_id() {
-                    let hall_opt = self.db.halls().by_source_id(hall_source_id).await.unwrap();
-
-                    if hall_opt.is_none() {
-                        warn!("Events: hall source_id {hall_source_id} not found in db");
-                    }
-
-                    hall_opt.map(|h| h.id)
-                } else {
-                    None
-                };
-
-                let event_create = event.to_create(production.production.id, hall_uuid);
-                self.db.events().insert(event_create).await.unwrap();
+                    .unwrap();
             }
             info!("Events: inserted {amt} into db");
         }
@@ -382,17 +315,9 @@ impl ApiImporter {
             let amt = prices.len();
             info!("Prices: got {amt} from api");
             for price in prices {
-                let source_id = extract_source_id(&price.id);
-
-                if let Some(source_id) = source_id
-                    && let Some(existing) = self.db.prices().by_source_id(source_id).await.unwrap()
-                {
-                    let model = price.to_model(existing.id);
-                    self.db.prices().update(model).await.unwrap();
-                    continue;
-                }
-
-                self.db.prices().insert(price.into()).await.unwrap();
+                crate::insert::prices::insert_price(&self.db, price)
+                    .await
+                    .unwrap();
             }
             info!("Prices: inserted {amt} into db");
         }
@@ -412,18 +337,9 @@ impl ApiImporter {
             let amt = ranks.len();
             info!("PriceRanks: got {amt} from api");
             for rank in ranks {
-                let source_id = extract_source_id(&rank.id);
-
-                if let Some(source_id) = source_id
-                    && let Some(existing) =
-                        self.db.price_ranks().by_source_id(source_id).await.unwrap()
-                {
-                    let model = rank.to_model(existing.id);
-                    self.db.price_ranks().update(model).await.unwrap();
-                    continue;
-                }
-
-                self.db.price_ranks().insert(rank.into()).await.unwrap();
+                crate::insert::price_ranks::insert_price_rank(&self.db, rank)
+                    .await
+                    .unwrap();
             }
             info!("PriceRanks: inserted {amt} into db");
         }
@@ -443,92 +359,7 @@ impl ApiImporter {
             let amt = event_prices.len();
             info!("EventPrices: got {amt} from api");
             for event_price in event_prices {
-                let Some(amount_cents) = parse_amount_cents(&event_price.amount) else {
-                    warn!(
-                        "EventPrices: invalid amount '{}' for event price {}, skipping",
-                        event_price.amount, event_price.id
-                    );
-                    continue;
-                };
-
-                let Some(event_source_id) = extract_source_id(&event_price.event) else {
-                    warn!("EventPrices: event_price has no event source_id, skipping");
-                    continue;
-                };
-
-                let Some(price_source_id) = extract_source_id(&event_price.price) else {
-                    warn!("EventPrices: event_price has no price source_id, skipping");
-                    continue;
-                };
-
-                let Some(rank_source_id) = extract_source_id(&event_price.rank) else {
-                    warn!("EventPrices: event_price has no rank source_id, skipping");
-                    continue;
-                };
-
-                let Some(event) = self
-                    .db
-                    .events()
-                    .by_source_id(event_source_id)
-                    .await
-                    .unwrap()
-                else {
-                    warn!(
-                        "EventPrices: event source_id {event_source_id} not found in db, skipping"
-                    );
-                    continue;
-                };
-
-                let Some(price) = self
-                    .db
-                    .prices()
-                    .by_source_id(price_source_id)
-                    .await
-                    .unwrap()
-                else {
-                    warn!(
-                        "EventPrices: price source_id {price_source_id} not found in db, skipping"
-                    );
-                    continue;
-                };
-
-                let Some(rank) = self
-                    .db
-                    .price_ranks()
-                    .by_source_id(rank_source_id)
-                    .await
-                    .unwrap()
-                else {
-                    warn!("EventPrices: rank source_id {rank_source_id} not found in db, skipping");
-                    continue;
-                };
-
-                let source_id = extract_source_id(&event_price.id);
-
-                if let Some(source_id) = source_id
-                    && let Some(existing) = self
-                        .db
-                        .event_prices()
-                        .by_source_id(source_id)
-                        .await
-                        .unwrap()
-                {
-                    let model = event_price.to_model(
-                        existing.id,
-                        event.id,
-                        price.id,
-                        rank.id,
-                        amount_cents,
-                    );
-                    self.db.event_prices().update(model).await.unwrap();
-                    continue;
-                }
-
-                let event_price_create =
-                    event_price.to_create(event.id, price.id, rank.id, amount_cents);
-                self.db
-                    .event_prices()
-                    .insert(event_price_create)
+                crate::insert::event_prices::insert_event_price(&self.db, event_price)
                     .await
                     .unwrap();
             }


### PR DESCRIPTION
Extract per-entity DB insert logic from `ApiImporter` into a new `api::insert` module so both the live HTTP importer and the upcoming offline seed binary (#286) can share it.

- New `backend/api/src/insert/{locations,spaces,halls,productions,events,prices,price_ranks,event_prices}.rs`, one async fn per entity taking `&Database` + a parsed `Api*` struct.
- `update_*` methods in `ApiImporter` shrink to stream-loop + per-item delegate call; S3 gallery logic stays on the live importer (seed binary does not touch S3).
- `insert_production` returns the source_id so the live path can still drive gallery fetches; seed path ignores it.
- Behavior preserved: same lookups, same warn-and-skip on missing FKs, same upsert semantics for prices / price_ranks / event_prices.

**Related Issue**
Fixes #284

**How Has This Been Tested?**
- [ ] Local manual testing
- [ ] Added/updated unit or integration tests
- [ ] Tested in the staging environment

**Developer Checklist:**
- [ ] I have performed a self-review of my own code.
- [ ] I have left comments in hard-to-understand areas of my code.
- [ ] My changes generate no new warnings or console errors.
- [ ] I have updated the documentation (if applicable).

**Screenshots / Video (if UI/UX changed):**