### PR TITLE
feat(api): stats endpoint & year slider/ date picker bounds from /stats

### DIFF
--- a/backend/database/src/repos/article.rs
+++ b/backend/database/src/repos/article.rs
@@ -18,6 +18,17 @@ impl<'a> ArticleRepo<'a> {
         Self { db }
     }
 
+    pub async fn count(&self) -> Result<i64, DatabaseError> {
+        let count = sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM articles WHERE status = $1",
+        )
+        .bind(ArticleStatus::Published)
+        .fetch_one(self.db)
+        .await?;
+
+        Ok(count)
+    }
+
     pub async fn all(&self) -> Result<Vec<Article>, DatabaseError> {
         Ok(Article::select()
             .order_asc("updated_at")

--- a/backend/database/src/repos/article.rs
+++ b/backend/database/src/repos/article.rs
@@ -18,7 +18,7 @@ impl<'a> ArticleRepo<'a> {
         Self { db }
     }
 
-    pub async fn count(&self) -> Result<i64, DatabaseError> {
+    pub async fn count_published(&self) -> Result<i64, DatabaseError> {
         let count = sqlx::query_scalar::<_, i64>(
             "SELECT COUNT(*) FROM articles WHERE status = $1",
         )

--- a/backend/database/src/repos/artist.rs
+++ b/backend/database/src/repos/artist.rs
@@ -19,4 +19,12 @@ impl<'a> ArtistRepo<'a> {
         .fetch_all(self.db)
         .await?)
     }
+
+        pub async fn count(&self) -> Result<i64, DatabaseError> {
+        let count = sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM artists")
+            .fetch_one(self.db)
+            .await?;
+
+        Ok(count)
+    }
 }

--- a/backend/database/src/repos/collection.rs
+++ b/backend/database/src/repos/collection.rs
@@ -27,6 +27,14 @@ impl<'a> CollectionRepo<'a> {
         Self { db }
     }
 
+    pub async fn count(&self) -> Result<i64, DatabaseError> {
+        let count = sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM collections")
+            .fetch_one(self.db)
+            .await?;
+
+        Ok(count)
+    }
+
     pub async fn all(&self) -> Result<Vec<CollectionWithTranslations>, DatabaseError> {
         let collections =
             sqlx::query_as::<_, Collection>("SELECT * FROM collections ORDER BY created_at DESC")

--- a/backend/database/src/repos/event.rs
+++ b/backend/database/src/repos/event.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Utc};
 use ormlite::{Insert, Model};
 use sqlx::PgPool;
 use uuid::Uuid;
@@ -14,6 +15,26 @@ pub struct EventRepo<'a> {
 impl<'a> EventRepo<'a> {
     pub fn new(db: &'a PgPool) -> Self {
         Self { db }
+    }
+
+    pub async fn count(&self) -> Result<i64, DatabaseError> {
+        let count = sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM events")
+            .fetch_one(self.db)
+            .await?;
+
+        Ok(count)
+    }
+
+    pub async fn bounds(
+        &self,
+    ) -> Result<(Option<DateTime<Utc>>, Option<DateTime<Utc>>), DatabaseError> {
+        let (oldest, newest) = sqlx::query_as::<_, (Option<DateTime<Utc>>, Option<DateTime<Utc>>)>(
+            "SELECT MIN(starts_at), MAX(starts_at) FROM events",
+        )
+        .fetch_one(self.db)
+        .await?;
+
+        Ok((oldest, newest))
     }
 
     pub async fn by_id(&self, id: Uuid) -> Result<Event, DatabaseError> {

--- a/backend/database/src/repos/location.rs
+++ b/backend/database/src/repos/location.rs
@@ -25,6 +25,14 @@ impl<'a> LocationRepo<'a> {
         Self { db }
     }
 
+    pub async fn count(&self) -> Result<i64, DatabaseError> {
+        let count = sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM locations")
+            .fetch_one(self.db)
+            .await?;
+
+        Ok(count)
+    }
+
     pub async fn by_id(&self, id: Uuid) -> Result<LocationWithTranslations, DatabaseError> {
         let location = Location::select()
             .where_("id = $1")

--- a/backend/database/src/repos/production.rs
+++ b/backend/database/src/repos/production.rs
@@ -25,6 +25,14 @@ impl<'a> ProductionRepo<'a> {
         Self { db }
     }
 
+    pub async fn count(&self) -> Result<i64, DatabaseError> {
+        let count = sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM productions")
+            .fetch_one(self.db)
+            .await?;
+
+        Ok(count)
+    }
+
     pub async fn by_id(&self, id: Uuid) -> Result<ProductionWithTranslations, DatabaseError> {
         let production = Production::select()
             .where_("id = $1")

--- a/backend/src/dto/mod.rs
+++ b/backend/src/dto/mod.rs
@@ -11,3 +11,4 @@ pub mod media;
 pub mod production;
 pub mod series;
 pub mod space;
+pub mod stats;

--- a/backend/src/dto/stats.rs
+++ b/backend/src/dto/stats.rs
@@ -1,0 +1,50 @@
+use chrono::{DateTime, Utc};
+use database::Database;
+use serde::Serialize;
+use utoipa::ToSchema;
+
+use crate::error::AppError;
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct StatsPayload {
+    pub oldest_event: Option<DateTime<Utc>>,
+    pub newest_event: Option<DateTime<Utc>>,
+    pub event_count: i64,
+    pub production_count: i64,
+    pub location_count: i64,
+    pub article_count: i64,
+}
+
+impl StatsPayload {
+    pub async fn collect(db: &Database) -> Result<Self, AppError> {
+        let db_events_bounds = db.clone();
+        let db_events_count = db.clone();
+        let db_productions = db.clone();
+        let db_locations = db.clone();
+        let db_articles = db.clone();
+
+        let (
+            event_bounds,
+            event_count,
+            production_count,
+            location_count,
+            article_count,
+        ) = tokio::try_join!(
+            async move { db_events_bounds.events().bounds().await },
+            async move { db_events_count.events().count().await },
+            async move { db_productions.productions().count().await },
+            async move { db_locations.locations().count().await },
+            async move { db_articles.articles().count().await },
+        )?;
+        let (oldest_event, newest_event) = event_bounds;
+
+        Ok(Self {
+            oldest_event,
+            newest_event,
+            event_count,
+            production_count,
+            location_count,
+            article_count,
+        })
+    }
+}

--- a/backend/src/dto/stats.rs
+++ b/backend/src/dto/stats.rs
@@ -13,6 +13,8 @@ pub struct StatsPayload {
     pub production_count: i64,
     pub location_count: i64,
     pub article_count: i64,
+    pub artist_count: i64,
+    pub collection_count: i64,
 }
 
 impl StatsPayload {
@@ -22,6 +24,8 @@ impl StatsPayload {
         let db_productions = db.clone();
         let db_locations = db.clone();
         let db_articles = db.clone();
+        let db_artists = db.clone();
+        let db_collections = db.clone();
 
         let (
             event_bounds,
@@ -29,12 +33,16 @@ impl StatsPayload {
             production_count,
             location_count,
             article_count,
+            artist_count,
+            collection_count,
         ) = tokio::try_join!(
             async move { db_events_bounds.events().bounds().await },
             async move { db_events_count.events().count().await },
             async move { db_productions.productions().count().await },
             async move { db_locations.locations().count().await },
             async move { db_articles.articles().count_published().await },
+            async move { db_artists.artists().count().await },
+            async move { db_collections.collections().count().await },
         )?;
         let (oldest_event, newest_event) = event_bounds;
 
@@ -45,6 +53,8 @@ impl StatsPayload {
             production_count,
             location_count,
             article_count,
+            artist_count,
+            collection_count,
         })
     }
 }

--- a/backend/src/dto/stats.rs
+++ b/backend/src/dto/stats.rs
@@ -34,7 +34,7 @@ impl StatsPayload {
             async move { db_events_count.events().count().await },
             async move { db_productions.productions().count().await },
             async move { db_locations.locations().count().await },
-            async move { db_articles.articles().count().await },
+            async move { db_articles.articles().count_published().await },
         )?;
         let (oldest_event, newest_event) = event_bounds;
 

--- a/backend/src/dto/stats.rs
+++ b/backend/src/dto/stats.rs
@@ -19,16 +19,8 @@ pub struct StatsPayload {
 
 impl StatsPayload {
     pub async fn collect(db: &Database) -> Result<Self, AppError> {
-        let db_events_bounds = db.clone();
-        let db_events_count = db.clone();
-        let db_productions = db.clone();
-        let db_locations = db.clone();
-        let db_articles = db.clone();
-        let db_artists = db.clone();
-        let db_collections = db.clone();
-
         let (
-            event_bounds,
+            (oldest_event, newest_event),
             event_count,
             production_count,
             location_count,
@@ -36,16 +28,14 @@ impl StatsPayload {
             artist_count,
             collection_count,
         ) = tokio::try_join!(
-            async move { db_events_bounds.events().bounds().await },
-            async move { db_events_count.events().count().await },
-            async move { db_productions.productions().count().await },
-            async move { db_locations.locations().count().await },
-            async move { db_articles.articles().count_published().await },
-            async move { db_artists.artists().count().await },
-            async move { db_collections.collections().count().await },
+            async { db.events().bounds().await },
+            async { db.events().count().await },
+            async { db.productions().count().await },
+            async { db.locations().count().await },
+            async { db.articles().count_published().await },
+            async { db.artists().count().await },
+            async { db.collections().count().await },
         )?;
-        let (oldest_event, newest_event) = event_bounds;
-
         Ok(Self {
             oldest_event,
             newest_event,

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -1,4 +1,7 @@
-use axum::{Json, http::StatusCode};
+use axum::{
+    Json,
+    http::{HeaderMap, HeaderValue, StatusCode, header::CACHE_CONTROL},
+};
 use serde::Serialize;
 
 use crate::error::AppError;
@@ -16,6 +19,7 @@ pub mod production;
 pub mod series;
 pub mod space;
 pub mod tagging;
+pub mod stats;
 pub mod taxonomy;
 pub mod version;
 pub mod queries {
@@ -26,13 +30,18 @@ pub mod queries {
     pub mod sort;
 }
 
+/// Default `Cache-Control` for publicly cacheable JSON responses (`/stats`, etc.).
+const PUBLIC_CACHE_HEADER: &str = "public, max-age=3600, stale-while-revalidate=86400";
+
 pub type JsonResponse<T> = Result<Json<T>, AppError>;
 pub type JsonStatusResponse<T> = Result<(StatusCode, Json<T>), AppError>;
+pub type JsonCachedResponse<T> = Result<(HeaderMap, Json<T>), AppError>;
 pub type StatusResponse = Result<StatusCode, AppError>;
 
 pub trait IntoApiResponse: Sized {
     fn json_created(self) -> JsonStatusResponse<Self>;
     fn json(self) -> JsonResponse<Self>;
+    fn json_public_cached(self) -> JsonCachedResponse<Self>;
 }
 
 impl<T: Serialize> IntoApiResponse for T {
@@ -42,5 +51,11 @@ impl<T: Serialize> IntoApiResponse for T {
 
     fn json(self) -> JsonResponse<Self> {
         Ok(Json(self))
+    }
+
+    fn json_public_cached(self) -> JsonCachedResponse<Self> {
+        let mut headers = HeaderMap::new();
+        headers.insert(CACHE_CONTROL, HeaderValue::from_static(PUBLIC_CACHE_HEADER));
+        Ok((headers, Json(self)))
     }
 }

--- a/backend/src/handlers/stats.rs
+++ b/backend/src/handlers/stats.rs
@@ -1,0 +1,25 @@
+use database::Database;
+
+use crate::{
+    dto::stats::StatsPayload,
+    handlers::{IntoApiResponse, JsonCachedResponse},
+};
+
+#[utoipa::path(
+    method(get),
+    path = "/stats",
+    tag = "Stats",
+    operation_id = "get_stats",
+    description = "Aggregate public site statistics (cached)",
+    responses(
+        (status = 200, description = "Success", body = StatsPayload,
+            headers(
+                ("Cache-Control" = String,
+                    description = "Public cache: max-age=3600 (1h), stale-while-revalidate=86400 (24h)")
+            )
+        )
+    )
+)]
+pub async fn get(db: Database) -> JsonCachedResponse<StatsPayload> {
+    StatsPayload::collect(&db).await?.json_public_cached()
+}

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -22,9 +22,10 @@ use utoipa_swagger_ui::{Config, SwaggerUi};
 
 use crate::config::AppConfig;
 use crate::error::AppError;
+use crate::dto::stats::StatsPayload;
 use crate::handlers::{
     admin, article, artist, auth, collection, event, hall, location, media, production, series,
-    space, tagging, taxonomy, version,
+    space, tagging, stats, taxonomy, version,
 };
 
 pub mod config;
@@ -43,11 +44,12 @@ pub struct AppState {
 #[derive(OpenApi)]
 #[openapi(
     modifiers(&SecurityAddon),
-    components(schemas(EntityType, Facet, Sort)),
+    components(schemas(EntityType, Facet, Sort, StatsPayload)),
     tags(
         (name = "viernulvier_api", description = "API Endpoints"),
         (name = "Collections", description = "A saved, titled selection of archive items with a shareable URL. No login required to view."),
-        (name = "Series", description = "Thematic/programmatic groupings of productions.")
+        (name = "Series", description = "Thematic/programmatic groupings of productions."),
+        (name = "Stats", description = "Aggregate public site statistics.")
     )
 )]
 pub struct ApiDoc;
@@ -216,6 +218,8 @@ fn public_routes() -> OpenApiRouter<AppState> {
     OpenApiRouter::new()
         // version
         .routes(routes!(version::get))
+        // stats
+        .routes(routes!(stats::get))
         // auth
         .routes(routes!(auth::login))
         .routes(routes!(auth::refresh))

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -22,7 +22,6 @@ use utoipa_swagger_ui::{Config, SwaggerUi};
 
 use crate::config::AppConfig;
 use crate::error::AppError;
-use crate::dto::stats::StatsPayload;
 use crate::handlers::{
     admin, article, artist, auth, collection, event, hall, location, media, production, series,
     space, tagging, stats, taxonomy, version,
@@ -44,7 +43,7 @@ pub struct AppState {
 #[derive(OpenApi)]
 #[openapi(
     modifiers(&SecurityAddon),
-    components(schemas(EntityType, Facet, Sort, StatsPayload)),
+    components(schemas(EntityType, Facet, Sort)),
     tags(
         (name = "viernulvier_api", description = "API Endpoints"),
         (name = "Collections", description = "A saved, titled selection of archive items with a shareable URL. No login required to view."),

--- a/backend/tests/common/router.rs
+++ b/backend/tests/common/router.rs
@@ -38,11 +38,6 @@ impl TestRouter {
         }
     }
 
-    /// Pool for direct SQL in tests (expected rows, aggregates, etc.).
-    pub fn db(&self) -> &PgPool {
-        &self.db
-    }
-
     pub async fn login(mut self, email: &str, role: UserRole) -> Self {
         let database = Database::new(self.db.clone());
         let config = AppConfig::load().unwrap();

--- a/backend/tests/common/router.rs
+++ b/backend/tests/common/router.rs
@@ -38,6 +38,11 @@ impl TestRouter {
         }
     }
 
+    /// Pool for direct SQL in tests (expected rows, aggregates, etc.).
+    pub fn db(&self) -> &PgPool {
+        &self.db
+    }
+
     pub async fn login(mut self, email: &str, role: UserRole) -> Self {
         let database = Database::new(self.db.clone());
         let config = AppConfig::load().unwrap();

--- a/backend/tests/fixtures/stats.sql
+++ b/backend/tests/fixtures/stats.sql
@@ -1,0 +1,32 @@
+-- Fixture for GET /stats integration tests.
+-- Keeps deterministic golden counts and event bounds independent of other fixtures.
+
+INSERT INTO productions (id, source_id, slug, starts_at, ends_at, attendance_mode) VALUES
+('aa111111-1111-1111-1111-111111111111', 9001, 'stats-production-one', '2026-04-10 20:00:00+02', '2026-04-10 22:00:00+02', 'live'),
+('aa222222-2222-2222-2222-222222222222', 9002, 'stats-production-two', '2026-07-15 19:00:00+02', '2026-07-15 21:00:00+02', 'live');
+
+INSERT INTO events (
+    id, source_id, created_at, updated_at, starts_at, ends_at, status, production_id
+) VALUES
+('bb111111-1111-1111-1111-111111111111', 9101, '2026-03-01 10:00:00+00', '2026-03-01 10:00:00+00', '2026-04-10 20:00:00+02', '2026-04-10 22:00:00+02', 'confirmed', 'aa111111-1111-1111-1111-111111111111'),
+('bb222222-2222-2222-2222-222222222222', 9102, '2026-03-02 10:00:00+00', '2026-03-02 10:00:00+00', '2026-05-20 21:00:00+02', '2026-05-20 23:00:00+02', 'confirmed', 'aa111111-1111-1111-1111-111111111111'),
+('bb333333-3333-3333-3333-333333333333', 9103, '2026-03-03 10:00:00+00', '2026-03-03 10:00:00+00', '2026-07-15 19:00:00+02', '2026-07-15 21:00:00+02', 'cancelled', 'aa222222-2222-2222-2222-222222222222');
+
+INSERT INTO locations (id, source_id, name, city, country, slug) VALUES
+('cc000000-0000-0000-0000-000000000001', 9201, 'Stats Hall A', 'Gent', 'Belgium', 'stats-hall-a'),
+('cc000000-0000-0000-0000-000000000002', 9202, 'Stats Hall B', 'Gent', 'Belgium', 'stats-hall-b'),
+('cc000000-0000-0000-0000-000000000003', 9203, 'Stats Hall C', 'Antwerpen', 'Belgium', 'stats-hall-c'),
+('cc000000-0000-0000-0000-000000000004', 9204, 'Stats Hall D', 'Brussel', 'Belgium', 'stats-hall-d');
+
+INSERT INTO articles (id, slug, status, title, content, created_at, updated_at) VALUES
+('dd000000-0000-0000-0000-000000000001', 'stats-published', 'published', 'Stats Published', '{"type":"doc","content":[]}', '2026-03-01 10:00:00+00', '2026-03-01 10:00:00+00'),
+('dd000000-0000-0000-0000-000000000002', 'stats-draft', 'draft', 'Stats Draft', NULL, '2026-03-02 10:00:00+00', '2026-03-02 10:00:00+00');
+
+INSERT INTO artists (id, name, slug) VALUES
+('ee000000-0000-0000-0000-000000000001', 'Stats Artist One', 'stats-artist-one'),
+('ee000000-0000-0000-0000-000000000002', 'Stats Artist Two', 'stats-artist-two');
+
+INSERT INTO collections (id, slug) VALUES
+('ff000000-0000-0000-0000-000000000001', 'stats-collection-one'),
+('ff000000-0000-0000-0000-000000000002', 'stats-collection-two'),
+('ff000000-0000-0000-0000-000000000003', 'stats-collection-three');

--- a/backend/tests/stats.rs
+++ b/backend/tests/stats.rs
@@ -1,0 +1,152 @@
+//! Integration tests for `GET /stats` (see `PLAN_STATS_ENDPOINT.md`).
+
+use axum::http::{StatusCode, header};
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+use sqlx::PgPool;
+
+use crate::common::{into_struct::IntoStruct, router::TestRouter};
+
+mod common;
+
+const PUBLIC_CACHE_HEADER: &str = "public, max-age=3600, stale-while-revalidate=86400";
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct StatsBody {
+    oldest_event: Option<DateTime<Utc>>,
+    newest_event: Option<DateTime<Utc>>,
+    event_count: i64,
+    production_count: i64,
+    location_count: i64,
+    article_count: i64,
+}
+
+async fn expected_stats_from_db(db: &PgPool) -> StatsBody {
+    let (oldest_event, newest_event) = sqlx::query_as::<_, (Option<DateTime<Utc>>, Option<DateTime<Utc>>)>(
+        "SELECT MIN(starts_at), MAX(starts_at) FROM events",
+    )
+    .fetch_one(db)
+    .await
+    .unwrap();
+
+    let event_count: i64 = sqlx::query_scalar("SELECT COUNT(*)::bigint FROM events")
+        .fetch_one(db)
+        .await
+        .unwrap();
+
+    let production_count: i64 = sqlx::query_scalar("SELECT COUNT(*)::bigint FROM productions")
+        .fetch_one(db)
+        .await
+        .unwrap();
+
+    let location_count: i64 = sqlx::query_scalar("SELECT COUNT(*)::bigint FROM locations")
+        .fetch_one(db)
+        .await
+        .unwrap();
+
+    let article_count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*)::bigint FROM articles WHERE status = 'published'")
+            .fetch_one(db)
+            .await
+            .unwrap();
+
+    StatsBody {
+        oldest_event,
+        newest_event,
+        event_count,
+        production_count,
+        location_count,
+        article_count,
+    }
+}
+
+#[sqlx::test(fixtures("events", "locations", "articles"))]
+#[test_log::test]
+async fn get_stats_returns_ok(db: PgPool) {
+    let app = TestRouter::new(db);
+    let response = app.get("/stats").await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let _: StatsBody = response.into_struct().await;
+}
+
+#[sqlx::test(fixtures("events", "locations", "articles"))]
+#[test_log::test]
+async fn get_stats_counts(db: PgPool) {
+    let app = TestRouter::new(db);
+    let response = app.get("/stats").await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body: StatsBody = response.into_struct().await;
+    let expected = expected_stats_from_db(app.db()).await;
+    assert_eq!(body, expected);
+}
+
+#[sqlx::test(fixtures("events"))]
+#[test_log::test]
+async fn get_stats_event_bounds(db: PgPool) {
+    let app = TestRouter::new(db);
+    let response = app.get("/stats").await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body: StatsBody = response.into_struct().await;
+    let expected = expected_stats_from_db(app.db()).await;
+    assert_eq!(body.oldest_event, expected.oldest_event);
+    assert_eq!(body.newest_event, expected.newest_event);
+    assert_eq!(body.event_count, expected.event_count);
+}
+
+#[sqlx::test(fixtures("articles"))]
+#[test_log::test]
+async fn get_stats_published_articles_only(db: PgPool) {
+    let app = TestRouter::new(db);
+    let response = app.get("/stats").await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body: StatsBody = response.into_struct().await;
+    let pool = app.db();
+
+    let published: i64 =
+        sqlx::query_scalar("SELECT COUNT(*)::bigint FROM articles WHERE status = 'published'")
+            .fetch_one(pool)
+            .await
+            .unwrap();
+
+    assert_eq!(body.article_count, published);
+
+    let total: i64 = sqlx::query_scalar("SELECT COUNT(*)::bigint FROM articles")
+        .fetch_one(pool)
+        .await
+        .unwrap();
+    assert!(
+        total > published,
+        "fixture should include non-published rows when total > published count"
+    );
+}
+
+#[sqlx::test]
+#[test_log::test]
+async fn get_stats_empty_database(db: PgPool) {
+    let app = TestRouter::new(db);
+    let response = app.get("/stats").await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body: StatsBody = response.into_struct().await;
+    let expected = expected_stats_from_db(app.db()).await;
+    assert_eq!(body, expected);
+}
+
+#[sqlx::test(fixtures("events"))]
+#[test_log::test]
+async fn get_stats_has_cache_headers(db: PgPool) {
+    let app = TestRouter::new(db);
+    let response = app.get("/stats").await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let cache = response
+        .headers()
+        .get(header::CACHE_CONTROL)
+        .expect("Cache-Control header")
+        .to_str()
+        .expect("Cache-Control utf-8");
+    assert_eq!(cache, PUBLIC_CACHE_HEADER);
+}

--- a/backend/tests/stats.rs
+++ b/backend/tests/stats.rs
@@ -1,4 +1,4 @@
-//! Integration tests for `GET /stats` (see `PLAN_STATS_ENDPOINT.md`).
+//! Integration tests for `GET /stats`.
 
 use axum::http::{StatusCode, header};
 use chrono::{DateTime, Utc};
@@ -23,148 +23,15 @@ struct StatsBody {
     collection_count: i64,
 }
 
-async fn expected_stats_from_db(db: &PgPool) -> StatsBody {
-    let (oldest_event, newest_event) = sqlx::query_as::<_, (Option<DateTime<Utc>>, Option<DateTime<Utc>>)>(
-        "SELECT MIN(starts_at), MAX(starts_at) FROM events",
-    )
-    .fetch_one(db)
-    .await
-    .unwrap();
-
-    let event_count: i64 = sqlx::query_scalar("SELECT COUNT(*)::bigint FROM events")
-        .fetch_one(db)
-        .await
-        .unwrap();
-
-    let production_count: i64 = sqlx::query_scalar("SELECT COUNT(*)::bigint FROM productions")
-        .fetch_one(db)
-        .await
-        .unwrap();
-
-    let location_count: i64 = sqlx::query_scalar("SELECT COUNT(*)::bigint FROM locations")
-        .fetch_one(db)
-        .await
-        .unwrap();
-
-    let article_count: i64 =
-        sqlx::query_scalar("SELECT COUNT(*)::bigint FROM articles WHERE status = 'published'")
-            .fetch_one(db)
-            .await
-            .unwrap();
-
-    let artist_count: i64 = sqlx::query_scalar("SELECT COUNT(*)::bigint FROM artists")
-        .fetch_one(db)
-        .await
-        .unwrap();
-
-    let collection_count: i64 = sqlx::query_scalar("SELECT COUNT(*)::bigint FROM collections")
-        .fetch_one(db)
-        .await
-        .unwrap();
-
-    StatsBody {
-        oldest_event,
-        newest_event,
-        event_count,
-        production_count,
-        location_count,
-        article_count,
-        artist_count,
-        collection_count,
-    }
+fn utc(s: &str) -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339(s)
+        .expect("valid RFC3339")
+        .with_timezone(&Utc)
 }
 
-#[sqlx::test(fixtures("events", "locations", "articles"))]
+#[sqlx::test(fixtures("stats"))]
 #[test_log::test]
-async fn get_stats_returns_ok(db: PgPool) {
-    let app = TestRouter::new(db);
-    let response = app.get("/stats").await;
-    assert_eq!(response.status(), StatusCode::OK);
-    let _: StatsBody = response.into_struct().await;
-}
-
-#[sqlx::test(fixtures("events", "locations", "articles"))]
-#[test_log::test]
-async fn get_stats_counts(db: PgPool) {
-    let app = TestRouter::new(db);
-    let response = app.get("/stats").await;
-    assert_eq!(response.status(), StatusCode::OK);
-
-    let body: StatsBody = response.into_struct().await;
-    let expected = expected_stats_from_db(app.db()).await;
-    assert_eq!(body, expected);
-}
-
-#[sqlx::test(fixtures("events"))]
-#[test_log::test]
-async fn get_stats_event_bounds(db: PgPool) {
-    let app = TestRouter::new(db);
-    let response = app.get("/stats").await;
-    assert_eq!(response.status(), StatusCode::OK);
-
-    let body: StatsBody = response.into_struct().await;
-    let expected = expected_stats_from_db(app.db()).await;
-    assert_eq!(body.oldest_event, expected.oldest_event);
-    assert_eq!(body.newest_event, expected.newest_event);
-    assert_eq!(body.event_count, expected.event_count);
-}
-
-#[sqlx::test(fixtures("articles"))]
-#[test_log::test]
-async fn get_stats_published_articles_only(db: PgPool) {
-    let app = TestRouter::new(db);
-    let response = app.get("/stats").await;
-    assert_eq!(response.status(), StatusCode::OK);
-
-    let body: StatsBody = response.into_struct().await;
-    let pool = app.db();
-
-    let published: i64 =
-        sqlx::query_scalar("SELECT COUNT(*)::bigint FROM articles WHERE status = 'published'")
-            .fetch_one(pool)
-            .await
-            .unwrap();
-
-    assert_eq!(body.article_count, published);
-
-    let total: i64 = sqlx::query_scalar("SELECT COUNT(*)::bigint FROM articles")
-        .fetch_one(pool)
-        .await
-        .unwrap();
-    assert!(
-        total > published,
-        "fixture should include non-published rows when total > published count"
-    );
-}
-
-#[sqlx::test(fixtures("artists", "collections"))]
-#[test_log::test]
-async fn get_stats_artist_and_collection_counts(db: PgPool) {
-    let app = TestRouter::new(db);
-    let response = app.get("/stats").await;
-    assert_eq!(response.status(), StatusCode::OK);
-
-    let body: StatsBody = response.into_struct().await;
-    let expected = expected_stats_from_db(app.db()).await;
-    assert_eq!(body.artist_count, expected.artist_count);
-    assert_eq!(body.collection_count, expected.collection_count);
-}
-
-#[sqlx::test]
-#[test_log::test]
-async fn get_stats_empty_database(db: PgPool) {
-    let app = TestRouter::new(db);
-    let response = app.get("/stats").await;
-    assert_eq!(response.status(), StatusCode::OK);
-
-    let body: StatsBody = response.into_struct().await;
-    let expected = expected_stats_from_db(app.db()).await;
-    assert_eq!(body, expected);
-}
-
-#[sqlx::test(fixtures("events"))]
-#[test_log::test]
-async fn get_stats_has_cache_headers(db: PgPool) {
+async fn get_stats_matches_fixture(db: PgPool) {
     let app = TestRouter::new(db);
     let response = app.get("/stats").await;
     assert_eq!(response.status(), StatusCode::OK);
@@ -176,4 +43,49 @@ async fn get_stats_has_cache_headers(db: PgPool) {
         .to_str()
         .expect("Cache-Control utf-8");
     assert_eq!(cache, PUBLIC_CACHE_HEADER);
+
+    let body: StatsBody = response.into_struct().await;
+    let expected = StatsBody {
+        oldest_event: Some(utc("2026-04-10T18:00:00Z")),
+        newest_event: Some(utc("2026-07-15T17:00:00Z")),
+        event_count: 3,
+        production_count: 2,
+        location_count: 4,
+        // One published article seeded in the stats fixture, plus one from the
+        // `seed_article_kleurenstudies` migration.
+        article_count: 2,
+        artist_count: 2,
+        collection_count: 3,
+    };
+    assert_eq!(body, expected);
+}
+
+#[sqlx::test]
+#[test_log::test]
+async fn get_stats_empty_database(db: PgPool) {
+    let app = TestRouter::new(db);
+    let response = app.get("/stats").await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let cache = response
+        .headers()
+        .get(header::CACHE_CONTROL)
+        .expect("Cache-Control header")
+        .to_str()
+        .expect("Cache-Control utf-8");
+    assert_eq!(cache, PUBLIC_CACHE_HEADER);
+
+    let body: StatsBody = response.into_struct().await;
+    let expected = StatsBody {
+        oldest_event: None,
+        newest_event: None,
+        event_count: 0,
+        production_count: 0,
+        location_count: 0,
+        // Migrations seed one published article.
+        article_count: 1,
+        artist_count: 0,
+        collection_count: 0,
+    };
+    assert_eq!(body, expected);
 }

--- a/backend/tests/stats.rs
+++ b/backend/tests/stats.rs
@@ -19,6 +19,8 @@ struct StatsBody {
     production_count: i64,
     location_count: i64,
     article_count: i64,
+    artist_count: i64,
+    collection_count: i64,
 }
 
 async fn expected_stats_from_db(db: &PgPool) -> StatsBody {
@@ -50,6 +52,16 @@ async fn expected_stats_from_db(db: &PgPool) -> StatsBody {
             .await
             .unwrap();
 
+    let artist_count: i64 = sqlx::query_scalar("SELECT COUNT(*)::bigint FROM artists")
+        .fetch_one(db)
+        .await
+        .unwrap();
+
+    let collection_count: i64 = sqlx::query_scalar("SELECT COUNT(*)::bigint FROM collections")
+        .fetch_one(db)
+        .await
+        .unwrap();
+
     StatsBody {
         oldest_event,
         newest_event,
@@ -57,6 +69,8 @@ async fn expected_stats_from_db(db: &PgPool) -> StatsBody {
         production_count,
         location_count,
         article_count,
+        artist_count,
+        collection_count,
     }
 }
 
@@ -121,6 +135,19 @@ async fn get_stats_published_articles_only(db: PgPool) {
         total > published,
         "fixture should include non-published rows when total > published count"
     );
+}
+
+#[sqlx::test(fixtures("artists", "collections"))]
+#[test_log::test]
+async fn get_stats_artist_and_collection_counts(db: PgPool) {
+    let app = TestRouter::new(db);
+    let response = app.get("/stats").await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body: StatsBody = response.into_struct().await;
+    let expected = expected_stats_from_db(app.db()).await;
+    assert_eq!(body.artist_count, expected.artist_count);
+    assert_eq!(body.collection_count, expected.collection_count);
 }
 
 #[sqlx::test]

--- a/frontend/src/app/[locale]/(app)/search/page.tsx
+++ b/frontend/src/app/[locale]/(app)/search/page.tsx
@@ -22,8 +22,6 @@ import { ArchiveSidebar } from "@/components/searchpage/archive-sidebar";
 import { ProductionList } from "@/components/searchpage/production-list";
 import { VintageEmptyState } from "@/components/shared/vintage-empty-state";
 
-const ARCHIVE_MIN_YEAR = 1980;
-
 export default function SearchPage() {
     const locale = useLocale();
     const t = useTranslations("Search");
@@ -120,8 +118,6 @@ export default function SearchPage() {
         };
     }, [loadMore]);
 
-    const maxYear = useMemo(() => new Date().getFullYear(), []);
-
     if (isLoading && allProductions.length === 0) {
         return (
             <>
@@ -150,12 +146,7 @@ export default function SearchPage() {
             <ResultsBar shownCount={allProductions.length} totalCount={allProductions.length} />
 
             <div className="flex min-h-[calc(100vh-300px)] overflow-hidden">
-                <ArchiveSidebar
-                    locations={locationsData}
-                    facets={facets ?? []}
-                    minYear={ARCHIVE_MIN_YEAR}
-                    maxYear={maxYear}
-                />
+                <ArchiveSidebar locations={locationsData} facets={facets ?? []} />
                 <main className="min-w-0 flex-1 overflow-hidden">
                     {allProductions.length === 0 && !isLoading ? (
                         <VintageEmptyState

--- a/frontend/src/components/searchpage/archive-sidebar/ArchiveSidebar.tsx
+++ b/frontend/src/components/searchpage/archive-sidebar/ArchiveSidebar.tsx
@@ -7,9 +7,11 @@ import { SlidersHorizontal, X } from "lucide-react";
 import type { Location } from "@/types/models/location.types";
 import type { Facet } from "@/types/models/taxonomy.types";
 import { getLabel } from "@/lib/utils";
+import { useGetStats } from "@/hooks/api/useStats";
 
 import { YearRangeSlider } from "./YearRangeSlider";
 import { DateRangePicker } from "./DateRangePicker";
+import { yearBoundsFromStats } from "./statsYearBounds";
 
 const CATEGORIES = ["artists", "productions", "articles", "posters"] as const;
 
@@ -31,12 +33,21 @@ interface ArchiveSidebarProps {
 export function ArchiveSidebar({
     locations = [],
     facets = [],
-    minYear = 1980,
-    maxYear = new Date().getFullYear(),
+    minYear: minYearProp,
+    maxYear: maxYearProp,
     onFilterChange,
 }: ArchiveSidebarProps) {
     const t = useTranslations("Sidebar");
     const locale = useLocale();
+    const { data: stats } = useGetStats();
+
+    const bounds = useMemo(
+        () => yearBoundsFromStats(stats, { minYear: minYearProp, maxYear: maxYearProp }),
+        [stats, minYearProp, maxYearProp]
+    );
+
+    const minDate = useMemo(() => new Date(bounds.minYear, 0, 1), [bounds.minYear]);
+    const maxDate = useMemo(() => new Date(bounds.maxYear, 11, 31), [bounds.maxYear]);
     const [mobileOpen, setMobileOpen] = useState(false);
     const [activeTags, setActiveTags] = useState<Set<string>>(new Set());
     const [checkedCategories, setCheckedCategories] = useState<Set<string>>(
@@ -44,18 +55,46 @@ export function ArchiveSidebar({
     );
     const [checkedLocations, setCheckedLocations] = useState<Set<string>>(new Set());
 
-    const validatedMinYear = Math.min(minYear, maxYear);
-    const validatedMaxYear = Math.max(minYear, maxYear);
-
-    const minDate = new Date(validatedMinYear, 0, 1);
-    const maxDate = new Date(validatedMaxYear, 11, 31);
-
     const [dateMode, setDateMode] = useState<DateFilterMode>("year");
-    const [yearRange, setYearRange] = useState<[number, number]>([
-        validatedMinYear,
-        validatedMaxYear,
-    ]);
-    const [dateRange, setDateRange] = useState<[Date, Date]>([minDate, maxDate]);
+    const [yearRange, setYearRange] = useState<[number, number]>(() => {
+        const b = yearBoundsFromStats(undefined, { minYear: minYearProp, maxYear: maxYearProp });
+        return [b.minYear, b.maxYear];
+    });
+    const [dateRange, setDateRange] = useState<[Date, Date]>(() => {
+        const b = yearBoundsFromStats(undefined, { minYear: minYearProp, maxYear: maxYearProp });
+        return [new Date(b.minYear, 0, 1), new Date(b.maxYear, 11, 31)];
+    });
+
+    const appliedStatsRef = useRef(false);
+
+    useEffect(() => {
+        // First time /stats returns: replace fallback bounds (max was current year) with real
+        // oldest/newest years so the right thumb matches the archive upper bound, not "today".
+        if (stats && !appliedStatsRef.current) {
+            appliedStatsRef.current = true;
+            setYearRange([bounds.minYear, bounds.maxYear]);
+            setDateRange([new Date(bounds.minYear, 0, 1), new Date(bounds.maxYear, 11, 31)]);
+            return;
+        }
+
+        setYearRange((prev) => {
+            const lo = Math.max(bounds.minYear, Math.min(prev[0], bounds.maxYear));
+            const hi = Math.max(bounds.minYear, Math.min(prev[1], bounds.maxYear));
+            if (lo <= hi) return [lo, hi];
+            return [bounds.minYear, bounds.maxYear];
+        });
+        setDateRange((prev) => {
+            const minD = new Date(bounds.minYear, 0, 1);
+            const maxD = new Date(bounds.maxYear, 11, 31);
+            let start = prev[0] < minD ? minD : prev[0] > maxD ? maxD : prev[0];
+            let end = prev[1] > maxD ? maxD : prev[1] < minD ? minD : prev[1];
+            if (start > end) {
+                start = minD;
+                end = maxD;
+            }
+            return [start, end];
+        });
+    }, [stats, bounds.minYear, bounds.maxYear]);
 
     const effectiveDateRange = useMemo<[Date, Date]>(
         () =>
@@ -133,9 +172,9 @@ export function ArchiveSidebar({
         setCheckedCategories(new Set());
         setCheckedLocations(new Set());
         setDateMode("year");
-        setYearRange([validatedMinYear, validatedMaxYear]);
-        setDateRange([new Date(validatedMinYear, 0, 1), new Date(validatedMaxYear, 11, 31)]);
-    }, [validatedMinYear, validatedMaxYear]);
+        setYearRange([bounds.minYear, bounds.maxYear]);
+        setDateRange([new Date(bounds.minYear, 0, 1), new Date(bounds.maxYear, 11, 31)]);
+    }, [bounds.minYear, bounds.maxYear]);
 
     const sidebarContent = (
         <>
@@ -254,8 +293,8 @@ export function ArchiveSidebar({
                             <span>{yearRange[1]}</span>
                         </div>
                         <YearRangeSlider
-                            min={validatedMinYear}
-                            max={validatedMaxYear}
+                            min={bounds.minYear}
+                            max={bounds.maxYear}
                             value={yearRange}
                             onChange={setYearRange}
                             ariaLabelStart={t("year.rangeFrom")}

--- a/frontend/src/components/searchpage/archive-sidebar/ArchiveSidebar.tsx
+++ b/frontend/src/components/searchpage/archive-sidebar/ArchiveSidebar.tsx
@@ -56,45 +56,31 @@ export function ArchiveSidebar({
     const [checkedLocations, setCheckedLocations] = useState<Set<string>>(new Set());
 
     const [dateMode, setDateMode] = useState<DateFilterMode>("year");
-    const [yearRange, setYearRange] = useState<[number, number]>(() => {
-        const b = yearBoundsFromStats(undefined, { minYear: minYearProp, maxYear: maxYearProp });
-        return [b.minYear, b.maxYear];
-    });
-    const [dateRange, setDateRange] = useState<[Date, Date]>(() => {
-        const b = yearBoundsFromStats(undefined, { minYear: minYearProp, maxYear: maxYearProp });
-        return [new Date(b.minYear, 0, 1), new Date(b.maxYear, 11, 31)];
-    });
+    /** `null` = full range for current archive bounds (updates automatically when /stats arrives). */
+    const [yearRangeDraft, setYearRangeDraft] = useState<[number, number] | null>(null);
+    const [dateRangeDraft, setDateRangeDraft] = useState<[Date, Date] | null>(null);
 
-    const appliedStatsRef = useRef(false);
+    const yearRange = useMemo((): [number, number] => {
+        const full: [number, number] = [bounds.minYear, bounds.maxYear];
+        if (yearRangeDraft === null) return full;
+        const lo = Math.max(bounds.minYear, Math.min(yearRangeDraft[0], bounds.maxYear));
+        const hi = Math.max(bounds.minYear, Math.min(yearRangeDraft[1], bounds.maxYear));
+        if (lo <= hi) return [lo, hi];
+        return full;
+    }, [yearRangeDraft, bounds.minYear, bounds.maxYear]);
 
-    useEffect(() => {
-        // First time /stats returns: replace fallback bounds (max was current year) with real
-        // oldest/newest years so the right thumb matches the archive upper bound, not "today".
-        if (stats && !appliedStatsRef.current) {
-            appliedStatsRef.current = true;
-            setYearRange([bounds.minYear, bounds.maxYear]);
-            setDateRange([new Date(bounds.minYear, 0, 1), new Date(bounds.maxYear, 11, 31)]);
-            return;
-        }
-
-        setYearRange((prev) => {
-            const lo = Math.max(bounds.minYear, Math.min(prev[0], bounds.maxYear));
-            const hi = Math.max(bounds.minYear, Math.min(prev[1], bounds.maxYear));
-            if (lo <= hi) return [lo, hi];
-            return [bounds.minYear, bounds.maxYear];
-        });
-        setDateRange((prev) => {
-            const minD = new Date(bounds.minYear, 0, 1);
-            const maxD = new Date(bounds.maxYear, 11, 31);
-            let start = prev[0] < minD ? minD : prev[0] > maxD ? maxD : prev[0];
-            let end = prev[1] > maxD ? maxD : prev[1] < minD ? minD : prev[1];
-            if (start > end) {
-                start = minD;
-                end = maxD;
-            }
-            return [start, end];
-        });
-    }, [stats, bounds.minYear, bounds.maxYear]);
+    const dateRange = useMemo((): [Date, Date] => {
+        const minD = new Date(bounds.minYear, 0, 1);
+        const maxD = new Date(bounds.maxYear, 11, 31);
+        const full: [Date, Date] = [minD, maxD];
+        if (dateRangeDraft === null) return full;
+        const start =
+            dateRangeDraft[0] < minD ? minD : dateRangeDraft[0] > maxD ? maxD : dateRangeDraft[0];
+        const end =
+            dateRangeDraft[1] > maxD ? maxD : dateRangeDraft[1] < minD ? minD : dateRangeDraft[1];
+        if (start > end) return full;
+        return [start, end];
+    }, [dateRangeDraft, bounds.minYear, bounds.maxYear]);
 
     const effectiveDateRange = useMemo<[Date, Date]>(
         () =>
@@ -105,12 +91,12 @@ export function ArchiveSidebar({
     );
 
     const switchToExact = () => {
-        setDateRange([new Date(yearRange[0], 0, 1), new Date(yearRange[1], 11, 31)]);
+        setDateRangeDraft([new Date(yearRange[0], 0, 1), new Date(yearRange[1], 11, 31)]);
         setDateMode("exact");
     };
 
     const switchToYear = () => {
-        setYearRange([dateRange[0].getFullYear(), dateRange[1].getFullYear()]);
+        setYearRangeDraft([dateRange[0].getFullYear(), dateRange[1].getFullYear()]);
         setDateMode("year");
     };
 
@@ -172,9 +158,9 @@ export function ArchiveSidebar({
         setCheckedCategories(new Set());
         setCheckedLocations(new Set());
         setDateMode("year");
-        setYearRange([bounds.minYear, bounds.maxYear]);
-        setDateRange([new Date(bounds.minYear, 0, 1), new Date(bounds.maxYear, 11, 31)]);
-    }, [bounds.minYear, bounds.maxYear]);
+        setYearRangeDraft(null);
+        setDateRangeDraft(null);
+    }, []);
 
     const sidebarContent = (
         <>
@@ -296,7 +282,7 @@ export function ArchiveSidebar({
                             min={bounds.minYear}
                             max={bounds.maxYear}
                             value={yearRange}
-                            onChange={setYearRange}
+                            onChange={setYearRangeDraft}
                             ariaLabelStart={t("year.rangeFrom")}
                             ariaLabelEnd={t("year.rangeTo")}
                         />
@@ -310,7 +296,7 @@ export function ArchiveSidebar({
                             endDate={dateRange[1]}
                             minDate={minDate}
                             maxDate={maxDate}
-                            onChange={(start, end) => setDateRange([start, end])}
+                            onChange={(start, end) => setDateRangeDraft([start, end])}
                         />
                     </div>
                 )}

--- a/frontend/src/components/searchpage/archive-sidebar/ArchiveSidebar.tsx
+++ b/frontend/src/components/searchpage/archive-sidebar/ArchiveSidebar.tsx
@@ -91,7 +91,11 @@ export function ArchiveSidebar({
     );
 
     const switchToExact = () => {
-        setDateRangeDraft([new Date(yearRange[0], 0, 1), new Date(yearRange[1], 11, 31)]);
+        setDateRangeDraft(
+            yearRangeDraft === null
+                ? null
+                : [new Date(yearRange[0], 0, 1), new Date(yearRange[1], 11, 31)]
+        );
         setDateMode("exact");
     };
 

--- a/frontend/src/components/searchpage/archive-sidebar/statsYearBounds.ts
+++ b/frontend/src/components/searchpage/archive-sidebar/statsYearBounds.ts
@@ -1,0 +1,44 @@
+import type { StatsPayload } from "@/types/api/stats.api.types";
+
+const FALLBACK_MIN_YEAR = 1980;
+
+function currentYear(): number {
+    return new Date().getFullYear();
+}
+
+/**
+ * Inclusive calendar years for the archive filter, from GET /stats event bounds
+ * (optional prop overrides for tests).
+ */
+export function yearBoundsFromStats(
+    stats: StatsPayload | undefined,
+    opts?: { minYear?: number; maxYear?: number }
+): { minYear: number; maxYear: number } {
+    const fallbackMax = currentYear();
+
+    let minY =
+        opts?.minYear !== undefined
+            ? opts.minYear
+            : stats?.oldest_event
+              ? new Date(stats.oldest_event).getFullYear()
+              : FALLBACK_MIN_YEAR;
+
+    let maxY =
+        opts?.maxYear !== undefined
+            ? opts.maxYear
+            : stats?.newest_event
+              ? new Date(stats.newest_event).getFullYear()
+              : fallbackMax;
+
+    if (!Number.isFinite(minY)) minY = FALLBACK_MIN_YEAR;
+    if (!Number.isFinite(maxY)) maxY = fallbackMax;
+
+    if (minY > maxY) {
+        [minY, maxY] = [maxY, minY];
+    }
+    if (minY === maxY) {
+        maxY = minY + 1;
+    }
+
+    return { minYear: minY, maxYear: maxY };
+}

--- a/frontend/src/hooks/api/index.ts
+++ b/frontend/src/hooks/api/index.ts
@@ -9,5 +9,6 @@ export * from "./useLocations";
 export * from "./useMedia";
 export * from "./useProductions";
 export * from "./useSpaces";
+export * from "./useStats";
 export * from "./useTaxonomy";
 export * from "./useVersion";

--- a/frontend/src/hooks/api/query-keys.ts
+++ b/frontend/src/hooks/api/query-keys.ts
@@ -12,6 +12,7 @@ const buildQueryKey = (
 export const queryKeys = {
     user: ["user"] as const,
     version: ["version"] as const,
+    stats: ["stats"] as const,
     locations: {
         all: (pagination?: PaginationParams) => buildQueryKey(["locations"], pagination),
         detail: (id: string) => ["locations", id] as const,

--- a/frontend/src/hooks/api/useStats.ts
+++ b/frontend/src/hooks/api/useStats.ts
@@ -1,12 +1,12 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { api } from "@/lib/api-client";
-import type { StatsPayload } from "@/types/api/stats.api.types";
+import type { GetStatsResponse } from "@/types/api/stats.api.types";
 
 import { queryKeys } from "./query-keys";
 
-const fetchStats = async (): Promise<StatsPayload> => {
-    const { data } = await api.get<StatsPayload>("/stats");
+const fetchStats = async (): Promise<GetStatsResponse> => {
+    const { data } = await api.get<GetStatsResponse>("/stats");
     return data;
 };
 

--- a/frontend/src/hooks/api/useStats.ts
+++ b/frontend/src/hooks/api/useStats.ts
@@ -1,0 +1,20 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { api } from "@/lib/api-client";
+import type { StatsPayload } from "@/types/api/stats.api.types";
+
+import { queryKeys } from "./query-keys";
+
+const fetchStats = async (): Promise<StatsPayload> => {
+    const { data } = await api.get<StatsPayload>("/stats");
+    return data;
+};
+
+export const useGetStats = (options?: { enabled?: boolean }) => {
+    return useQuery({
+        queryKey: queryKeys.stats,
+        queryFn: fetchStats,
+        staleTime: 60 * 60 * 1000,
+        ...options,
+    });
+};

--- a/frontend/src/types/api/generated.ts
+++ b/frontend/src/types/api/generated.ts
@@ -747,6 +747,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/stats": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Aggregate public site statistics (cached) */
+        get: operations["get_stats"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/version": {
         parameters: {
             query?: never;
@@ -1452,6 +1469,20 @@ export interface components {
         };
         /** @enum {string} */
         Sort: "recent" | "oldest" | "relevance";
+        StatsPayload: {
+            /** Format: int64 */
+            article_count: number;
+            /** Format: int64 */
+            event_count: number;
+            /** Format: int64 */
+            location_count: number;
+            /** Format: date-time */
+            newest_event?: string | null;
+            /** Format: date-time */
+            oldest_event?: string | null;
+            /** Format: int64 */
+            production_count: number;
+        };
         SpacePayload: {
             /** Format: uuid */
             id: string;
@@ -3802,6 +3833,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["FacetResponse"][];
+                };
+            };
+        };
+    };
+    get_stats: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Success */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["StatsPayload"];
                 };
             };
         };

--- a/frontend/src/types/api/stats.api.types.ts
+++ b/frontend/src/types/api/stats.api.types.ts
@@ -1,0 +1,6 @@
+import { components } from "@/types/api/generated";
+import { SuccessResponse } from "./api.types";
+
+export type GetStatsResponse = SuccessResponse<"get_stats">;
+
+export type StatsPayload = components["schemas"]["StatsPayload"];

--- a/frontend/test/unit/components/searchpage/ArchiveSidebar.test.tsx
+++ b/frontend/test/unit/components/searchpage/ArchiveSidebar.test.tsx
@@ -5,6 +5,14 @@ import { ArchiveSidebar } from "@/components/searchpage/archive-sidebar/ArchiveS
 import { NextIntlClientProvider } from "next-intl";
 import type { Facet } from "@/types/models/taxonomy.types";
 
+vi.mock("@/hooks/api/useStats", () => ({
+    useGetStats: () => ({
+        data: undefined,
+        isLoading: false,
+        isError: false,
+    }),
+}));
+
 const messages = {
     Sidebar: {
         title: "Filter",

--- a/frontend/test/unit/components/searchpage/ArchiveSidebar.test.tsx
+++ b/frontend/test/unit/components/searchpage/ArchiveSidebar.test.tsx
@@ -4,13 +4,18 @@ import userEvent from "@testing-library/user-event";
 import { ArchiveSidebar } from "@/components/searchpage/archive-sidebar/ArchiveSidebar";
 import { NextIntlClientProvider } from "next-intl";
 import type { Facet } from "@/types/models/taxonomy.types";
+import type { StatsPayload } from "@/types/api/stats.api.types";
 
-vi.mock("@/hooks/api/useStats", () => ({
-    useGetStats: () => ({
-        data: undefined,
+const { useGetStatsMock } = vi.hoisted(() => ({
+    useGetStatsMock: vi.fn(() => ({
+        data: undefined as StatsPayload | undefined,
         isLoading: false,
         isError: false,
-    }),
+    })),
+}));
+
+vi.mock("@/hooks/api/useStats", () => ({
+    useGetStats: useGetStatsMock,
 }));
 
 const messages = {
@@ -85,6 +90,11 @@ describe("ArchiveSidebar component", () => {
     beforeEach(() => {
         // jsdom does not implement scrollIntoView (needed by DateRangePicker)
         window.HTMLElement.prototype.scrollIntoView = vi.fn();
+        useGetStatsMock.mockReturnValue({
+            data: undefined,
+            isLoading: false,
+            isError: false,
+        });
     });
 
     afterEach(() => {
@@ -310,6 +320,48 @@ describe("ArchiveSidebar component", () => {
 
         await user.click(screen.getByRole("button", { name: "Year range" }));
         expect(screen.getAllByRole("slider")).toHaveLength(2);
+    });
+
+    it("updates year range labels when /stats arrives after mount (null draft tracks new bounds)", async () => {
+        const currentYear = new Date().getFullYear();
+
+        useGetStatsMock.mockReturnValue({
+            data: undefined,
+            isLoading: false,
+            isError: false,
+        });
+
+        const { rerender } = renderWithIntl(<ArchiveSidebar />);
+
+        expect(screen.getByText("1980")).toBeInTheDocument();
+        expect(screen.getByText(String(currentYear))).toBeInTheDocument();
+
+        const statsPayload: StatsPayload = {
+            oldest_event: "2016-06-15T12:00:00.000Z",
+            newest_event: "2023-08-01T12:00:00.000Z",
+            event_count: 10,
+            production_count: 5,
+            location_count: 3,
+            article_count: 2,
+        };
+
+        useGetStatsMock.mockReturnValue({
+            data: statsPayload,
+            isLoading: false,
+            isError: false,
+        });
+
+        rerender(
+            <NextIntlClientProvider locale="en" messages={messages}>
+                <ArchiveSidebar />
+            </NextIntlClientProvider>
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText("2016")).toBeInTheDocument();
+        });
+        expect(screen.getByText("2023")).toBeInTheDocument();
+        expect(screen.queryByText("1980")).not.toBeInTheDocument();
     });
 
     // ── Mobile open/close ─────────────────────────────────────────────────────


### PR DESCRIPTION
### Description
Added a public _GET /stats_ endpoint that returns site statistics: **article_count**, **event_count**, **location_count**, **production_count**, **newest_event**, **oldest_event**. Right now endpoint is only being used to get the the oldest/newest event for the search archive bar, so the year range slider and the date picker use real min/max instead of hard-coded bounds. In addition we can add these stats on the dashboard of the CMS and maybe show a number of productions in on the archive website. 

Also refactors sidebar date state so bounds updates (e.g. when /stats loads) don’t rely on useEffect + setState, avoiding cascading renders and aligning the slider thumbs with the API-driven range.

**Backend**

- StatsPayload: counts + optional oldest_event / newest_event (UTC).
- Handler registered on the public API router; OpenAPI documented.
- Responses use **public HTTP caching**
-DB reads for stats are run in **parallel** with tokio::try_join!

**Frontend**

- useGetStats + stats.api.types aligned with generated OpenAPI types.
- yearBoundsFromStats maps stats (with fallbacks) to slider/picker bounds.
- ArchiveSidebar: optional minYear / maxYear overrides (e.g. tests); draft null = “full range” for current bounds
- **Client cache**: React Query staleTime (aprox. 1h) on useGetStats

### Related Issue
Fixes #

### How Has This Been Tested?
- [x] Local manual testing
- [x] Added/updated unit or integration tests
- [x] Tested in the staging environment

### Developer Checklist:
- [x] I have performed a self-review of my own code.
- [x] I have left comments in hard-to-understand areas of my code.
- [x] My changes generate no new warnings or console errors.
- [x] I have updated the documentation (if applicable).

### Screenshots / Video (if UI/UX changed):
