### PR TITLE
feat(api): improve aesthetics of swaggerdocs

### DIFF
--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -45,7 +45,6 @@ pub struct AppState {
     modifiers(&SecurityAddon),
     components(schemas(EntityType, Facet, Sort)),
     tags(
-        (name = "viernulvier_api", description = "API Endpoints"),
         (name = "Collections", description = "A saved, titled selection of archive items with a shareable URL. No login required to view."),
         (name = "Series", description = "Thematic/programmatic groupings of productions."),
         (name = "Stats", description = "Aggregate public site statistics.")

--- a/frontend/src/types/api/generated.ts
+++ b/frontend/src/types/api/generated.ts
@@ -712,6 +712,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/stats": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Aggregate public site statistics (cached) */
+        get: operations["get_stats"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/tags/{entity_type}/{entity_id}": {
         parameters: {
             query?: never;
@@ -739,23 +756,6 @@ export interface paths {
         };
         /** @description Get all facets with their tags */
         get: operations["get_facets"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/stats": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** @description Aggregate public site statistics (cached) */
-        get: operations["get_stats"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1469,20 +1469,6 @@ export interface components {
         };
         /** @enum {string} */
         Sort: "recent" | "oldest" | "relevance";
-        StatsPayload: {
-            /** Format: int64 */
-            article_count: number;
-            /** Format: int64 */
-            event_count: number;
-            /** Format: int64 */
-            location_count: number;
-            /** Format: date-time */
-            newest_event?: string | null;
-            /** Format: date-time */
-            oldest_event?: string | null;
-            /** Format: int64 */
-            production_count: number;
-        };
         SpacePayload: {
             /** Format: uuid */
             id: string;
@@ -1498,6 +1484,24 @@ export interface components {
             name_nl: string;
             /** Format: int32 */
             source_id?: number | null;
+        };
+        StatsPayload: {
+            /** Format: int64 */
+            article_count: number;
+            /** Format: int64 */
+            artist_count: number;
+            /** Format: int64 */
+            collection_count: number;
+            /** Format: int64 */
+            event_count: number;
+            /** Format: int64 */
+            location_count: number;
+            /** Format: date-time */
+            newest_event?: string | null;
+            /** Format: date-time */
+            oldest_event?: string | null;
+            /** Format: int64 */
+            production_count: number;
         };
         TagResponse: {
             slug: string;
@@ -3729,6 +3733,28 @@ export interface operations {
             };
         };
     };
+    get_stats: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Success */
+            200: {
+                headers: {
+                    /** @description Public cache: max-age=3600 (1h), stale-while-revalidate=86400 (24h) */
+                    "Cache-Control"?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["StatsPayload"];
+                };
+            };
+        };
+    };
     get_entity_tags: {
         parameters: {
             query?: never;
@@ -3832,26 +3858,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["FacetResponse"][];
-                };
-            };
-        };
-    };
-    get_stats: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Success */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["StatsPayload"];
                 };
             };
         };

--- a/frontend/test/unit/components/searchpage/ArchiveSidebar.test.tsx
+++ b/frontend/test/unit/components/searchpage/ArchiveSidebar.test.tsx
@@ -343,6 +343,8 @@ describe("ArchiveSidebar component", () => {
             production_count: 5,
             location_count: 3,
             article_count: 2,
+            artist_count: 0,
+            collection_count: 0,
         };
 
         useGetStatsMock.mockReturnValue({


### PR DESCRIPTION
removes this ugly piece of shyt that doesnt even contain anything:
<img width="1840" height="227" alt="image" src="https://github.com/user-attachments/assets/4ba03f49-83c6-49a3-a5aa-d3817210bc3e" />

so we have:
<img width="1962" height="403" alt="image" src="https://github.com/user-attachments/assets/0178f84f-c04a-401c-ba3a-3d425889b53c" />
