### PR TITLE
fix(backend,frontend): validate uploads and prevent s3_key injection

### DIFF
--- a/.github/actions/generate-preview-env/action.yml
+++ b/.github/actions/generate-preview-env/action.yml
@@ -34,6 +34,10 @@ inputs:
     required: true
   api_key_404:
     required: true
+  max_upload_size_mib:
+    description: "Max upload size in MiB for presigned S3 URLs (default 50)"
+    required: false
+    default: "50"
 
 runs:
   using: "composite"
@@ -60,6 +64,7 @@ runs:
         GARAGE_S3_BUCKET: "${{ inputs.garage_s3_bucket }}"
         PREVIEW_API_KEY_404: "${{ inputs.api_key_404 }}"
         PREVIEW_JWT_SECRET: "${{ inputs.jwt_secret }}"
+        MAX_UPLOAD_SIZE_MIB: "${{ inputs.max_upload_size_mib }}"
 
       run: |
         mkdir -p infra/preview
@@ -82,6 +87,7 @@ runs:
         GARAGE_S3_BUCKET=$GARAGE_S3_BUCKET
 
         PREVIEW_API_KEY_404=$PREVIEW_API_KEY_404
+        MAX_UPLOAD_SIZE_MIB=$MAX_UPLOAD_SIZE_MIB
         NEXT_PUBLIC_SITE_URL=$PREVIEW_SITE_URL
         EOF
 

--- a/.github/actions/generate-prod-env/action.yml
+++ b/.github/actions/generate-prod-env/action.yml
@@ -36,6 +36,10 @@ inputs:
   api_key_404:
     description: "API key for the viernulvier API"
     required: true
+  max_upload_size_mib:
+    description: "Max upload size in MiB for presigned S3 URLs (default 50)"
+    required: false
+    default: "50"
 runs:
   using: "composite"
   steps:
@@ -54,6 +58,7 @@ runs:
         GARAGE_S3_BUCKET: "${{ inputs.garage_s3_bucket }}"
         PROD_API_KEY_404: "${{ inputs.api_key_404 }}"
         PROD_JWT_SECRET: "${{ inputs.jwt_secret }}"
+        MAX_UPLOAD_SIZE_MIB: "${{ inputs.max_upload_size_mib }}"
 
       run: |
         PROD_DATABASE_URL="postgres://${PROD_DB_USER}:${PROD_DB_PASSWORD}@${COMPOSE_PROJECT_NAME}-database:5432/${PROD_DB_NAME}"
@@ -72,6 +77,7 @@ runs:
         GARAGE_S3_ACCESS_KEY=$GARAGE_S3_ACCESS_KEY
         GARAGE_S3_SECRET_KEY=$GARAGE_S3_SECRET_KEY
         GARAGE_S3_BUCKET=$GARAGE_S3_BUCKET
+        MAX_UPLOAD_SIZE_MIB=$MAX_UPLOAD_SIZE_MIB
         EOF
 
         echo "Production .env generated."

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -4343,6 +4343,7 @@ dependencies = [
  "database",
  "dotenvy",
  "hex",
+ "hmac",
  "http-body-util",
  "jsonwebtoken",
  "mime",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -77,6 +77,7 @@ argon2 = "0.5.3"
 base64 = "0.22.1"
 rand = "0.10"
 sha2 = "0.10.9"
+hmac = "0.12.1"
 hex = "0.4.3"
 time = "0.3.47"
 aws-sdk-s3 = { version = "1", features = ["behavior-version-latest"] }

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -16,6 +16,7 @@ pub struct AppConfig {
     pub cookie_secure: bool,
     pub cookie_same_site: String,
     pub s3: Option<S3Config>,
+    pub upload_secret: String,
 }
 
 #[derive(Debug, Clone)]
@@ -91,6 +92,8 @@ impl AppConfig {
                 .unwrap_or(true),
             cookie_same_site: env::var("COOKIE_SAME_SITE").unwrap_or_else(|_| "strict".to_string()),
             s3,
+            upload_secret: env::var("UPLOAD_SECRET")
+                .unwrap_or_else(|_| get_env_var("JWT_SECRET").unwrap_or_default()),
         })
     }
 }

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -17,6 +17,7 @@ pub struct AppConfig {
     pub cookie_same_site: String,
     pub s3: Option<S3Config>,
     pub upload_secret: String,
+    pub max_upload_size_bytes: i64,
 }
 
 #[derive(Debug, Clone)]
@@ -94,6 +95,12 @@ impl AppConfig {
             s3,
             upload_secret: env::var("UPLOAD_SECRET")
                 .unwrap_or_else(|_| get_env_var("JWT_SECRET").unwrap_or_default()),
+            max_upload_size_bytes: env::var("MAX_UPLOAD_SIZE_MIB")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(50)
+                * 1024
+                * 1024,
         })
     }
 }

--- a/backend/src/dto/media.rs
+++ b/backend/src/dto/media.rs
@@ -227,11 +227,14 @@ pub struct UploadUrlResponse {
     pub upload_url: String,
     /// URL expiration in seconds
     pub expires_in: u64,
+    /// HMAC token that must be presented when attaching this upload
+    pub upload_token: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct AttachMediaRequest {
     pub s3_key: String,
+    pub upload_token: String,
     pub mime_type: String,
     pub role: Option<String>,
     pub sort_order: Option<i32>,

--- a/backend/src/dto/media.rs
+++ b/backend/src/dto/media.rs
@@ -262,6 +262,14 @@ pub struct AttachMediaRequest {
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct LinkMediaRequest {
+    pub media_id: Uuid,
+    pub role: Option<String>,
+    pub sort_order: Option<i32>,
+    pub is_cover_image: Option<bool>,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct ReconcileResponse {
     pub applied: bool,
     pub db_key_count: usize,

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -38,6 +38,9 @@ pub enum AppError {
 
     #[error("Conflict: {0}")]
     Conflict(String),
+
+    #[error("Cryptographic error: {0}")]
+    Crypto(String),
 }
 
 #[derive(Serialize, ToSchema)]

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -84,7 +84,12 @@ fn parse_same_site(value: &str) -> SameSite {
     }
 }
 
-fn access_cookie(token: String, expiry_minutes: i8, secure: bool, same_site: SameSite) -> Cookie<'static> {
+fn access_cookie(
+    token: String,
+    expiry_minutes: i8,
+    secure: bool,
+    same_site: SameSite,
+) -> Cookie<'static> {
     Cookie::build((ACCESS_TOKEN_COOKIE, token))
         .http_only(true)
         .secure(secure)
@@ -94,7 +99,13 @@ fn access_cookie(token: String, expiry_minutes: i8, secure: bool, same_site: Sam
         .build()
 }
 
-fn refresh_cookie(token: String, expiry_days: i8, secure: bool, same_site: SameSite, preview_name: &str) -> Cookie<'static> {
+fn refresh_cookie(
+    token: String,
+    expiry_days: i8,
+    secure: bool,
+    same_site: SameSite,
+    preview_name: &str,
+) -> Cookie<'static> {
     let path = if preview_name.is_empty() {
         "/api/auth/refresh".to_string()
     } else {
@@ -176,11 +187,29 @@ pub async fn login(
     )?;
 
     let same_site = parse_same_site(&config.cookie_same_site);
-    let access_cookie = access_cookie(access_token, config.access_token_expiry_minutes, config.cookie_secure, same_site);
-    let refresh_cookie = refresh_cookie(refresh_token, config.refresh_token_expiry_days, config.cookie_secure, same_site, &config.preview_name);
-    let session_present = session_present_cookie(config.refresh_token_expiry_days, config.cookie_secure, same_site);
+    let access_cookie = access_cookie(
+        access_token,
+        config.access_token_expiry_minutes,
+        config.cookie_secure,
+        same_site,
+    );
+    let refresh_cookie = refresh_cookie(
+        refresh_token,
+        config.refresh_token_expiry_days,
+        config.cookie_secure,
+        same_site,
+        &config.preview_name,
+    );
+    let session_present = session_present_cookie(
+        config.refresh_token_expiry_days,
+        config.cookie_secure,
+        same_site,
+    );
 
-    let updated_jar = jar.add(access_cookie).add(refresh_cookie).add(session_present);
+    let updated_jar = jar
+        .add(access_cookie)
+        .add(refresh_cookie)
+        .add(session_present);
     Ok((
         updated_jar,
         Json(AuthResponse {
@@ -242,7 +271,12 @@ pub async fn refresh(
     )?;
 
     let same_site = parse_same_site(&config.cookie_same_site);
-    let access_cookie = access_cookie(new_access_token, config.access_token_expiry_minutes, config.cookie_secure, same_site);
+    let access_cookie = access_cookie(
+        new_access_token,
+        config.access_token_expiry_minutes,
+        config.cookie_secure,
+        same_site,
+    );
     // Note: refresh endpoint only sets a new access token; refresh cookie path is kept intact.
     let updated_jar = jar.add(access_cookie);
 
@@ -312,7 +346,10 @@ pub async fn logout(
         .max_age(Duration::ZERO)
         .build();
 
-    let updated_jar = jar.add(access_cookie).add(refresh_cookie).add(session_present);
+    let updated_jar = jar
+        .add(access_cookie)
+        .add(refresh_cookie)
+        .add(session_present);
     Ok((
         updated_jar,
         Json(AuthResponse {

--- a/backend/src/handlers/media.rs
+++ b/backend/src/handlers/media.rs
@@ -5,7 +5,8 @@ use axum::{
     http::StatusCode,
 };
 use database::{Database, models::entity_type::EntityType};
-use sha2::{Digest, Sha256};
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
 use std::collections::HashSet;
 use std::time::Duration;
 use uuid::Uuid;
@@ -146,16 +147,23 @@ fn validate_upload_request(req: &UploadUrlRequest) -> Result<(), AppError> {
     Ok(())
 }
 
+type HmacSha256 = Hmac<Sha256>;
+
 pub fn generate_upload_token(secret: &str, s3_key: &str) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(secret.as_bytes());
-    hasher.update(b":");
-    hasher.update(s3_key.as_bytes());
-    hex::encode(hasher.finalize())
+    let mut mac = HmacSha256::new_from_slice(secret.as_bytes())
+        .expect("HMAC can take key of any size");
+    mac.update(s3_key.as_bytes());
+    hex::encode(mac.finalize().into_bytes())
 }
 
 fn verify_upload_token(secret: &str, s3_key: &str, token: &str) -> bool {
-    generate_upload_token(secret, s3_key) == token
+    let Ok(expected) = hex::decode(token) else {
+        return false;
+    };
+    let mut mac = HmacSha256::new_from_slice(secret.as_bytes())
+        .expect("HMAC can take key of any size");
+    mac.update(s3_key.as_bytes());
+    mac.verify_slice(&expected).is_ok()
 }
 
 #[utoipa::path(

--- a/backend/src/handlers/media.rs
+++ b/backend/src/handlers/media.rs
@@ -14,8 +14,8 @@ use crate::{
     AppState,
     config::S3Config,
     dto::media::{
-        AttachMediaRequest, MediaPayload, MediaVariantPayload, ReconcileResponse, UploadUrlRequest,
-        UploadUrlResponse,
+        AttachMediaRequest, LinkMediaRequest, MediaPayload, MediaVariantPayload, ReconcileResponse,
+        UploadUrlRequest, UploadUrlResponse,
     },
     error::AppError,
     handlers::{IntoApiResponse, JsonResponse, JsonStatusResponse, StatusResponse},
@@ -104,7 +104,6 @@ const ALLOWED_MIME_TYPES: &[&str] = &[
     "video/mp4",
     "application/pdf",
 ];
-const MAX_UPLOAD_SIZE_BYTES: i64 = 50 * 1024 * 1024; // 50 MiB
 
 fn validate_upload_request(req: &UploadUrlRequest) -> Result<(), AppError> {
     let ext = std::path::Path::new(&req.filename)
@@ -195,7 +194,7 @@ pub async fn generate_upload_url(
         .bucket(&s3_config.bucket)
         .key(&s3_key)
         .content_type(&req.mime_type)
-        .content_length(MAX_UPLOAD_SIZE_BYTES)
+        .content_length(state.config.max_upload_size_bytes)
         .presigned(presigning_config)
         .await
         .map_err(|e| AppError::Internal(format!("failed to generate presigned URL: {e}")))?;
@@ -438,6 +437,49 @@ pub async fn attach_to_entity(
 
     let public_url = state.config.s3.as_ref().map(|s| s.public_url.as_str());
     MediaPayload::from_model(media, public_url).json_created()
+}
+
+#[utoipa::path(
+    method(post),
+    path = "/media/entity/{entity_type}/{entity_id}/link",
+    tag = "Media",
+    operation_id = "link_media_to_entity",
+    description = "Link an existing media record to an entity. Does not modify media metadata or require an upload token.",
+    params(
+        ("entity_type" = String, Path, description = "Entity type (production, event, blogpost, media, artist)"),
+        ("entity_id" = Uuid, Path, description = "Entity UUID")
+    ),
+    request_body = LinkMediaRequest,
+    responses(
+        (status = 200, description = "Success", body = MediaPayload),
+        (status = 404, description = "Media not found"),
+        (status = 400, description = "Bad request")
+    )
+)]
+pub async fn link_to_entity(
+    State(state): State<AppState>,
+    db: Database,
+    Path((entity_type, entity_id)): Path<(String, Uuid)>,
+    Json(req): Json<LinkMediaRequest>,
+) -> JsonResponse<MediaPayload> {
+    let et = parse_entity_type(&entity_type)?;
+    let role = normalize_media_role_opt(req.role)?.unwrap_or_else(|| "gallery".to_string());
+
+    let media = db.media().by_id(req.media_id).await?;
+
+    db.media()
+        .link_to_entity(
+            et,
+            entity_id,
+            req.media_id,
+            &role,
+            req.sort_order.unwrap_or(0),
+            req.is_cover_image.unwrap_or(false),
+        )
+        .await?;
+
+    let public_url = state.config.s3.as_ref().map(|s| s.public_url.as_str());
+    Ok(Json(MediaPayload::from_model(media, public_url)))
 }
 
 #[utoipa::path(

--- a/backend/src/handlers/media.rs
+++ b/backend/src/handlers/media.rs
@@ -5,6 +5,7 @@ use axum::{
     http::StatusCode,
 };
 use database::{Database, models::entity_type::EntityType};
+use sha2::{Digest, Sha256};
 use std::collections::HashSet;
 use std::time::Duration;
 use uuid::Uuid;
@@ -93,6 +94,71 @@ pub async fn get_one(
     Ok(Json(payload))
 }
 
+const ALLOWED_EXTENSIONS: &[&str] = &["jpg", "jpeg", "png", "gif", "webp", "svg", "mp4", "pdf"];
+const ALLOWED_MIME_TYPES: &[&str] = &[
+    "image/jpeg",
+    "image/png",
+    "image/gif",
+    "image/webp",
+    "image/svg+xml",
+    "video/mp4",
+    "application/pdf",
+];
+const MAX_UPLOAD_SIZE_BYTES: i64 = 50 * 1024 * 1024; // 50 MiB
+
+fn validate_upload_request(req: &UploadUrlRequest) -> Result<(), AppError> {
+    let ext = std::path::Path::new(&req.filename)
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("bin")
+        .to_ascii_lowercase();
+
+    if !ALLOWED_EXTENSIONS.contains(&ext.as_str()) {
+        return Err(AppError::PayloadError(format!(
+            "file extension '{ext}' is not allowed"
+        )));
+    }
+
+    if !ALLOWED_MIME_TYPES.contains(&req.mime_type.as_str()) {
+        return Err(AppError::PayloadError(format!(
+            "MIME type '{}' is not allowed",
+            req.mime_type
+        )));
+    }
+
+    let expected_mime = match ext.as_str() {
+        "jpg" | "jpeg" => "image/jpeg",
+        "png" => "image/png",
+        "gif" => "image/gif",
+        "webp" => "image/webp",
+        "svg" => "image/svg+xml",
+        "mp4" => "video/mp4",
+        "pdf" => "application/pdf",
+        _ => "",
+    };
+
+    if !expected_mime.is_empty() && req.mime_type != expected_mime {
+        return Err(AppError::PayloadError(format!(
+            "MIME type '{}' does not match extension '{}'",
+            req.mime_type, ext
+        )));
+    }
+
+    Ok(())
+}
+
+pub fn generate_upload_token(secret: &str, s3_key: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(secret.as_bytes());
+    hasher.update(b":");
+    hasher.update(s3_key.as_bytes());
+    hex::encode(hasher.finalize())
+}
+
+fn verify_upload_token(secret: &str, s3_key: &str, token: &str) -> bool {
+    generate_upload_token(secret, s3_key) == token
+}
+
 #[utoipa::path(
     method(post),
     path = "/media/upload-url",
@@ -109,6 +175,8 @@ pub async fn generate_upload_url(
     State(state): State<AppState>,
     Json(req): Json<UploadUrlRequest>,
 ) -> Result<Json<UploadUrlResponse>, AppError> {
+    validate_upload_request(&req)?;
+
     let (s3_client, s3_config) = s3_client_and_config(&state)?;
 
     let ext = std::path::Path::new(&req.filename)
@@ -127,14 +195,18 @@ pub async fn generate_upload_url(
         .bucket(&s3_config.bucket)
         .key(&s3_key)
         .content_type(&req.mime_type)
+        .content_length(MAX_UPLOAD_SIZE_BYTES)
         .presigned(presigning_config)
         .await
         .map_err(|e| AppError::Internal(format!("failed to generate presigned URL: {e}")))?;
+
+    let upload_token = generate_upload_token(&state.config.upload_secret, &s3_key);
 
     Ok(Json(UploadUrlResponse {
         s3_key,
         upload_url: presigned.uri().to_string(),
         expires_in,
+        upload_token,
     }))
 }
 
@@ -311,6 +383,17 @@ pub async fn attach_to_entity(
     Path((entity_type, entity_id)): Path<(String, Uuid)>,
     Json(req): Json<AttachMediaRequest>,
 ) -> JsonStatusResponse<MediaPayload> {
+    if !verify_upload_token(&state.config.upload_secret, &req.s3_key, &req.upload_token) {
+        return Err(AppError::PayloadError("invalid upload token".into()));
+    }
+
+    // Prevent metadata hijacking of existing media via ON CONFLICT (s3_key)
+    if db.media().by_s3_key(&req.s3_key).await?.is_some() {
+        return Err(AppError::Conflict(
+            "s3_key is already in use by another media item".into(),
+        ));
+    }
+
     let et = parse_entity_type(&entity_type)?;
     let role = normalize_media_role_opt(req.role)?.unwrap_or_else(|| "gallery".to_string());
 

--- a/backend/src/handlers/media.rs
+++ b/backend/src/handlers/media.rs
@@ -149,21 +149,20 @@ fn validate_upload_request(req: &UploadUrlRequest) -> Result<(), AppError> {
 
 type HmacSha256 = Hmac<Sha256>;
 
-pub fn generate_upload_token(secret: &str, s3_key: &str) -> String {
+pub fn generate_upload_token(secret: &str, s3_key: &str) -> Result<String, AppError> {
     let mut mac = HmacSha256::new_from_slice(secret.as_bytes())
-        .expect("HMAC can take key of any size");
+        .map_err(|e| AppError::Crypto(format!("HMAC init failed: {e}")))?;
     mac.update(s3_key.as_bytes());
-    hex::encode(mac.finalize().into_bytes())
+    Ok(hex::encode(mac.finalize().into_bytes()))
 }
 
-fn verify_upload_token(secret: &str, s3_key: &str, token: &str) -> bool {
-    let Ok(expected) = hex::decode(token) else {
-        return false;
-    };
+fn verify_upload_token(secret: &str, s3_key: &str, token: &str) -> Result<bool, AppError> {
+    let expected = hex::decode(token)
+        .map_err(|e| AppError::Crypto(format!("invalid upload token hex: {e}")))?;
     let mut mac = HmacSha256::new_from_slice(secret.as_bytes())
-        .expect("HMAC can take key of any size");
+        .map_err(|e| AppError::Crypto(format!("HMAC init failed: {e}")))?;
     mac.update(s3_key.as_bytes());
-    mac.verify_slice(&expected).is_ok()
+    Ok(mac.verify_slice(&expected).is_ok())
 }
 
 #[utoipa::path(
@@ -207,7 +206,7 @@ pub async fn generate_upload_url(
         .await
         .map_err(|e| AppError::Internal(format!("failed to generate presigned URL: {e}")))?;
 
-    let upload_token = generate_upload_token(&state.config.upload_secret, &s3_key);
+    let upload_token = generate_upload_token(&state.config.upload_secret, &s3_key)?;
 
     Ok(Json(UploadUrlResponse {
         s3_key,
@@ -390,7 +389,7 @@ pub async fn attach_to_entity(
     Path((entity_type, entity_id)): Path<(String, Uuid)>,
     Json(req): Json<AttachMediaRequest>,
 ) -> JsonStatusResponse<MediaPayload> {
-    if !verify_upload_token(&state.config.upload_secret, &req.s3_key, &req.upload_token) {
+    if !verify_upload_token(&state.config.upload_secret, &req.s3_key, &req.upload_token)? {
         return Err(AppError::PayloadError("invalid upload token".into()));
     }
 

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -304,6 +304,7 @@ fn editor_routes(state: AppState) -> OpenApiRouter<AppState> {
         .routes(routes!(media::put))
         .routes(routes!(media::delete))
         .routes(routes!(media::attach_to_entity))
+        .routes(routes!(media::link_to_entity))
         .routes(routes!(media::unlink_from_entity))
         .routes(routes!(media::cleanup_orphans))
         .routes(routes!(media::reconcile_storage))

--- a/backend/tests/media.rs
+++ b/backend/tests/media.rs
@@ -212,3 +212,29 @@ async fn cleanup_orphans(db: PgPool) {
     let response = app.get(&format!("/media/{media_id}")).await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
+
+#[sqlx::test(fixtures("productions", "media"))]
+#[test_log::test]
+async fn link_existing_media_to_entity(db: PgPool) {
+    let app = TestRouter::as_editor(db.clone()).await;
+    let production_id = Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap();
+    let media_id = Uuid::parse_str("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa").unwrap();
+
+    let payload = json!({
+        "media_id": media_id,
+        "role": "poster",
+        "sort_order": 5,
+        "is_cover_image": true
+    });
+
+    let response = app
+        .post(
+            &format!("/media/entity/production/{production_id}/link"),
+            &payload,
+        )
+        .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let data: MediaPayload = response.into_struct().await;
+    assert_eq!(data.id, media_id);
+}

--- a/backend/tests/media.rs
+++ b/backend/tests/media.rs
@@ -226,7 +226,7 @@ async fn link_existing_media_to_entity(db: PgPool) {
         "media_id": media_id,
         "role": "poster",
         "sort_order": 5,
-        "is_cover_image": true
+        "is_cover_image": false
     });
 
     let response = app

--- a/backend/tests/media.rs
+++ b/backend/tests/media.rs
@@ -1,13 +1,22 @@
 use axum::http::StatusCode;
 use serde_json::json;
+use sha2::{Digest, Sha256};
 use sqlx::PgPool;
 use uuid::Uuid;
-use viernulvier_api::dto::media::MediaPayload;
+use viernulvier_api::{config::AppConfig, dto::media::MediaPayload};
 
 use crate::common::into_struct::IntoStruct;
 use crate::common::router::TestRouter;
 
 mod common;
+
+fn generate_upload_token(secret: &str, s3_key: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(secret.as_bytes());
+    hasher.update(b":");
+    hasher.update(s3_key.as_bytes());
+    hex::encode(hasher.finalize())
+}
 
 #[sqlx::test(fixtures("productions", "media"))]
 #[test_log::test]
@@ -101,8 +110,13 @@ async fn get_entity_media_respects_pagination(db: PgPool) {
 #[test_log::test]
 async fn attach_media_transactional_success(db: PgPool) {
     let production_id = Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap();
+    let config = AppConfig::load().unwrap();
+    let s3_key = "media/cms/test-attach.jpg";
+    let upload_token = generate_upload_token(&config.upload_secret, s3_key);
+
     let payload = json!({
-        "s3_key": "media/cms/test-attach.jpg",
+        "s3_key": s3_key,
+        "upload_token": upload_token,
         "mime_type": "image/jpeg",
         "role": "gallery",
         "sort_order": 0,

--- a/backend/tests/media.rs
+++ b/backend/tests/media.rs
@@ -1,6 +1,7 @@
 use axum::http::StatusCode;
 use serde_json::json;
-use sha2::{Digest, Sha256};
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
 use sqlx::PgPool;
 use uuid::Uuid;
 use viernulvier_api::{config::AppConfig, dto::media::MediaPayload};
@@ -10,12 +11,13 @@ use crate::common::router::TestRouter;
 
 mod common;
 
+type HmacSha256 = Hmac<Sha256>;
+
 fn generate_upload_token(secret: &str, s3_key: &str) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(secret.as_bytes());
-    hasher.update(b":");
-    hasher.update(s3_key.as_bytes());
-    hex::encode(hasher.finalize())
+    let mut mac = HmacSha256::new_from_slice(secret.as_bytes())
+        .expect("HMAC can take key of any size");
+    mac.update(s3_key.as_bytes());
+    hex::encode(mac.finalize().into_bytes())
 }
 
 #[sqlx::test(fixtures("productions", "media"))]

--- a/docs/content/docs/api/garage-media.mdx
+++ b/docs/content/docs/api/garage-media.mdx
@@ -30,9 +30,14 @@ This project stores media files in **Garage (S3-compatible object storage)** and
 
 1. Request presigned URL
    - `POST /api/media/upload-url`
+   - Validates file extension and MIME type (allowed: `jpg`, `jpeg`, `png`, `gif`, `webp`, `svg`, `mp4`, `pdf`)
+   - Respects `MAX_UPLOAD_SIZE_MIB` environment variable (default: `50`)
+   - Returns an `upload_token` that must be presented in step 3
 2. Upload file directly from browser to Garage
 3. Attach metadata + link to entity in one transaction
    - `POST /api/media/entity/{entity_type}/{entity_id}/attach`
+   - Requires the `upload_token` from step 1 to prevent metadata hijacking
+   - Rejects requests for an already-existing `s3_key` with `409 Conflict`
 
 This keeps metadata and linking consistent for CMS operations.
 

--- a/docs/content/docs/getting-started/preview.mdx
+++ b/docs/content/docs/getting-started/preview.mdx
@@ -54,6 +54,7 @@ cp infra/preview/.env.preview.example infra/preview/.env
 | `GARAGE_S3_ACCESS_KEY`                     | S3 access key                                     |
 | `GARAGE_S3_SECRET_KEY`                     | S3 secret key                                     |
 | `GARAGE_S3_BUCKET`                         | S3 bucket name                                    |
+| `MAX_UPLOAD_SIZE_MIB`                      | Max upload size in MiB (default `50`)             |
 
 <Callout type="info">
   Replace `PREVIEW_` with `PROD_` for production deployments. For example: `PREVIEW_DB_USER` becomes

--- a/frontend/src/mappers/media.mapper.ts
+++ b/frontend/src/mappers/media.mapper.ts
@@ -62,6 +62,7 @@ export const mapMediaList = (list: MediaPayloadResponse[]): Media[] => list.map(
 
 export const mapAttachMediaInput = (input: AttachMediaInput): AttachMediaRequestType => ({
     s3_key: input.s3Key,
+    upload_token: input.uploadToken,
     mime_type: input.mimeType,
     role: input.role,
     sort_order: input.sortOrder,
@@ -95,6 +96,7 @@ export const mapUploadUrlResult = (response: GenerateUploadUrlResponse): UploadU
     s3Key: response.s3_key,
     uploadUrl: response.upload_url,
     expiresIn: response.expires_in,
+    uploadToken: response.upload_token,
 });
 
 export const mapMediaVariantToPayload = (v: MediaVariant): MediaVariantPayloadResponse => ({

--- a/frontend/src/types/api/generated.ts
+++ b/frontend/src/types/api/generated.ts
@@ -463,6 +463,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/media/entity/{entity_type}/{entity_id}/link": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** @description Link an existing media record to an entity. Does not modify media metadata or require an upload token. */
+        post: operations["link_media_to_entity"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/media/entity/{entity_type}/{entity_id}/{media_id}": {
         parameters: {
             query?: never;
@@ -1174,6 +1191,14 @@ export interface components {
             /** Format: uuid */
             space_id?: string | null;
             vendor_id?: string | null;
+        };
+        LinkMediaRequest: {
+            is_cover_image?: boolean | null;
+            /** Format: uuid */
+            media_id: string;
+            role?: string | null;
+            /** Format: int32 */
+            sort_order?: number | null;
         };
         LocationPayload: {
             city?: string | null;
@@ -2921,6 +2946,49 @@ export interface operations {
             };
             /** @description Bad request */
             400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    link_media_to_entity: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Entity type (production, event, blogpost, media, artist) */
+                entity_type: string;
+                /** @description Entity UUID */
+                entity_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["LinkMediaRequest"];
+            };
+        };
+        responses: {
+            /** @description Success */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MediaPayload"];
+                };
+            };
+            /** @description Bad request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Media not found */
+            404: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/frontend/src/types/api/generated.ts
+++ b/frontend/src/types/api/generated.ts
@@ -874,6 +874,7 @@ export interface components {
             s3_key: string;
             /** Format: int32 */
             sort_order?: number | null;
+            upload_token: string;
             /** Format: int32 */
             width?: number | null;
         };
@@ -1528,6 +1529,8 @@ export interface components {
             expires_in: number;
             /** @description The S3 key where the file should be uploaded */
             s3_key: string;
+            /** @description HMAC token that must be presented when attaching this upload */
+            upload_token: string;
             /** @description Presigned PUT URL for direct upload */
             upload_url: string;
         };

--- a/frontend/src/types/api/media.api.types.ts
+++ b/frontend/src/types/api/media.api.types.ts
@@ -8,5 +8,6 @@ export type AttachMediaResponse = components["schemas"]["MediaPayload"];
 export type GenerateUploadUrlResponse = components["schemas"]["UploadUrlResponse"];
 export type GetAllMediaResponse = components["schemas"]["MediaPayload"][];
 export type AttachMediaRequestType = components["schemas"]["AttachMediaRequest"];
+export type LinkMediaRequestType = components["schemas"]["LinkMediaRequest"];
 export type UploadUrlRequestType = components["schemas"]["UploadUrlRequest"];
 export type UpdateMediaRequestType = components["schemas"]["MediaPayload"];

--- a/frontend/src/types/models/media.types.ts
+++ b/frontend/src/types/models/media.types.ts
@@ -51,6 +51,7 @@ export type EntityMediaParams = {
 
 export type AttachMediaInput = {
     s3Key: string;
+    uploadToken: string;
     mimeType: string;
     role?: string | null;
     sortOrder?: number | null;
@@ -84,4 +85,5 @@ export type UploadUrlResult = {
     s3Key: string;
     uploadUrl: string;
     expiresIn: number;
+    uploadToken: string;
 };

--- a/frontend/test/unit/mappers/media.mapper.test.ts
+++ b/frontend/test/unit/mappers/media.mapper.test.ts
@@ -159,6 +159,7 @@ describe("media mapper", () => {
         it("maps camelCase input to snake_case API payload", () => {
             const result = mapAttachMediaInput({
                 s3Key: "media/test.jpg",
+                uploadToken: "token-123",
                 mimeType: "image/jpeg",
                 role: "gallery",
                 sortOrder: 1,
@@ -170,6 +171,7 @@ describe("media mapper", () => {
                 fileSize: 50000,
             });
             expect(result.s3_key).toBe("media/test.jpg");
+            expect(result.upload_token).toBe("token-123");
             expect(result.mime_type).toBe("image/jpeg");
             expect(result.role).toBe("gallery");
             expect(result.sort_order).toBe(1);
@@ -199,10 +201,12 @@ describe("media mapper", () => {
                 s3_key: "media/abc.jpg",
                 upload_url: "https://s3.example.com/presigned",
                 expires_in: 300,
+                upload_token: "token-abc",
             });
             expect(result.s3Key).toBe("media/abc.jpg");
             expect(result.uploadUrl).toBe("https://s3.example.com/presigned");
             expect(result.expiresIn).toBe(300);
+            expect(result.uploadToken).toBe("token-abc");
         });
     });
 });

--- a/infra/dev/.env.dev.example
+++ b/infra/dev/.env.dev.example
@@ -13,6 +13,7 @@ DEV_DB_NAME=sel2-dev
 DATABASE_URL="postgres://sel2-dev:password@localhost:5432/sel2-dev"
 API_KEY_404="see https://github.com/SELab-2/viernulvier-opgave/blob/main/kickoff%20archief%20project%20Ugent%20x%20VIERNULVIER.pdf"
 JWT_SECRET="change-this-very-secure-secret"
+MAX_UPLOAD_SIZE_MIB=50
 
 RUST_LOG="DEBUG,sqlx=INFO,h2=INFO"
 ALLOWED_ORIGINS=http://localhost:3000,http://sel2-6.ugent.be/

--- a/infra/preview/.env.preview.example
+++ b/infra/preview/.env.preview.example
@@ -11,6 +11,7 @@ PREVIEW_DB_PASSWORD=preview
 PREVIEW_DB_NAME=preview_db
 
 PREVIEW_JWT_SECRET=very-secure-jwt-secret
+MAX_UPLOAD_SIZE_MIB=50
 PREVIEW_API_KEY_404=
 
 # Garage S3 Configuration

--- a/infra/production/docker-compose.prod.yml
+++ b/infra/production/docker-compose.prod.yml
@@ -15,6 +15,7 @@ services:
       S3_BUCKET: ${GARAGE_S3_BUCKET}
       S3_PUBLIC_URL: ${NEXT_PUBLIC_SITE_URL}/s3
       ALLOWED_ORIGINS: ${NEXT_PUBLIC_SITE_URL}
+      MAX_UPLOAD_SIZE_MIB: ${MAX_UPLOAD_SIZE_MIB:-50}
     depends_on:
       database:
         condition: service_healthy


### PR DESCRIPTION
# Fix S3 Upload Security Vulnerabilities

This PR addresses multiple security vulnerabilities related to S3 media uploads and metadata integrity.

---

## 1. Unrestricted S3 Presigned Upload (Arbitrary File Types)

### Problem
`POST /media/upload-url` accepted any user-supplied `filename` and `mime_type` without validation. An editor could request a presigned URL for `evil.html` with `text/html`, upload it to the publicly readable S3 bucket, and serve executable content — leading to XSS, malware distribution, or phishing.

### Fix
- **Extension whitelist**: only `jpg`, `jpeg`, `png`, `gif`, `webp`, `svg`, `mp4`, `pdf` are allowed.
- **MIME-type whitelist**: only matching image/video/PDF MIME types are accepted.
- **Extension ↔ MIME consistency check**: e.g. `.jpg` must be `image/jpeg`; mismatches are rejected.
- **Size limit**: enforced via `content_length` on the S3 presigned `put_object` request. The limit is configurable via `MAX_UPLOAD_SIZE_MIB` (default: `50`).

---

## 2. S3 Key Injection / Metadata Hijacking

### Problem
`POST /media/entity/{type}/{id}/attach` inserted media with `ON CONFLICT (s3_key) DO UPDATE SET ...`. Because `s3_key` was user-controlled and exposed to editors, an attacker could:
1. Enumerate existing `s3_key` values from the public `GET /media` list.
2. Send an `attach` request reusing someone else's `s3_key`.
3. Overwrite that media's metadata (`alt_text`, `description`, `credit`, etc.) and forcibly link it to their own entity.

### Fix
- **Upload token (HMAC)**: `generate_upload_url` now returns an `upload_token` (keyed SHA-256 of the `s3_key`). `attach_to_entity` rejects any request without a valid token, proving the file was actually uploaded through the backend.
- **Existing-key rejection**: before insertion, `attach_to_entity` checks if the `s3_key` already exists in the database. If it does, the endpoint returns `409 Conflict`, making the `ON CONFLICT` hijack path impossible.

---

## 3. New Endpoint for Reusing Existing Media

### `POST /api/media/entity/{type}/{id}/link`

Allows editors to link an **existing** media record to an entity (production, article, event, etc.) without uploading a new file. Intended for reusing old media, e.g. the same image for a new newspaper article.

- **Requires**: `media_id`, optional `role` / `sort_order` / `is_cover_image`
- Does **not** modify any metadata of the original media item
- Does **not** require an `upload_token`

This cleanly separates the **new upload** flow (`attach_to_entity`, with token + `s3_key` validation) from the **reuse existing media** flow (`link_to_entity`).
