### PR TITLE
chore(ui): restyle toast notifications to match theme

### DIFF
--- a/frontend/src/components/ui/sonner.tsx
+++ b/frontend/src/components/ui/sonner.tsx
@@ -29,7 +29,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
                     "--error-bg": "var(--popover)",
                     "--error-text": "var(--destructive)",
                     "--error-border": "var(--destructive)",
-                    "--border-radius": "var(--radius)",
+                    "--border-radius": "0px",
                 } as React.CSSProperties
             }
             toastOptions={{

--- a/frontend/src/components/ui/sonner.tsx
+++ b/frontend/src/components/ui/sonner.tsx
@@ -1,12 +1,6 @@
 "use client";
 
-import {
-    CircleCheckIcon,
-    InfoIcon,
-    Loader2Icon,
-    OctagonXIcon,
-    TriangleAlertIcon,
-} from "lucide-react";
+import { Check, Info, Loader2, TriangleAlert, X } from "lucide-react";
 import { useTheme } from "next-themes";
 import { Toaster as Sonner, type ToasterProps } from "sonner";
 
@@ -18,20 +12,36 @@ const Toaster = ({ ...props }: ToasterProps) => {
             theme={theme as ToasterProps["theme"]}
             className="toaster group"
             icons={{
-                success: <CircleCheckIcon className="size-4" />,
-                info: <InfoIcon className="size-4" />,
-                warning: <TriangleAlertIcon className="size-4" />,
-                error: <OctagonXIcon className="size-4" />,
-                loading: <Loader2Icon className="size-4 animate-spin" />,
+                success: <Check className="size-4" />,
+                info: <Info className="size-4" />,
+                warning: <TriangleAlert className="size-4" />,
+                error: <X className="size-4" />,
+                loading: <Loader2 className="size-4 animate-spin" />,
             }}
             style={
                 {
                     "--normal-bg": "var(--popover)",
                     "--normal-text": "var(--popover-foreground)",
                     "--normal-border": "var(--border)",
+                    "--success-bg": "var(--popover)",
+                    "--success-text": "var(--popover-foreground)",
+                    "--success-border": "var(--border)",
+                    "--error-bg": "var(--popover)",
+                    "--error-text": "var(--destructive)",
+                    "--error-border": "var(--destructive)",
                     "--border-radius": "var(--radius)",
                 } as React.CSSProperties
             }
+            toastOptions={{
+                classNames: {
+                    toast: "gap-3 px-4 py-3 text-sm",
+                    icon: "mt-0.5 shrink-0",
+                    success: "border-l-2 border-l-foreground",
+                    error: "border-l-2 border-l-destructive",
+                    warning: "border-l-2 border-l-muted-foreground",
+                    info: "border-l-2 border-l-muted-foreground",
+                },
+            }}
             {...props}
         />
     );


### PR DESCRIPTION
Swaps the `CircleCheckIcon`/`OctagonXIcon` icons for simpler `Check`/`X` that fit the chip-sized toast better. Adds per-type left-border accents to differentiate toast types visually without introducing new color tokens: success gets a `foreground` border, error gets `destructive`, warning and info get `muted-foreground`. All background and text tokens continue to use the existing `--popover`/`--border` variables.

Refs #321

<img width="638" height="140" alt="image" src="https://github.com/user-attachments/assets/c3b7d64b-5558-4ea7-8cea-aa02146f5fc1" />
