### PR TITLE
feat: show stats counts on CMS overview cards

### DIFF
--- a/frontend/src/app/[locale]/(cms)/cms/(overview)/page.tsx
+++ b/frontend/src/app/[locale]/(cms)/cms/(overview)/page.tsx
@@ -3,15 +3,7 @@
 import { useTranslations } from "next-intl";
 import { useEffect, useRef } from "react";
 import { animate, stagger } from "animejs";
-import {
-    FileUp,
-    Database,
-    Clapperboard,
-    MapPin,
-    Newspaper,
-    Users,
-    FolderArchive,
-} from "lucide-react";
+import { FileUp, Database, Drama, MapPin, Newspaper, Users, SquareStack } from "lucide-react";
 
 import { SectionCard, SectionCardContent } from "@/components/cms/SectionCard";
 import { useGetStats } from "@/hooks/api/useStats";
@@ -21,7 +13,7 @@ interface ContentSection {
     href: string;
     editionKey: string;
     span: string;
-    icon: typeof Clapperboard;
+    icon: typeof Drama;
     comingSoon?: boolean;
 }
 
@@ -31,7 +23,7 @@ const CONTENT_SECTIONS: ContentSection[] = [
         href: "/cms/productions",
         editionKey: "edition1",
         span: "lg:col-span-8",
-        icon: Clapperboard,
+        icon: Drama,
     },
     {
         key: "locations",
@@ -60,7 +52,7 @@ const CONTENT_SECTIONS: ContentSection[] = [
         href: "/cms/collections",
         editionKey: "edition5",
         span: "lg:col-span-12",
-        icon: FolderArchive,
+        icon: SquareStack,
     },
 ];
 

--- a/frontend/src/app/[locale]/(cms)/cms/(overview)/page.tsx
+++ b/frontend/src/app/[locale]/(cms)/cms/(overview)/page.tsx
@@ -14,6 +14,7 @@ import {
 } from "lucide-react";
 
 import { SectionCard, SectionCardContent } from "@/components/cms/SectionCard";
+import { useGetStats } from "@/hooks/api/useStats";
 
 interface ContentSection {
     key: string;
@@ -58,7 +59,7 @@ const CONTENT_SECTIONS: ContentSection[] = [
         key: "collections",
         href: "/cms/collections",
         editionKey: "edition5",
-        span: "lg:col-span-6",
+        span: "lg:col-span-12",
         icon: FolderArchive,
     },
 ];
@@ -90,6 +91,7 @@ export default function CmsOverviewPage() {
     const tEditions = useTranslations("Cms.editions");
     const containerRef = useRef<HTMLDivElement>(null);
     const headerRef = useRef<HTMLElement>(null);
+    const { data: stats } = useGetStats();
 
     useEffect(() => {
         if (headerRef.current) {
@@ -152,6 +154,17 @@ export default function CmsOverviewPage() {
                                     actionLabel={t("openSection")}
                                     icon={section.icon}
                                     comingSoon={section.comingSoon}
+                                    count={
+                                        stats
+                                            ? {
+                                                  productions: stats.production_count,
+                                                  locations: stats.location_count,
+                                                  articles: stats.article_count,
+                                                  performers: stats.artist_count,
+                                                  collections: stats.collection_count,
+                                              }[section.key]
+                                            : undefined
+                                    }
                                 />
                             </div>
                         </SectionCard>

--- a/frontend/src/components/cms/SectionCard.tsx
+++ b/frontend/src/components/cms/SectionCard.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from "next-intl";
 import { Link } from "@/i18n/routing";
 import { animate } from "animejs";
 import type { LucideIcon } from "lucide-react";
+import { AnimatedNumber } from "@/components/ui/animated-number";
 
 interface SectionCardProps {
     children: ReactNode;
@@ -58,6 +59,7 @@ interface SectionCardContentProps {
     actionLabel: string;
     icon: LucideIcon;
     comingSoon?: boolean;
+    count?: number;
 }
 
 export function SectionCardContent({
@@ -67,6 +69,7 @@ export function SectionCardContent({
     actionLabel,
     icon: Icon,
     comingSoon = false,
+    count,
 }: SectionCardContentProps) {
     const t = useTranslations("Cms.SectionCard");
     return (
@@ -75,7 +78,15 @@ export function SectionCardContent({
                 <div className="text-muted-foreground mb-3 font-mono text-[9px] tracking-[1.4px] uppercase">
                     {edition}
                 </div>
-                <Icon className="text-muted-foreground/40 group-hover:text-foreground h-5 w-5 transition-colors duration-200" />
+                <div className="flex items-center gap-2">
+                    {count != null && (
+                        <AnimatedNumber
+                            value={count}
+                            className="font-display text-muted-foreground/40 group-hover:text-foreground text-[18px] font-bold tracking-tight transition-colors duration-200"
+                        />
+                    )}
+                    <Icon className="text-muted-foreground/40 group-hover:text-foreground h-5 w-5 transition-colors duration-200" />
+                </div>
             </div>
 
             {comingSoon && (

--- a/frontend/src/components/cms/cms-sidebar.tsx
+++ b/frontend/src/components/cms/cms-sidebar.tsx
@@ -4,15 +4,7 @@ import { useCallback, useMemo, useState } from "react";
 import { useTranslations, useLocale } from "next-intl";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Link, usePathname } from "@/i18n/routing";
-import {
-    Clapperboard,
-    MapPin,
-    Newspaper,
-    Users,
-    Database,
-    FileUp,
-    FolderArchive,
-} from "lucide-react";
+import { Drama, MapPin, Newspaper, Users, Database, FileUp, SquareStack } from "lucide-react";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import { Sheet, SheetContent, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
@@ -21,11 +13,11 @@ import { getLabel } from "@/lib/utils";
 import type { EntityType, Facet } from "@/types/models/taxonomy.types";
 
 const navItems = [
-    { key: "productions", href: "/cms/productions", icon: Clapperboard, editionKey: "edition1" },
+    { key: "productions", href: "/cms/productions", icon: Drama, editionKey: "edition1" },
     { key: "locations", href: "/cms/locations", icon: MapPin, editionKey: "edition2" },
     { key: "articles", href: "/cms/articles", icon: Newspaper, editionKey: "edition3" },
     { key: "performers", href: "/cms/performers", icon: Users, editionKey: "edition4" },
-    { key: "collections", href: "/cms/collections", icon: FolderArchive, editionKey: "edition5" },
+    { key: "collections", href: "/cms/collections", icon: SquareStack, editionKey: "edition5" },
 ];
 
 const utilityItems = [

--- a/frontend/src/components/ui/animated-number.tsx
+++ b/frontend/src/components/ui/animated-number.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import { animate } from "animejs";
+
+interface AnimatedNumberProps {
+    value: number;
+    duration?: number;
+    className?: string;
+}
+
+export function AnimatedNumber({ value, duration = 1200, className }: AnimatedNumberProps) {
+    const [display, setDisplay] = useState(0);
+    const objRef = useRef({ value: 0 });
+    const animRef = useRef<ReturnType<typeof animate> | null>(null);
+
+    useEffect(() => {
+        const startValue = objRef.current.value;
+
+        if (animRef.current) {
+            animRef.current.pause();
+        }
+
+        animRef.current = animate(objRef.current, {
+            value: [startValue, value],
+            duration,
+            ease: "easeOutQuart",
+            onUpdate: () => {
+                setDisplay(Math.round(objRef.current.value));
+            },
+        });
+
+        return () => {
+            if (animRef.current) {
+                animRef.current.pause();
+            }
+        };
+    }, [value, duration]);
+
+    return <span className={className}>{display.toLocaleString()}</span>;
+}


### PR DESCRIPTION
Small feature introducing stats in cms overview page using the stats endpoint implemented by @jarnex47 

https://github.com/user-attachments/assets/f3a61f55-5321-48e8-a56b-00a3afab1ea1

