### PR TITLE
fix: update @codecov/webpack-plugin to v2 to patch undici CVE

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -41,7 +41,7 @@
                 "zod": "^4.3.6"
             },
             "devDependencies": {
-                "@codecov/webpack-plugin": "^1.9.1",
+                "@codecov/webpack-plugin": "^2.0.1",
                 "@eslint/eslintrc": "^0.1.0",
                 "@playwright/test": "^1.58.2",
                 "@tailwindcss/postcss": "^4",
@@ -70,47 +70,68 @@
             }
         },
         "node_modules/@actions/core": {
-            "version": "1.11.1",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.0.tgz",
+            "integrity": "sha512-zYt6cz+ivnTmiT/ksRVriMBOiuoUpDCJJlZ5KPl2/FRdvwU3f7MPh9qftvbkXJThragzUZieit2nyHUyw53Seg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@actions/exec": "^1.1.1",
-                "@actions/http-client": "^2.0.1"
+                "@actions/exec": "^3.0.0",
+                "@actions/http-client": "^4.0.0"
             }
         },
         "node_modules/@actions/exec": {
-            "version": "1.1.1",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-3.0.0.tgz",
+            "integrity": "sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@actions/io": "^1.0.1"
+                "@actions/io": "^3.0.2"
             }
         },
         "node_modules/@actions/github": {
-            "version": "6.0.1",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/@actions/github/-/github-9.1.0.tgz",
+            "integrity": "sha512-u0hDGQeCS+7VNoLA8hYG65RLdPLMaPGfka0sZ0up7P0AiShqfX6xcuXNteGkQ7X7Tod7AMNwHd4p7DS63i8zzA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@actions/http-client": "^2.2.0",
-                "@octokit/core": "^5.0.1",
-                "@octokit/plugin-paginate-rest": "^9.2.2",
-                "@octokit/plugin-rest-endpoint-methods": "^10.4.0",
-                "@octokit/request": "^8.4.1",
-                "@octokit/request-error": "^5.1.1",
-                "undici": "^5.28.5"
+                "@actions/http-client": "^3.0.2",
+                "@octokit/core": "^7.0.6",
+                "@octokit/plugin-paginate-rest": "^14.0.0",
+                "@octokit/plugin-rest-endpoint-methods": "^17.0.0",
+                "@octokit/request": "^10.0.7",
+                "@octokit/request-error": "^7.1.0",
+                "undici": "^6.23.0"
             }
         },
-        "node_modules/@actions/http-client": {
-            "version": "2.2.3",
+        "node_modules/@actions/github/node_modules/@actions/http-client": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-3.0.2.tgz",
+            "integrity": "sha512-JP38FYYpyqvUsz+Igqlc/JG6YO9PaKuvqjM3iGvaLqFnJ7TFmcLyy2IDrY0bI0qCQug8E9K+elv5ZNfw62ZJzA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "tunnel": "^0.0.6",
-                "undici": "^5.25.4"
+                "undici": "^6.23.0"
+            }
+        },
+        "node_modules/@actions/http-client": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.0.tgz",
+            "integrity": "sha512-QuwPsgVMsD6qaPD57GLZi9sqzAZCtiJT8kVBCDpLtxhL5MydQ4gS+DrejtZZPdIYyB1e95uCK9Luyds7ybHI3g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tunnel": "^0.0.6",
+                "undici": "^6.23.0"
             }
         },
         "node_modules/@actions/io": {
-            "version": "1.1.3",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@actions/io/-/io-3.0.2.tgz",
+            "integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
             "dev": true,
             "license": "MIT"
         },
@@ -622,23 +643,27 @@
             }
         },
         "node_modules/@codecov/bundler-plugin-core": {
-            "version": "1.9.1",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@codecov/bundler-plugin-core/-/bundler-plugin-core-2.0.1.tgz",
+            "integrity": "sha512-TkdKn/rEwZQ723M7DDUmHe5r0IJa23rUT4TAx5jXmg12wGZGAHGWWU7LKeQsYCsKdLMxK7bLaGk9M++4wSRD5w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@actions/core": "^1.10.1",
-                "@actions/github": "^6.0.0",
+                "@actions/core": "^3.0.0",
+                "@actions/github": "^9.0.0",
                 "chalk": "4.1.2",
                 "semver": "^7.5.4",
                 "unplugin": "^1.10.1",
                 "zod": "^3.22.4"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@codecov/bundler-plugin-core/node_modules/zod": {
             "version": "3.25.76",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -646,15 +671,17 @@
             }
         },
         "node_modules/@codecov/webpack-plugin": {
-            "version": "1.9.1",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@codecov/webpack-plugin/-/webpack-plugin-2.0.1.tgz",
+            "integrity": "sha512-BC5+SOt8Z7mSAQnEZnmXuu8R//rYVWwQ0/CAglXAK6esY23Js8lLHU5fUo6fJL9e5iDCPSKJzxlAjFIsFMzimw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@codecov/bundler-plugin-core": "^1.9.1",
+                "@codecov/bundler-plugin-core": "^2.0.1",
                 "unplugin": "^1.10.1"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             },
             "peerDependencies": {
                 "webpack": "5.x"
@@ -1167,14 +1194,6 @@
                 "@noble/hashes": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/@fastify/busboy": {
-            "version": "2.1.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=14"
             }
         },
         "node_modules/@floating-ui/core": {
@@ -2240,147 +2259,141 @@
             }
         },
         "node_modules/@octokit/auth-token": {
-            "version": "4.0.0",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
+            "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">= 18"
+                "node": ">= 20"
             }
         },
         "node_modules/@octokit/core": {
-            "version": "5.2.2",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
+            "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@octokit/auth-token": "^4.0.0",
-                "@octokit/graphql": "^7.1.0",
-                "@octokit/request": "^8.4.1",
-                "@octokit/request-error": "^5.1.1",
-                "@octokit/types": "^13.0.0",
-                "before-after-hook": "^2.2.0",
-                "universal-user-agent": "^6.0.0"
+                "@octokit/auth-token": "^6.0.0",
+                "@octokit/graphql": "^9.0.3",
+                "@octokit/request": "^10.0.6",
+                "@octokit/request-error": "^7.0.2",
+                "@octokit/types": "^16.0.0",
+                "before-after-hook": "^4.0.0",
+                "universal-user-agent": "^7.0.0"
             },
             "engines": {
-                "node": ">= 18"
+                "node": ">= 20"
             }
         },
         "node_modules/@octokit/endpoint": {
-            "version": "9.0.6",
+            "version": "11.0.3",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
+            "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@octokit/types": "^13.1.0",
-                "universal-user-agent": "^6.0.0"
+                "@octokit/types": "^16.0.0",
+                "universal-user-agent": "^7.0.2"
             },
             "engines": {
-                "node": ">= 18"
+                "node": ">= 20"
             }
         },
         "node_modules/@octokit/graphql": {
-            "version": "7.1.1",
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
+            "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@octokit/request": "^8.4.1",
-                "@octokit/types": "^13.0.0",
-                "universal-user-agent": "^6.0.0"
+                "@octokit/request": "^10.0.6",
+                "@octokit/types": "^16.0.0",
+                "universal-user-agent": "^7.0.0"
             },
             "engines": {
-                "node": ">= 18"
+                "node": ">= 20"
             }
         },
         "node_modules/@octokit/openapi-types": {
-            "version": "24.2.0",
+            "version": "27.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+            "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@octokit/plugin-paginate-rest": {
-            "version": "9.2.2",
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
+            "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@octokit/types": "^12.6.0"
+                "@octokit/types": "^16.0.0"
             },
             "engines": {
-                "node": ">= 18"
+                "node": ">= 20"
             },
             "peerDependencies": {
-                "@octokit/core": "5"
-            }
-        },
-        "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
-            "version": "20.0.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
-            "version": "12.6.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@octokit/openapi-types": "^20.0.0"
+                "@octokit/core": ">=6"
             }
         },
         "node_modules/@octokit/plugin-rest-endpoint-methods": {
-            "version": "10.4.1",
+            "version": "17.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
+            "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@octokit/types": "^12.6.0"
+                "@octokit/types": "^16.0.0"
             },
             "engines": {
-                "node": ">= 18"
+                "node": ">= 20"
             },
             "peerDependencies": {
-                "@octokit/core": "5"
-            }
-        },
-        "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/openapi-types": {
-            "version": "20.0.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
-            "version": "12.6.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@octokit/openapi-types": "^20.0.0"
+                "@octokit/core": ">=6"
             }
         },
         "node_modules/@octokit/request": {
-            "version": "8.4.1",
+            "version": "10.0.8",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.8.tgz",
+            "integrity": "sha512-SJZNwY9pur9Agf7l87ywFi14W+Hd9Jg6Ifivsd33+/bGUQIjNujdFiXII2/qSlN2ybqUHfp5xpekMEjIBTjlSw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@octokit/endpoint": "^9.0.6",
-                "@octokit/request-error": "^5.1.1",
-                "@octokit/types": "^13.1.0",
-                "universal-user-agent": "^6.0.0"
+                "@octokit/endpoint": "^11.0.3",
+                "@octokit/request-error": "^7.0.2",
+                "@octokit/types": "^16.0.0",
+                "fast-content-type-parse": "^3.0.0",
+                "json-with-bigint": "^3.5.3",
+                "universal-user-agent": "^7.0.2"
             },
             "engines": {
-                "node": ">= 18"
+                "node": ">= 20"
             }
         },
         "node_modules/@octokit/request-error": {
-            "version": "5.1.1",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
+            "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@octokit/types": "^13.1.0",
-                "deprecation": "^2.0.0",
-                "once": "^1.4.0"
+                "@octokit/types": "^16.0.0"
             },
             "engines": {
-                "node": ">= 18"
+                "node": ">= 20"
             }
         },
         "node_modules/@octokit/types": {
-            "version": "13.10.0",
+            "version": "16.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+            "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@octokit/openapi-types": "^24.2.0"
+                "@octokit/openapi-types": "^27.0.0"
             }
         },
         "node_modules/@open-draft/deferred-promise": {
@@ -7423,7 +7436,9 @@
             }
         },
         "node_modules/before-after-hook": {
-            "version": "2.2.3",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
+            "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
             "dev": true,
             "license": "Apache-2.0"
         },
@@ -8174,11 +8189,6 @@
             "engines": {
                 "node": ">= 0.8"
             }
-        },
-        "node_modules/deprecation": {
-            "version": "2.3.1",
-            "dev": true,
-            "license": "ISC"
         },
         "node_modules/dequal": {
             "version": "2.0.3",
@@ -9163,6 +9173,23 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/express"
             }
+        },
+        "node_modules/fast-content-type-parse": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
+            "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
@@ -10723,6 +10750,13 @@
         },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/json-with-bigint": {
+            "version": "3.5.8",
+            "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.8.tgz",
+            "integrity": "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==",
             "dev": true,
             "license": "MIT"
         },
@@ -14368,6 +14402,8 @@
         },
         "node_modules/tunnel": {
             "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+            "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -14571,14 +14607,13 @@
             }
         },
         "node_modules/undici": {
-            "version": "5.29.0",
+            "version": "6.25.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+            "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "@fastify/busboy": "^2.0.0"
-            },
             "engines": {
-                "node": ">=14.0"
+                "node": ">=18.17"
             }
         },
         "node_modules/undici-types": {
@@ -14597,7 +14632,9 @@
             }
         },
         "node_modules/universal-user-agent": {
-            "version": "6.0.1",
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+            "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
             "dev": true,
             "license": "ISC"
         },
@@ -14619,6 +14656,8 @@
         },
         "node_modules/unplugin": {
             "version": "1.16.1",
+            "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-1.16.1.tgz",
+            "integrity": "sha512-4/u/j4FrCKdi17jaxuJA0jClGxB1AvU2hw/IuayPc4ay1XGaJs/rbb4v5WKwAjNifjmXK9PIFyuPiaK8azyR9w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -14631,6 +14670,8 @@
         },
         "node_modules/unplugin/node_modules/acorn": {
             "version": "8.16.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+            "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -15129,6 +15170,8 @@
         },
         "node_modules/webpack-virtual-modules": {
             "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
+            "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
             "dev": true,
             "license": "MIT"
         },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -61,7 +61,7 @@
         "zod": "^4.3.6"
     },
     "devDependencies": {
-        "@codecov/webpack-plugin": "^1.9.1",
+        "@codecov/webpack-plugin": "^2.0.1",
         "@eslint/eslintrc": "^0.1.0",
         "@playwright/test": "^1.58.2",
         "@tailwindcss/postcss": "^4",


### PR DESCRIPTION
Bump @codecov/webpack-plugin 1.9.1 → 2.0.1. This pulls in updated @actions/* dependencies which use undici ^6 instead of the vulnerable undici ^5 chain.

Eliminates undici 5.29.0 (CVE-2025-XXXX / GHSA-...):
- Root undici: 5.29.0 → 6.25.0 (patched >= 6.24.0)
- jsdom undici: already 7.25.0 (patched)

Build verified locally with npm run build.
