### PR TITLE
fix(cms): add collapse-all button for expanded table rows

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -67,6 +67,7 @@ const nextConfig: NextConfig = {
     },
 
     // Production build
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     webpack(config: Configuration, options) {
         // Ensure module and rules exist on the config object
         if (!config.module || !config.module.rules) return config;

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -67,8 +67,7 @@ const nextConfig: NextConfig = {
     },
 
     // Production build
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    webpack(config: Configuration, options) {
+    webpack(config: Configuration) {
         // Ensure module and rules exist on the config object
         if (!config.module || !config.module.rules) return config;
 

--- a/frontend/src/app/[locale]/(cms)/cms/tables/data-table.tsx
+++ b/frontend/src/app/[locale]/(cms)/cms/tables/data-table.tsx
@@ -120,6 +120,8 @@ interface DataTableProps<TData, TValue> {
     compact?: boolean;
     rowSelection?: RowSelectionState;
     onRowSelectionChange?: OnChangeFn<RowSelectionState>;
+    expanded?: ExpandedState;
+    onExpandedChange?: OnChangeFn<ExpandedState>;
     getRowId?: (row: TData) => string;
     onRowClick?: (row: TData) => void;
 }
@@ -135,11 +137,16 @@ export function DataTable<TData, TValue>({
     compact = false,
     rowSelection,
     onRowSelectionChange,
+    expanded: expandedProp,
+    onExpandedChange: onExpandedChangeProp,
     getRowId,
     onRowClick,
 }: DataTableProps<TData, TValue>) {
     const t = useTranslations("Cms.DataTable");
-    const [expanded, setExpanded] = useState<ExpandedState>({});
+    const [expandedInternal, setExpandedInternal] = useState<ExpandedState>({});
+    const expanded = expandedProp !== undefined ? expandedProp : expandedInternal;
+    const onExpandedChange =
+        onExpandedChangeProp !== undefined ? onExpandedChangeProp : setExpandedInternal;
 
     // Support both renderSubComponent and renderSubRows for backwards compatibility
     const renderSubComponent = renderSubComponentProp ?? renderSubRows;
@@ -235,7 +242,7 @@ export function DataTable<TData, TValue>({
         ...(renderSubComponent && {
             getExpandedRowModel: getExpandedRowModel(),
             getRowCanExpand,
-            onExpandedChange: setExpanded,
+            onExpandedChange,
         }),
         ...(hasSelection && {
             onRowSelectionChange,

--- a/frontend/src/app/[locale]/(cms)/cms/tables/locations/locations-table.tsx
+++ b/frontend/src/app/[locale]/(cms)/cms/tables/locations/locations-table.tsx
@@ -2,8 +2,8 @@
 
 import { useCallback, useMemo, useState, useRef, useEffect } from "react";
 import { useTranslations } from "next-intl";
-import { Archive } from "lucide-react";
-import type { Row } from "@tanstack/react-table";
+import { Archive, ChevronsUp } from "lucide-react";
+import type { ExpandedState, Row } from "@tanstack/react-table";
 import { DataTable, MemoSubTable } from "../data-table";
 import { EditSheet } from "../edit-sheet";
 import { ActionBar } from "../action-bar";
@@ -11,6 +11,7 @@ import { useParentChildSelection } from "../use-parent-child-selection";
 import { makeLocationColumns, locationFields, toLocationUpdateInput } from "./columns";
 import { makeHallColumns, hallFields, toHallUpdateInput } from "./hall-columns";
 import { CollectionPickerDialog } from "@/components/cms/collection-picker-dialog";
+import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { useGetInfiniteLocations, useUpdateLocation } from "@/hooks/api/useLocations";
 import { useGetHalls, useUpdateHall } from "@/hooks/api/useHalls";
@@ -20,6 +21,7 @@ import type { Hall } from "@/types/models/hall.types";
 
 export function LocationsTable() {
     const t = useTranslations("Cms.Locations");
+    const tCommon = useTranslations("Cms.common");
     const tCollections = useTranslations("Cms.Collections");
     const tActions = useTranslations("Cms.ActionsColumn");
     const loadMoreRef = useRef<HTMLDivElement>(null);
@@ -67,6 +69,7 @@ export function LocationsTable() {
     const [editLocation, setEditLocation] = useState<LocationRow | null>(null);
     const [editHall, setEditHall] = useState<Hall | null>(null);
     const [collectionDialogOpen, setCollectionDialogOpen] = useState(false);
+    const [expanded, setExpanded] = useState<ExpandedState>({});
 
     const hallsByLocation = useMemo(() => {
         const spaceToLocation = new Map<string, string>();
@@ -156,6 +159,9 @@ export function LocationsTable() {
         [childSelection, getChildHandler, getHallRowId, hallCols, hallsByLocation, hallsLoading]
     );
 
+    const hasExpanded = Object.keys(expanded).length > 0;
+    const collapseAll = useCallback(() => setExpanded({}), []);
+
     const actions = useMemo(
         () => [
             {
@@ -174,7 +180,7 @@ export function LocationsTable() {
 
     return (
         <div className="flex h-full flex-col">
-            <div className="bg-background sticky top-0 z-10">
+            <div className="bg-background sticky top-0 z-10 flex items-center justify-between gap-2">
                 <ActionBar
                     entityCounts={[
                         { countKey: "locationsSelected", count: selectedLocationCount },
@@ -183,6 +189,17 @@ export function LocationsTable() {
                     actions={actions}
                     onClear={clearSelection}
                 />
+                {hasExpanded && (
+                    <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={collapseAll}
+                        className="text-muted-foreground hover:text-foreground shrink-0 cursor-pointer rounded-none font-mono text-[10px] tracking-[1.5px] uppercase"
+                    >
+                        <ChevronsUp className="mr-1 h-3.5 w-3.5" />
+                        {tCommon("collapseAll")}
+                    </Button>
+                )}
             </div>
             <div className="flex-1 overflow-auto">
                 <DataTable
@@ -193,6 +210,8 @@ export function LocationsTable() {
                     expanderLabels={expanderLabels}
                     rowSelection={parentSelection}
                     onRowSelectionChange={setParentSelection}
+                    expanded={expanded}
+                    onExpandedChange={setExpanded}
                     getRowId={getLocationRowId}
                 />
 

--- a/frontend/src/app/[locale]/(cms)/cms/tables/productions/productions-table.tsx
+++ b/frontend/src/app/[locale]/(cms)/cms/tables/productions/productions-table.tsx
@@ -2,8 +2,8 @@
 
 import { useCallback, useMemo, useState, useRef, useEffect } from "react";
 import { useLocale, useTranslations } from "next-intl";
-import { Archive } from "lucide-react";
-import type { Row } from "@tanstack/react-table";
+import { Archive, ChevronsUp } from "lucide-react";
+import type { ExpandedState, Row } from "@tanstack/react-table";
 import { DataTable, MemoSubTable } from "../data-table";
 import { EditSheet } from "../edit-sheet";
 import { makeProductionColumns } from "./columns";
@@ -11,6 +11,7 @@ import { makeEventFields, toEventUpdateInput } from "./event-columns";
 import { ActionBar } from "../action-bar";
 import { useParentChildSelection } from "../use-parent-child-selection";
 import { makeEventColumns } from "./event-columns";
+import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { useGetInfiniteProductions } from "@/hooks/api/useProductions";
 import { useGetEvents, useUpdateEvent } from "@/hooks/api/useEvents";
@@ -23,6 +24,7 @@ import type { Event } from "@/types/models/event.types";
 
 export function ProductionsTable() {
     const t = useTranslations("Cms.Productions");
+    const tCommon = useTranslations("Cms.common");
     const tCollections = useTranslations("Cms.Collections");
     const tActions = useTranslations("Cms.ActionsColumn");
     const locale = useLocale();
@@ -72,6 +74,7 @@ export function ProductionsTable() {
     const [collectionDialogOpen, setCollectionDialogOpen] = useState(false);
     const [mediaProduction, setMediaProduction] = useState<Production | null>(null);
     const [spotlight, setSpotlight] = useState<{ src: string; alt: string } | null>(null);
+    const [expanded, setExpanded] = useState<ExpandedState>({});
     const openSpotlight = useCallback((src: string, alt: string) => setSpotlight({ src, alt }), []);
     const spotlightItems: SpotlightItem[] = spotlight
         ? [{ kind: "plain", src: spotlight.src, alt: spotlight.alt }]
@@ -204,6 +207,9 @@ export function ProductionsTable() {
         ]
     );
 
+    const hasExpanded = Object.keys(expanded).length > 0;
+    const collapseAll = useCallback(() => setExpanded({}), []);
+
     const actions = useMemo(
         () => [
             {
@@ -222,7 +228,7 @@ export function ProductionsTable() {
 
     return (
         <div className="flex h-full flex-col">
-            <div className="bg-background sticky top-0 z-10">
+            <div className="bg-background sticky top-0 z-10 flex items-center justify-between gap-2">
                 <ActionBar
                     entityCounts={[
                         { countKey: "productionsSelected", count: selectedProductionCount },
@@ -231,6 +237,17 @@ export function ProductionsTable() {
                     actions={actions}
                     onClear={clearSelection}
                 />
+                {hasExpanded && (
+                    <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={collapseAll}
+                        className="text-muted-foreground hover:text-foreground shrink-0 cursor-pointer rounded-none font-mono text-[10px] tracking-[1.5px] uppercase"
+                    >
+                        <ChevronsUp className="mr-1 h-3.5 w-3.5" />
+                        {tCommon("collapseAll")}
+                    </Button>
+                )}
             </div>
 
             <div className="flex-1 overflow-auto">
@@ -242,6 +259,8 @@ export function ProductionsTable() {
                     rowSelection={parentSelection}
                     onRowSelectionChange={setParentSelection}
                     expanderLabels={expanderLabels}
+                    expanded={expanded}
+                    onExpandedChange={setExpanded}
                     getRowId={getProductionRowId}
                 />
 

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -237,6 +237,9 @@
             "locations": "Locations",
             "performers": "Performers"
         },
+        "common": {
+            "collapseAll": "Collapse all"
+        },
         "DataTable": {
             "noResults": "No results."
         },

--- a/frontend/src/messages/nl.json
+++ b/frontend/src/messages/nl.json
@@ -237,6 +237,9 @@
             "locations": "Locaties",
             "performers": "Uitvoerders"
         },
+        "common": {
+            "collapseAll": "Alles inklappen"
+        },
         "DataTable": {
             "noResults": "Geen resultaten."
         },


### PR DESCRIPTION
- DataTable now accepts optional expanded/onExpandedChange props for controlled expansion state (backwards compatible)
- ProductionsTable and LocationsTable lift expanded state and render a 'Collapse all' button when rows are expanded
- Added translations for en and nl

<img width="1795" height="328" alt="image" src="https://github.com/user-attachments/assets/e10c1cab-9b70-4c1d-aee6-f5b45a8fc687" />
