### PR TITLE
feat(cms): improved style and UX of collection picker dialog

### DIFF
--- a/frontend/src/components/cms/collection-picker-dialog.tsx
+++ b/frontend/src/components/cms/collection-picker-dialog.tsx
@@ -142,7 +142,7 @@ export function CollectionPickerDialog({
                         {showCreate && (
                             <button
                                 type="button"
-                                className="text-muted-foreground hover:bg-muted block w-full cursor-pointer px-2 py-1 text-left text-sm"
+                                className="text-muted-foreground hover:bg-foreground/10 block w-full cursor-pointer px-2 py-1 text-left text-sm"
                                 onClick={createNewCollection}
                             >
                                 + {t("createNamed", { name: query.trim() })}
@@ -152,10 +152,10 @@ export function CollectionPickerDialog({
                             <button
                                 key={collection.id}
                                 type="button"
-                                className={`block w-full cursor-pointer px-2 py-1 text-left text-sm ${
+                                className={`text-muted-foreground block w-full cursor-pointer px-2 py-1 text-left text-sm ${
                                     selectedCollectionId === collection.id
-                                        ? "bg-muted"
-                                        : "hover:bg-muted"
+                                        ? "bg-foreground/10"
+                                        : "hover:bg-foreground/10"
                                 }`}
                                 onClick={() => setSelectedCollectionId(collection.id)}
                             >

--- a/frontend/src/components/cms/collection-picker-dialog.tsx
+++ b/frontend/src/components/cms/collection-picker-dialog.tsx
@@ -142,7 +142,7 @@ export function CollectionPickerDialog({
                         {showCreate && (
                             <button
                                 type="button"
-                                className="text-muted-foreground hover:bg-muted block w-full px-2 py-1 text-left text-sm"
+                                className="text-muted-foreground hover:bg-muted block w-full cursor-pointer px-2 py-1 text-left text-sm"
                                 onClick={createNewCollection}
                             >
                                 + {t("createNamed", { name: query.trim() })}
@@ -152,7 +152,7 @@ export function CollectionPickerDialog({
                             <button
                                 key={collection.id}
                                 type="button"
-                                className={`block w-full px-2 py-1 text-left text-sm ${
+                                className={`block w-full cursor-pointer px-2 py-1 text-left text-sm ${
                                     selectedCollectionId === collection.id
                                         ? "bg-muted"
                                         : "hover:bg-muted"

--- a/frontend/src/components/cms/collection-picker-dialog.tsx
+++ b/frontend/src/components/cms/collection-picker-dialog.tsx
@@ -51,13 +51,18 @@ export function CollectionPickerDialog({
 
     const [query, setQuery] = useState("");
     const [selectedCollectionId, setSelectedCollectionId] = useState<string | null>(null);
-    const [newCollectionTitle, setNewCollectionTitle] = useState("");
 
     const filteredCollections = useMemo(() => {
         const q = query.trim().toLowerCase();
         if (!q) return collections;
         return collections.filter((c) => getCollectionTitle(c).toLowerCase().includes(q));
     }, [collections, query]);
+
+    const showCreate =
+        query.trim().length > 0 &&
+        !collections.some(
+            (c) => getCollectionTitle(c).toLowerCase() === query.trim().toLowerCase()
+        );
 
     const selectedCollection = collections.find((c) => c.id === selectedCollectionId) ?? null;
 
@@ -92,7 +97,7 @@ export function CollectionPickerDialog({
     };
 
     const createNewCollection = async () => {
-        const title = newCollectionTitle.trim();
+        const title = query.trim();
         if (!title) return;
 
         const slug = slugify(title);
@@ -107,7 +112,7 @@ export function CollectionPickerDialog({
         });
 
         setSelectedCollectionId(created.id);
-        setNewCollectionTitle("");
+        setQuery("");
     };
 
     return (
@@ -131,13 +136,23 @@ export function CollectionPickerDialog({
                         placeholder={t("searchCollections")}
                         value={query}
                         onChange={(event) => setQuery(event.target.value)}
+                        className="border-foreground/20 h-9 rounded-none text-sm focus-visible:ring-0"
                     />
-                    <div className="max-h-56 space-y-1 overflow-auto rounded border p-2">
+                    <div className="max-h-56 min-h-56 space-y-1 overflow-auto border p-2">
+                        {showCreate && (
+                            <button
+                                type="button"
+                                className="text-muted-foreground hover:bg-muted block w-full px-2 py-1 text-left text-sm"
+                                onClick={createNewCollection}
+                            >
+                                + {t("createNamed", { name: query.trim() })}
+                            </button>
+                        )}
                         {filteredCollections.map((collection) => (
                             <button
                                 key={collection.id}
                                 type="button"
-                                className={`block w-full rounded px-2 py-1 text-left text-sm ${
+                                className={`block w-full px-2 py-1 text-left text-sm ${
                                     selectedCollectionId === collection.id
                                         ? "bg-muted"
                                         : "hover:bg-muted"
@@ -148,38 +163,24 @@ export function CollectionPickerDialog({
                             </button>
                         ))}
                     </div>
-                    <div className="space-y-2 border-t pt-2">
-                        <Input
-                            placeholder={t("createNewCollection")}
-                            value={newCollectionTitle}
-                            onChange={(event) => setNewCollectionTitle(event.target.value)}
-                        />
-                        <Button
-                            type="button"
-                            variant="outline"
-                            onClick={createNewCollection}
-                            disabled={!newCollectionTitle.trim()}
-                        >
-                            {t("createNewCollection")}
-                        </Button>
-                    </div>
                 </div>
                 <DialogFooter>
-                    <Button type="button" variant="outline" onClick={() => setResolvedOpen(false)}>
+                    <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setResolvedOpen(false)}
+                        className="cursor-pointer rounded-none font-mono text-[10px] tracking-[1.5px] uppercase"
+                    >
                         {t("cancel")}
                     </Button>
                     <Button
                         type="button"
                         variant="outline"
-                        onClick={() => addToCollection(true)}
-                        disabled={!selectedCollectionId}
-                    >
-                        {t("addAndOpen")}
-                    </Button>
-                    <Button
-                        type="button"
+                        size="sm"
                         onClick={() => addToCollection(false)}
                         disabled={!selectedCollectionId}
+                        className="cursor-pointer rounded-none font-mono text-[10px] tracking-[1.5px] uppercase"
                     >
                         {t("addToCollection")}
                     </Button>

--- a/frontend/src/components/cms/collection-picker-dialog.tsx
+++ b/frontend/src/components/cms/collection-picker-dialog.tsx
@@ -142,7 +142,7 @@ export function CollectionPickerDialog({
                         {showCreate && (
                             <button
                                 type="button"
-                                className="text-muted-foreground hover:bg-foreground/10 block w-full cursor-pointer px-2 py-1 text-left text-sm"
+                                className="text-muted-foreground hover:bg-muted hover:text-background block w-full cursor-pointer px-2 py-1 text-left text-sm"
                                 onClick={createNewCollection}
                             >
                                 + {t("createNamed", { name: query.trim() })}
@@ -154,8 +154,8 @@ export function CollectionPickerDialog({
                                 type="button"
                                 className={`text-muted-foreground block w-full cursor-pointer px-2 py-1 text-left text-sm ${
                                     selectedCollectionId === collection.id
-                                        ? "bg-foreground/10"
-                                        : "hover:bg-foreground/10"
+                                        ? "bg-muted text-background"
+                                        : "hover:bg-muted hover:text-background"
                                 }`}
                                 onClick={() => setSelectedCollectionId(collection.id)}
                             >

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -50,7 +50,7 @@ function DialogContent({
             <DialogPrimitive.Content
                 data-slot="dialog-content"
                 className={cn(
-                    "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg",
+                    "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] grid-cols-1 gap-4 border p-6 shadow-lg",
                     className
                 )}
                 {...props}

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -29,10 +29,7 @@ function DialogOverlay({
     return (
         <DialogPrimitive.Overlay
             data-slot="dialog-overlay"
-            className={cn(
-                "data-[state=open]:animate-in data-[state=closed]:animate-out fixed inset-0 z-50 bg-black/50",
-                className
-            )}
+            className={cn("fixed inset-0 z-50 bg-black/50", className)}
             {...props}
         />
     );
@@ -50,7 +47,7 @@ function DialogContent({
             <DialogPrimitive.Content
                 data-slot="dialog-content"
                 className={cn(
-                    "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] grid-cols-1 gap-4 border p-6 shadow-lg",
+                    "bg-background fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] grid-cols-1 gap-4 border p-6 shadow-lg",
                     className
                 )}
                 {...props}

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -57,7 +57,7 @@ function DialogContent({
             >
                 {children}
                 {showClose && (
-                    <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-none disabled:pointer-events-none">
+                    <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 cursor-pointer rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-none disabled:pointer-events-none">
                         <X className="size-4" />
                         <span className="sr-only">Close</span>
                     </DialogPrimitive.Close>

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -477,6 +477,7 @@
             "addToCollection": "Add to collection",
             "addAndOpen": "Add and open collection",
             "createNewCollection": "Create new collection",
+            "createNamed": "Create ''{name}''",
             "searchCollections": "Search collections…",
             "selectedItems": "{count, plural, one {# selected item} other {# selected items}}",
             "alreadyInCollection": "{title} is already in this collection",

--- a/frontend/src/messages/nl.json
+++ b/frontend/src/messages/nl.json
@@ -477,6 +477,7 @@
             "addToCollection": "Toevoegen aan collectie",
             "addAndOpen": "Toevoegen en collectie openen",
             "createNewCollection": "Nieuwe collectie maken",
+            "createNamed": "Maak ''{name}'' aan",
             "searchCollections": "Collecties zoeken…",
             "selectedItems": "{count, plural, one {# geselecteerd item} other {# geselecteerde items}}",
             "alreadyInCollection": "{title} zit al in deze collectie",


### PR DESCRIPTION
Reworks the collection picker dialog's style and UX.

- Search-to-create: the search input now doubles as a new collection name: typing a query with no exact match shows a "+ Maak 'X' aan" row at the top of the list; clicking it creates and selects the collection. The separate create input/button section is removed.
- Buttons restyled to match the action bar (monospaced, uppercase, square, `sm` size); "Add and open" button removed.
- Inputs and list container are square (no border-radius); focus ring removed from inputs.
- List box has a fixed height (`min-h-56 max-h-56`) to prevent layout shift while filtering.
- `DialogContent` gets `grid-cols-1` to prevent content overflow on narrow viewports.
- Open/close animations removed from `DialogContent` and `DialogOverlay` to fix a pixel-shift glitch on close.
- `cursor-pointer` added to close button and collection list rows.

---

<img width="856" height="630" alt="image" src="https://github.com/user-attachments/assets/fb1e243c-807a-4d49-b680-c316b33cfc4b" />

<img width="856" height="630" alt="image" src="https://github.com/user-attachments/assets/2f1b406d-0b79-4bb5-9929-28866938c697" />


