### PR TITLE
fix: rotate cache and don't put in ram backed tmp

### DIFF
--- a/.github/workflows/build-push-deploy.yml
+++ b/.github/workflows/build-push-deploy.yml
@@ -46,8 +46,8 @@ jobs:
         with:
           context: ./backend
           push: true
-          cache-from: type=local,src=/tmp/.buildx-cache/backend
-          cache-to: type=local,dest=/tmp/.buildx-cache/backend,mode=max
+          cache-from: type=local,src=/home/server/.buildx-cache/backend
+          cache-to: type=local,dest=/home/server/.buildx-cache-new/backend,mode=max
           tags: |
             kayasem/${{ vars.PROJECT_NAME }}-backend:latest
             kayasem/${{ vars.PROJECT_NAME }}-backend:${{ github.sha }}
@@ -57,8 +57,8 @@ jobs:
         with:
           context: ./frontend
           push: true
-          cache-from: type=local,src=/tmp/.buildx-cache/frontend
-          cache-to: type=local,dest=/tmp/.buildx-cache/frontend,mode=max
+          cache-from: type=local,src=/home/server/.buildx-cache/frontend
+          cache-to: type=local,dest=/home/server/.buildx-cache-new/frontend,mode=max
           build-args: |
             "NEXT_PUBLIC_SITE_URL=${{ vars.NEXT_PUBLIC_SITE_URL }}"
             "NEXT_PUBLIC_API_URL=${{ vars.NEXT_PUBLIC_SITE_URL }}/api"
@@ -78,11 +78,16 @@ jobs:
         with:
           context: ./docs
           push: true
-          cache-from: type=local,src=/tmp/.buildx-cache/docs
-          cache-to: type=local,dest=/tmp/.buildx-cache/docs,mode=max
+          cache-from: type=local,src=/home/server/.buildx-cache/docs
+          cache-to: type=local,dest=/home/server/.buildx-cache-new/docs,mode=max
           tags: |
             kayasem/${{ vars.PROJECT_NAME }}-docs:latest
             kayasem/${{ vars.PROJECT_NAME }}-docs:${{ github.sha }}
+
+      - name: Rotate build cache
+        run: |
+          rm -rf /home/server/.buildx-cache
+          mv /home/server/.buildx-cache-new /home/server/.buildx-cache
 
   deploy:
     runs-on: prod


### PR DESCRIPTION
Buildx cache was writing to \`/tmp/.buildx-cache\` on the self-hosted runner, a RAM-backed tmpfs that filled up to 16 GB and broke CI. Moves the cache to \`/home/server/.buildx-cache\` on disk and adds a rotation step: each build writes to \`.buildx-cache-new\`, which replaces the old cache after all images are built, preventing unbounded growth across runs.

**How Has This Been Tested?**
- [ ] Local manual testing
- [ ] Added/updated unit or integration tests
- [ ] Tested in the staging environment

**Developer Checklist:**
- [ ] I have performed a self-review of my own code.
- [ ] I have left comments in hard-to-understand areas of my code.
- [ ] My changes generate no new warnings or console errors.
- [ ] I have updated the documentation (if applicable).

**Screenshots / Video (if UI/UX changed):**