### PR TITLE
feat(cicd): remove test dependency for preview

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -1,4 +1,4 @@
-name: Backend Tests
+name: Backend tests
 
 on:
   workflow_call:

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -1,9 +1,13 @@
 name: Backend Tests
 
-on: workflow_call
+on:
+  workflow_call:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   test:
+    if: github.event.pull_request.draft == false
     runs-on: kaya-sem-house
     container:
       image: rust:1.94-bookworm

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: kaya-sem-house
     container:
       image: rust:1.94-bookworm
+      options: -v /cache/cargo-registry:/root/.cargo/registry -v /cache/cargo-git:/root/.cargo/git -v /cache/cargo-bin:/root/.cargo/bin -v /cache/backend-target:/backend/target
       env:
         DATABASE_URL: postgres://test:test@postgres:5432/test
         ALLOWED_ORIGINS: "http://localhost:3000"
@@ -46,19 +47,8 @@ jobs:
       - name: Install dependencies
         run: apt-get update && apt-get install -y pkg-config libssl-dev postgresql-client
 
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: backend
-
-      - name: Cache cargo binaries
-        uses: actions/cache@v4
-        with:
-          path: ~/.cargo/bin
-          key: cargo-bin-sqlx-0.8
-
       - name: Install sqlx-cli
-        run: command -v sqlx || cargo install sqlx-cli --no-default-features --features native-tls,postgres
+        run: cargo install sqlx-cli --no-default-features --features native-tls,postgres
 
       - name: Run migrations
         run: cd backend && sqlx migrate run

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -15,18 +15,6 @@ permissions:
   issues: write
 
 jobs:
-  run_backend_tests:
-    name: Backend tests
-    if: github.event.action != 'closed'
-    uses: ./.github/workflows/backend-tests.yml
-    secrets: inherit
-
-  run_frontend_tests:
-    name: Frontend tests
-    if: github.event.action != 'closed'
-    uses: ./.github/workflows/frontend-tests.yml
-    secrets: inherit
-
   preview:
     if: >-
       github.event.action != 'closed' &&
@@ -34,7 +22,6 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'preview')
     runs-on: kaya-sem-house
     environment: preview
-    needs: [run_backend_tests, run_frontend_tests]
 
     steps:
       # We should not edit perms of this, if this breaks SSH into server and delete manually and let actions rebuild

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -1,9 +1,13 @@
 name: Frontend Tests
 
-on: workflow_call
+on:
+  workflow_call:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   test:
+    if: github.event.pull_request.draft == false
     runs-on: kaya-sem-house
     container:
       image: mcr.microsoft.com/playwright:v1.59.1-jammy

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: kaya-sem-house
     container:
       image: mcr.microsoft.com/playwright:v1.59.1-jammy
+      options: -v /cache/npm:/github/home/.npm -v /cache/playwright:/root/.cache/ms-playwright
     steps:
       - name: Clean up workspace
         run: |
@@ -24,19 +25,11 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: "npm"
-          cache-dependency-path: frontend/package-lock.json
 
       - name: Install dependencies
         run: |
           cd frontend
           npm ci
-
-      - name: Cache Playwright browsers
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ hashFiles('frontend/package-lock.json') }}
 
       - name: Install Playwright browsers
         run: cd frontend && npx playwright install --with-deps chromium

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -1,4 +1,4 @@
-name: Frontend Tests
+name: Frontend tests
 
 on:
   workflow_call:


### PR DESCRIPTION
Decouples preview deploys from the test suite and speeds up CI on the self-hosted runner.

- Preview deploy no longer waits for tests to pass; the `preview` job runs as soon as the `preview` label is applied
- Test workflows now trigger directly on `pull_request` (opened, synchronize, reopened, ready_for_review), skipping draft PRs
- Workflow names lowercased to match existing branch protection required check names, avoiding duplicate check entries
- GitHub's remote cache service replaced with host-mounted volumes for both frontend (npm, Playwright browsers) and backend (cargo registry, git, bin, target), eliminating slow remote cache downloads on the self-hosted runner

**Related Issue**
Fixes #

**How Has This Been Tested?**
- [ ] Local manual testing
- [ ] Added/updated unit or integration tests
- [ ] Tested in the staging environment

**Developer Checklist:**
- [ ] I have performed a self-review of my own code.
- [ ] I have left comments in hard-to-understand areas of my code.
- [ ] My changes generate no new warnings or console errors.
- [ ] I have updated the documentation (if applicable).

**Screenshots / Video (if UI/UX changed):**