### PR TITLE
feat(frontend): improved homepage

### DIFF
--- a/frontend/src/app/[locale]/(app)/(with-footer)/page.tsx
+++ b/frontend/src/app/[locale]/(app)/(with-footer)/page.tsx
@@ -6,10 +6,12 @@ import { useRouter } from "@/i18n/routing";
 import Link from "next/link";
 
 import { useGetProductions } from "@/hooks/api/useProductions";
+import { useGetArticles } from "@/hooks/api/useArticles";
 
 import { UnifiedHeader } from "@/components/layout/header";
 import { SearchBar } from "@/components/homepage/search-bar";
 import { FeaturedSection } from "@/components/homepage/featured-section";
+import { ArticlesSection } from "@/components/homepage/articles-section";
 import { ProductionItem } from "@/components/searchpage/production-list";
 
 export default function HomePage() {
@@ -47,6 +49,9 @@ export default function HomePage() {
     const featuredProductions = productions.slice(0, 3);
     const latestProductions = productions.slice(3, 7);
 
+    const { data: articles } = useGetArticles();
+    const publishedArticles = (articles ?? []).filter((a) => a.status === "published");
+
     return (
         <>
             <UnifiedHeader
@@ -67,18 +72,6 @@ export default function HomePage() {
                 </p>
 
                 <SearchBar onSearch={handleHeroSearch} placeholder={t("hero.searchPlaceholder")} />
-
-                <div className="flex flex-wrap items-center justify-center gap-2 sm:gap-3">
-                    {["theater", "dance", "concert", "nightlife"].map((tag) => (
-                        <Link
-                            key={tag}
-                            href={`/search?q=${t(`tags.${tag}`)}`}
-                            className="border-border text-muted-foreground hover:border-foreground hover:text-foreground border px-3 py-1.5 font-mono text-[9px] tracking-[1.1px] uppercase transition-all sm:text-[10px]"
-                        >
-                            {t(`tags.${tag}`)}
-                        </Link>
-                    ))}
-                </div>
             </section>
 
             {/* Featured */}
@@ -86,9 +79,14 @@ export default function HomePage() {
                 <FeaturedSection productions={featuredProductions} locale={locale} />
             </section>
 
+            {/* Articles */}
+            <section className="px-4 pt-10 sm:px-[30px] sm:pt-14">
+                <ArticlesSection articles={publishedArticles} />
+            </section>
+
             {/* Latest productions */}
             {latestProductions.length > 0 && (
-                <section className="border-muted/30 border-t px-4 py-10 sm:px-[30px] sm:py-14">
+                <section className="px-4 py-10 sm:px-[30px] sm:py-14">
                     <div className="mb-6 flex items-baseline justify-between">
                         <h3 className="font-display text-foreground text-[20px] font-bold tracking-[-0.02em] sm:text-[24px]">
                             {t("latest.label")}

--- a/frontend/src/app/[locale]/(app)/(with-footer)/page.tsx
+++ b/frontend/src/app/[locale]/(app)/(with-footer)/page.tsx
@@ -50,7 +50,6 @@ export default function HomePage() {
     const latestProductions = productions.slice(3, 7);
 
     const { data: articles } = useGetArticles();
-    const publishedArticles = (articles ?? []).filter((a) => a.status === "published");
 
     return (
         <>
@@ -78,7 +77,7 @@ export default function HomePage() {
             </section>
 
             <section className="px-4 pt-10 sm:px-[30px] sm:pt-14">
-                <ArticlesSection articles={publishedArticles} />
+                <ArticlesSection articles={articles ?? []} />
             </section>
 
             {latestProductions.length > 0 && (

--- a/frontend/src/app/[locale]/(app)/(with-footer)/page.tsx
+++ b/frontend/src/app/[locale]/(app)/(with-footer)/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useCallback, useState } from "react";
 import { useLocale, useTranslations } from "next-intl";
 import { useRouter } from "@/i18n/routing";
 import Link from "next/link";
@@ -62,7 +62,6 @@ export default function HomePage() {
                 searchHint={tSearch("hint")}
             />
 
-            {/* Hero */}
             <section className="flex flex-col items-center gap-6 px-4 py-16 text-center sm:px-10 sm:py-24">
                 <h1 className="font-display text-foreground text-[40px] leading-[1.05] font-bold tracking-[-0.03em] sm:text-[64px] md:text-[72px]">
                     {t("hero.title")}
@@ -74,17 +73,14 @@ export default function HomePage() {
                 <SearchBar onSearch={handleHeroSearch} placeholder={t("hero.searchPlaceholder")} />
             </section>
 
-            {/* Featured */}
             <section className="px-4 pt-8 sm:px-[30px] sm:pt-12">
                 <FeaturedSection productions={featuredProductions} locale={locale} />
             </section>
 
-            {/* Articles */}
             <section className="px-4 pt-10 sm:px-[30px] sm:pt-14">
                 <ArticlesSection articles={publishedArticles} />
             </section>
 
-            {/* Latest productions */}
             {latestProductions.length > 0 && (
                 <section className="px-4 py-10 sm:px-[30px] sm:py-14">
                     <div className="mb-6 flex items-baseline justify-between">
@@ -110,7 +106,6 @@ export default function HomePage() {
                 </section>
             )}
 
-            {/* About */}
             <section className="border-foreground/10 flex flex-col items-center gap-5 border-t px-4 py-14 text-center sm:px-10 sm:py-20">
                 <h3 className="font-display text-foreground text-[24px] leading-tight font-bold tracking-[-0.02em] sm:text-[32px]">
                     {t("about.title")}

--- a/frontend/src/components/homepage/articles-section/ArticlesSection.tsx
+++ b/frontend/src/components/homepage/articles-section/ArticlesSection.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import Image from "next/image";
+import { useLocale, useTranslations } from "next-intl";
+import { Link } from "@/i18n/routing";
+
+import type { ArticleListItem } from "@/types/models/article.types";
+
+interface ArticlesSectionProps {
+    articles: ArticleListItem[];
+}
+
+export function ArticlesSection({ articles }: ArticlesSectionProps) {
+    const t = useTranslations("Home");
+    const locale = useLocale();
+
+    const items = articles.slice(0, 3);
+
+    return (
+        <div>
+            <div className="text-muted-foreground mb-3 flex items-center gap-2.5 font-mono text-[9px] font-medium tracking-[2px] uppercase">
+                {t("articles.label")}
+                <span className="bg-muted/40 h-px flex-1" />
+                <Link href="/articles" className="hover:text-foreground transition-colors">
+                    {t("articles.viewAll")} →
+                </Link>
+            </div>
+
+            <div className="bg-muted -mx-4 grid grid-cols-1 gap-px sm:-mx-[30px] sm:grid-cols-3">
+                {items.map((article) => (
+                    <ArticleCard key={article.id} article={article} locale={locale} />
+                ))}
+            </div>
+        </div>
+    );
+}
+
+function formatDate(dateStr: string | null, locale: string): string | null {
+    if (!dateStr) return null;
+    return new Date(dateStr).toLocaleDateString(locale === "en" ? "en-GB" : "nl-BE", {
+        day: "numeric",
+        month: "long",
+        year: "numeric",
+    });
+}
+
+function ArticleCard({ article, locale }: { article: ArticleListItem; locale: string }) {
+    const date = formatDate(article.publishedAt, locale);
+
+    return (
+        <Link
+            href={`/articles/${article.slug}`}
+            className="group bg-background hover:bg-muted/5 block p-4 pb-5 transition-colors sm:p-5"
+        >
+            <div className="relative mb-3 h-[120px] w-full overflow-hidden bg-[#CCC6BC]">
+                {article.coverImageUrl ? (
+                    <Image
+                        src={article.coverImageUrl}
+                        alt={article.title ?? ""}
+                        fill
+                        className="object-cover"
+                        sizes="(min-width: 640px) 33vw, 100vw"
+                    />
+                ) : (
+                    <div className="h-full w-full bg-gradient-to-br from-[#CCC6BC] to-[#B5AEA4]" />
+                )}
+            </div>
+
+            {date && (
+                <div className="text-muted-foreground group-hover:text-foreground mb-1.5 font-mono text-[9px] tracking-[1.4px] uppercase transition-colors">
+                    {date}
+                </div>
+            )}
+
+            <div className="font-display text-foreground text-[18px] leading-[1.2] font-bold tracking-[-0.02em] sm:text-[20px]">
+                {article.title ?? "–"}
+            </div>
+        </Link>
+    );
+}

--- a/frontend/src/components/homepage/articles-section/index.ts
+++ b/frontend/src/components/homepage/articles-section/index.ts
@@ -1,0 +1,1 @@
+export * from "./ArticlesSection";

--- a/frontend/src/components/homepage/featured-section/FeaturedSection.tsx
+++ b/frontend/src/components/homepage/featured-section/FeaturedSection.tsx
@@ -27,7 +27,7 @@ export function FeaturedSection({ productions, locale }: FeaturedSectionProps) {
                 <span className="bg-muted/40 h-px flex-1" />
             </div>
 
-            <div className="bg-muted border-foreground -mx-4 grid grid-cols-1 gap-px border-x border-b-2 sm:-mx-[30px] sm:grid-cols-[1.6fr_1fr_1fr]">
+            <div className="bg-muted border-foreground -mx-4 grid grid-cols-1 gap-px sm:-mx-[30px] sm:grid-cols-[1.6fr_1fr_1fr]">
                 {featured.map((production, index) => (
                     <FeaturedCard
                         key={production.id}
@@ -61,7 +61,7 @@ function FeaturedCard({
             className="group bg-background hover:bg-muted/5 relative block cursor-pointer p-4 pb-5 transition-colors sm:p-5"
         >
             <div
-                className={`relative mb-3 h-[160px] w-full overflow-hidden bg-[#CCC6BC] ${isFirst ? "sm:h-[200px]" : "sm:h-[140px]"}`}
+                className={`relative mb-3 w-full overflow-hidden bg-[#CCC6BC] ${isFirst ? "h-[180px] sm:h-[260px]" : "h-[140px] sm:h-[170px]"}`}
             >
                 {production.coverImageUrl ? (
                     <Image
@@ -87,25 +87,23 @@ function FeaturedCard({
             )}
 
             <div
-                className={`font-display text-foreground mb-0.5 leading-[1.15] font-bold tracking-[-0.02em] ${
-                    isFirst ? "text-[24px] sm:text-[30px]" : "text-[20px] sm:text-[22px]"
+                className={`font-display text-foreground leading-[1.1] font-bold tracking-[-0.02em] ${
+                    isFirst ? "text-[26px] sm:text-[34px]" : "text-[19px] sm:text-[21px]"
                 }`}
             >
                 {title}
             </div>
 
             {artist && (
-                <div
-                    className={`font-display text-foreground/40 mb-2.5 font-bold ${
-                        isFirst ? "text-[24px] sm:text-[30px]" : "text-[20px] sm:text-[22px]"
-                    }`}
-                >
+                <div className="font-body text-muted-foreground mt-1.5 mb-2 text-xs italic">
                     {artist}
                 </div>
             )}
 
             {tagline && (
-                <p className="font-body text-muted-foreground group-hover:text-foreground text-xs leading-relaxed transition-colors">
+                <p
+                    className={`font-body text-foreground/70 group-hover:text-foreground border-muted/30 border-t pt-2.5 leading-snug transition-colors ${isFirst ? "text-sm" : "text-xs"}`}
+                >
                     {tagline}
                 </p>
             )}

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -153,6 +153,10 @@
             "concert": "Concert",
             "nightlife": "Nightlife"
         },
+        "articles": {
+            "label": "From the editors",
+            "viewAll": "All articles"
+        },
         "about": {
             "title": "Arts Centre VIERNULVIER",
             "text": "Since 1883, De Vooruit has been a breeding ground for art, culture and society. From revolutionary parties to contemporary performance. The archive preserves it all."

--- a/frontend/src/messages/nl.json
+++ b/frontend/src/messages/nl.json
@@ -153,6 +153,10 @@
             "concert": "Concert",
             "nightlife": "Nightlife"
         },
+        "articles": {
+            "label": "Van de redactie",
+            "viewAll": "Alle artikels"
+        },
         "about": {
             "title": "Kunstencentrum VIERNULVIER",
             "text": "Sinds 1883 is De Vooruit een broedplaats voor kunst, cultuur en samenleving. Van revolutionaire feesten tot hedendaagse performance. Het archief bewaart het allemaal."


### PR DESCRIPTION
Adds a published articles section to the homepage and tightens the featured productions grid.

- New `ArticlesSection` component shows up to 3 published articles in the same column-rule grid style as the featured section, with cover image, publish date, and title
- Featured card hierarchy fixed: artist was rendered as a faded duplicate of the title at the same size - now an italic byline; tagline gets a border-top and reads as a deck
- Primary featured card image taller (260px vs 200px) for more visual weight
- Removed the 4 genre tag pills under the search bar (they were text queries, not facet filters)

<img width="1783" height="1336" alt="image" src="https://github.com/user-attachments/assets/400ba9b7-3c37-4723-9026-82d6525cef24" />