### PR TITLE
fix: cicd/tests-on-draft

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   test:
-    if: github.event.pull_request.draft == false
     runs-on: kaya-sem-house
     container:
       image: rust:1.94-bookworm

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   test:
-    if: github.event.pull_request.draft == false
     runs-on: kaya-sem-house
     container:
       image: mcr.microsoft.com/playwright:v1.59.1-jammy


### PR DESCRIPTION
Removes the `if: github.event.pull_request.draft == false` guard from the frontend and backend test jobs. The draft skip was preventing the checks from ever registering as completed status checks in GitHub, making them impossible to add as required checks in branch protection rules.