### PR TITLE
feat(frontend): facelift searchpage

### DIFF
--- a/frontend/src/components/searchpage/archive-sidebar/ArchiveSidebar.tsx
+++ b/frontend/src/components/searchpage/archive-sidebar/ArchiveSidebar.tsx
@@ -299,7 +299,7 @@ export function ArchiveSidebar({
             )}
 
             <aside
-                className={`border-border shrink-0 overflow-x-hidden border-r py-5 pb-10 ${
+                className={`border-border shrink-0 overflow-x-hidden overscroll-contain border-r py-5 pb-10 ${
                     mobileOpen
                         ? "bg-background fixed inset-y-0 left-0 z-50 w-[290px] overflow-y-auto shadow-xl"
                         : "hidden lg:sticky lg:top-[var(--results-bar-height,41px)] lg:block lg:max-h-[calc(100vh-var(--results-bar-height,41px))] lg:w-[290px] lg:overflow-y-auto"

--- a/frontend/src/components/searchpage/archive-sidebar/ArchiveSidebar.tsx
+++ b/frontend/src/components/searchpage/archive-sidebar/ArchiveSidebar.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useCallback, useEffect, useMemo, useRef } from "react";
 import { useTranslations, useLocale } from "next-intl";
-import { ChevronDown, SlidersHorizontal, X } from "lucide-react";
+import { Minus, Plus, SlidersHorizontal, X } from "lucide-react";
 
 import type { Location } from "@/types/models/location.types";
 import type { Facet } from "@/types/models/taxonomy.types";
@@ -191,85 +191,8 @@ export function ArchiveSidebar({
                 </div>
             </div>
 
-            <FilterGroup label={t("categories.label")}>
-                <div className="flex flex-wrap gap-2 pb-2.5">
-                    {CATEGORIES.map((cat) => (
-                        <button
-                            key={cat}
-                            type="button"
-                            aria-pressed={checkedCategories.has(cat)}
-                            onClick={() => toggleCategory(cat)}
-                            className={`cursor-pointer border px-2 py-1 font-mono text-[10px] tracking-[1.1px] uppercase transition-all ${
-                                checkedCategories.has(cat)
-                                    ? "bg-foreground text-background border-foreground"
-                                    : "border-border text-muted-foreground hover:border-foreground hover:text-foreground"
-                            }`}
-                        >
-                            {t(`categories.${cat}`)}
-                        </button>
-                    ))}
-                </div>
-            </FilterGroup>
-
-            {facets.map((facet) => (
-                <FilterGroup key={facet.slug} label={getLabel(facet.translations, locale)}>
-                    <div className="flex flex-wrap gap-2 pb-2.5">
-                        {facet.tags.map((tag) => (
-                            <button
-                                key={tag.slug}
-                                type="button"
-                                aria-pressed={activeTags.has(tag.slug)}
-                                onClick={() => toggleTag(tag.slug)}
-                                className={`cursor-pointer border px-2 py-1 font-mono text-[10px] tracking-[1.1px] uppercase transition-all ${
-                                    activeTags.has(tag.slug)
-                                        ? "bg-foreground text-background border-foreground"
-                                        : "border-border text-muted-foreground hover:border-foreground hover:text-foreground"
-                                }`}
-                            >
-                                {getLabel(tag.translations, locale)}
-                            </button>
-                        ))}
-                    </div>
-                </FilterGroup>
-            ))}
-
-            <FilterGroup label={t("locations.label")}>
-                <div className="flex flex-wrap gap-2 pb-2.5">
-                    {locations.length > 0 ? (
-                        locations.map((loc) => (
-                            <button
-                                key={loc.id}
-                                type="button"
-                                aria-pressed={checkedLocations.has(loc.id)}
-                                onClick={() => toggleLocation(loc.id)}
-                                className={`cursor-pointer border px-2 py-1 font-mono text-[10px] tracking-[1.1px] uppercase transition-all ${
-                                    checkedLocations.has(loc.id)
-                                        ? "bg-foreground text-background border-foreground"
-                                        : "border-border text-muted-foreground hover:border-foreground hover:text-foreground"
-                                }`}
-                            >
-                                {loc.name ?? loc.address}
-                            </button>
-                        ))
-                    ) : (
-                        <button
-                            type="button"
-                            aria-pressed={checkedLocations.has("deVooruit")}
-                            onClick={() => toggleLocation("deVooruit")}
-                            className={`cursor-pointer border px-2 py-1 font-mono text-[10px] tracking-[1.1px] uppercase transition-all ${
-                                checkedLocations.has("deVooruit")
-                                    ? "bg-foreground text-background border-foreground"
-                                    : "border-border text-muted-foreground hover:border-foreground hover:text-foreground"
-                            }`}
-                        >
-                            De Vooruit
-                        </button>
-                    )}
-                </div>
-            </FilterGroup>
-
-            {/* Date filter — collapsible section */}
-            <CollapsibleDateSection label={t("year.label")}>
+            {/* Date filter */}
+            <div className="border-border border-t px-4 pt-6 pb-2.5">
                 <div className="mb-3.5 flex gap-5">
                     <ModeTab
                         label={t("year.rangeMode")}
@@ -312,7 +235,49 @@ export function ArchiveSidebar({
                         />
                     </div>
                 )}
-            </CollapsibleDateSection>
+            </div>
+
+            <FilterGroup label={t("categories.label")}>
+                <div className="flex flex-wrap gap-2 pb-2.5">
+                    {CATEGORIES.map((cat) => (
+                        <button
+                            key={cat}
+                            type="button"
+                            aria-pressed={checkedCategories.has(cat)}
+                            onClick={() => toggleCategory(cat)}
+                            className={`cursor-pointer border px-2 py-1 font-mono text-[10px] tracking-[1.1px] uppercase transition-all ${
+                                checkedCategories.has(cat)
+                                    ? "bg-foreground text-background border-foreground"
+                                    : "border-border text-muted-foreground hover:border-foreground hover:text-foreground"
+                            }`}
+                        >
+                            {t(`categories.${cat}`)}
+                        </button>
+                    ))}
+                </div>
+            </FilterGroup>
+
+            {facets.map((facet) => (
+                <FacetFilterGroup
+                    key={facet.slug}
+                    label={getLabel(facet.translations, locale)}
+                    facet={facet}
+                    activeTags={activeTags}
+                    toggleTag={toggleTag}
+                    locale={locale}
+                    showMoreLabel={t("showMore")}
+                    showLessLabel={t("showLess")}
+                />
+            ))}
+
+            <LocationFilterGroup
+                label={t("locations.label")}
+                locations={locations}
+                checkedLocations={checkedLocations}
+                toggleLocation={toggleLocation}
+                showMoreLabel={t("showMore")}
+                showLessLabel={t("showLess")}
+            />
         </>
     );
 
@@ -369,40 +334,143 @@ function ModeTab({
     );
 }
 
+const TAGS_INITIAL_COUNT = 4;
+
 function FilterGroup({ label, children }: { label: string; children: React.ReactNode }) {
-    const [open, setOpen] = useState(false);
     return (
-        <div className="border-border border-t">
-            <button
-                type="button"
-                onClick={() => setOpen((v) => !v)}
-                className="flex w-full cursor-pointer items-center justify-between px-4 py-2.5 font-mono text-[11px] font-medium tracking-[1.2px] uppercase transition-colors"
-            >
-                <span className="text-foreground">{label}</span>
-                <ChevronDown
-                    className={`text-muted-foreground h-3.5 w-3.5 transition-transform ${open ? "rotate-180" : ""}`}
-                />
-            </button>
-            {open && <div className="px-4 pb-2.5">{children}</div>}
+        <div className="border-border border-t px-4 py-2.5">
+            <span className="text-foreground mb-2.5 block font-mono text-[11px] font-medium tracking-[1.2px] uppercase">
+                {label}
+            </span>
+            {children}
         </div>
     );
 }
 
-function CollapsibleDateSection({ label, children }: { label: string; children: React.ReactNode }) {
-    const [open, setOpen] = useState(false);
+function FacetFilterGroup({
+    label,
+    facet,
+    activeTags,
+    toggleTag,
+    locale,
+    showMoreLabel,
+    showLessLabel,
+}: {
+    label: string;
+    facet: Facet;
+    activeTags: Set<string>;
+    toggleTag: (slug: string) => void;
+    locale: string;
+    showMoreLabel: string;
+    showLessLabel: string;
+}) {
+    const [expanded, setExpanded] = useState(false);
+    const tags = expanded ? facet.tags : facet.tags.slice(0, TAGS_INITIAL_COUNT);
+    const hasMore = facet.tags.length > TAGS_INITIAL_COUNT;
     return (
-        <div className="border-border border-t">
-            <button
-                type="button"
-                onClick={() => setOpen((v) => !v)}
-                className="flex w-full cursor-pointer items-center justify-between px-4 py-2.5 font-mono text-[11px] font-medium tracking-[1.2px] uppercase transition-colors"
-            >
-                <span className="text-foreground">{label}</span>
-                <ChevronDown
-                    className={`text-muted-foreground h-3.5 w-3.5 transition-transform ${open ? "rotate-180" : ""}`}
-                />
-            </button>
-            {open && <div className="px-4 pr-5 pb-3">{children}</div>}
-        </div>
+        <FilterGroup label={label}>
+            <div className="flex flex-wrap gap-2 pb-1">
+                {tags.map((tag) => (
+                    <button
+                        key={tag.slug}
+                        type="button"
+                        aria-pressed={activeTags.has(tag.slug)}
+                        onClick={() => toggleTag(tag.slug)}
+                        className={`cursor-pointer border px-2 py-1 font-mono text-[10px] tracking-[1.1px] uppercase transition-all ${
+                            activeTags.has(tag.slug)
+                                ? "bg-foreground text-background border-foreground"
+                                : "border-border text-muted-foreground hover:border-foreground hover:text-foreground"
+                        }`}
+                    >
+                        {getLabel(tag.translations, locale)}
+                    </button>
+                ))}
+                {hasMore && (
+                    <button
+                        type="button"
+                        onClick={() => setExpanded((v) => !v)}
+                        className="text-foreground inline-flex cursor-pointer items-center gap-1 px-2 py-1 font-mono text-[10px] tracking-[1.1px] uppercase"
+                    >
+                        {expanded ? (
+                            <Minus className="h-2.5 w-2.5" />
+                        ) : (
+                            <Plus className="h-2.5 w-2.5" />
+                        )}
+                        {expanded ? showLessLabel : showMoreLabel}
+                    </button>
+                )}
+            </div>
+        </FilterGroup>
+    );
+}
+
+function LocationFilterGroup({
+    label,
+    locations,
+    checkedLocations,
+    toggleLocation,
+    showMoreLabel,
+    showLessLabel,
+}: {
+    label: string;
+    locations: Location[];
+    checkedLocations: Set<string>;
+    toggleLocation: (id: string) => void;
+    showMoreLabel: string;
+    showLessLabel: string;
+}) {
+    const [expanded, setExpanded] = useState(false);
+    const fallback = locations.length === 0;
+    const items = fallback ? [] : expanded ? locations : locations.slice(0, TAGS_INITIAL_COUNT);
+    const hasMore = !fallback && locations.length > TAGS_INITIAL_COUNT;
+    return (
+        <FilterGroup label={label}>
+            <div className="flex flex-wrap gap-2 pb-1">
+                {fallback ? (
+                    <button
+                        type="button"
+                        aria-pressed={checkedLocations.has("deVooruit")}
+                        onClick={() => toggleLocation("deVooruit")}
+                        className={`cursor-pointer border px-2 py-1 font-mono text-[10px] tracking-[1.1px] uppercase transition-all ${
+                            checkedLocations.has("deVooruit")
+                                ? "bg-foreground text-background border-foreground"
+                                : "border-border text-muted-foreground hover:border-foreground hover:text-foreground"
+                        }`}
+                    >
+                        De Vooruit
+                    </button>
+                ) : (
+                    items.map((loc) => (
+                        <button
+                            key={loc.id}
+                            type="button"
+                            aria-pressed={checkedLocations.has(loc.id)}
+                            onClick={() => toggleLocation(loc.id)}
+                            className={`cursor-pointer border px-2 py-1 font-mono text-[10px] tracking-[1.1px] uppercase transition-all ${
+                                checkedLocations.has(loc.id)
+                                    ? "bg-foreground text-background border-foreground"
+                                    : "border-border text-muted-foreground hover:border-foreground hover:text-foreground"
+                            }`}
+                        >
+                            {loc.name ?? loc.address}
+                        </button>
+                    ))
+                )}
+                {hasMore && (
+                    <button
+                        type="button"
+                        onClick={() => setExpanded((v) => !v)}
+                        className="text-foreground inline-flex cursor-pointer items-center gap-1 px-2 py-1 font-mono text-[10px] tracking-[1.1px] uppercase"
+                    >
+                        {expanded ? (
+                            <Minus className="h-2.5 w-2.5" />
+                        ) : (
+                            <Plus className="h-2.5 w-2.5" />
+                        )}
+                        {expanded ? showLessLabel : showMoreLabel}
+                    </button>
+                )}
+            </div>
+        </FilterGroup>
     );
 }

--- a/frontend/src/components/searchpage/archive-sidebar/ArchiveSidebar.tsx
+++ b/frontend/src/components/searchpage/archive-sidebar/ArchiveSidebar.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useCallback, useEffect, useMemo, useRef } from "react";
 import { useTranslations, useLocale } from "next-intl";
-import { SlidersHorizontal, X } from "lucide-react";
+import { ChevronDown, SlidersHorizontal, X } from "lucide-react";
 
 import type { Location } from "@/types/models/location.types";
 import type { Facet } from "@/types/models/taxonomy.types";
@@ -175,12 +175,20 @@ export function ArchiveSidebar({
                     </h2>
                     <div className="bg-foreground mt-1 h-0.5 w-10" />
                 </div>
-                <button
-                    onClick={() => setMobileOpen(false)}
-                    className="text-muted-foreground hover:text-foreground cursor-pointer p-1 lg:hidden"
-                >
-                    <X className="h-5 w-5" />
-                </button>
+                <div className="flex items-center gap-3">
+                    <button
+                        onClick={clearAll}
+                        className="text-muted-foreground hover:text-foreground cursor-pointer font-mono text-[9px] tracking-[1.2px] uppercase transition-colors"
+                    >
+                        {t("clearAll")}
+                    </button>
+                    <button
+                        onClick={() => setMobileOpen(false)}
+                        className="text-muted-foreground hover:text-foreground cursor-pointer p-1 lg:hidden"
+                    >
+                        <X className="h-5 w-5" />
+                    </button>
+                </div>
             </div>
 
             <FilterGroup label={t("categories.label")}>
@@ -260,8 +268,8 @@ export function ArchiveSidebar({
                 </div>
             </FilterGroup>
 
-            {/* Date filter — tabs replace the section title */}
-            <div className="border-border border-t pt-2.5 pr-5 pb-3 pl-4">
+            {/* Date filter — collapsible section */}
+            <CollapsibleDateSection label={t("year.label")}>
                 <div className="mb-3.5 flex gap-5">
                     <ModeTab
                         label={t("year.rangeMode")}
@@ -304,14 +312,7 @@ export function ArchiveSidebar({
                         />
                     </div>
                 )}
-            </div>
-
-            <button
-                onClick={clearAll}
-                className="border-foreground text-foreground hover:bg-foreground hover:text-background mx-auto mt-4 block w-[calc(100%-40px)] max-w-[230px] cursor-pointer border bg-transparent px-4 py-[9px] font-mono text-[10px] font-medium tracking-[1.4px] uppercase transition-all"
-            >
-                {t("clearAll")}
-            </button>
+            </CollapsibleDateSection>
         </>
     );
 
@@ -369,12 +370,39 @@ function ModeTab({
 }
 
 function FilterGroup({ label, children }: { label: string; children: React.ReactNode }) {
+    const [open, setOpen] = useState(false);
     return (
-        <div className="border-border border-t px-5 py-2.5 pl-4">
-            <span className="text-foreground mb-2.5 block font-mono text-[11px] font-medium tracking-[1.2px] uppercase">
-                {label}
-            </span>
-            {children}
+        <div className="border-border border-t">
+            <button
+                type="button"
+                onClick={() => setOpen((v) => !v)}
+                className="flex w-full cursor-pointer items-center justify-between px-4 py-2.5 font-mono text-[11px] font-medium tracking-[1.2px] uppercase transition-colors"
+            >
+                <span className="text-foreground">{label}</span>
+                <ChevronDown
+                    className={`text-muted-foreground h-3.5 w-3.5 transition-transform ${open ? "rotate-180" : ""}`}
+                />
+            </button>
+            {open && <div className="px-4 pb-2.5">{children}</div>}
+        </div>
+    );
+}
+
+function CollapsibleDateSection({ label, children }: { label: string; children: React.ReactNode }) {
+    const [open, setOpen] = useState(false);
+    return (
+        <div className="border-border border-t">
+            <button
+                type="button"
+                onClick={() => setOpen((v) => !v)}
+                className="flex w-full cursor-pointer items-center justify-between px-4 py-2.5 font-mono text-[11px] font-medium tracking-[1.2px] uppercase transition-colors"
+            >
+                <span className="text-foreground">{label}</span>
+                <ChevronDown
+                    className={`text-muted-foreground h-3.5 w-3.5 transition-transform ${open ? "rotate-180" : ""}`}
+                />
+            </button>
+            {open && <div className="px-4 pr-5 pb-3">{children}</div>}
         </div>
     );
 }

--- a/frontend/src/components/searchpage/archive-sidebar/YearRangeSlider.tsx
+++ b/frontend/src/components/searchpage/archive-sidebar/YearRangeSlider.tsx
@@ -74,12 +74,12 @@ export function YearRangeSlider({
     const overlayActive = merged || isDragging;
 
     const thumbCls =
-        "absolute w-full -top-[6px] h-[14px] appearance-none bg-transparent pointer-events-none " +
+        "absolute w-full -top-[9px] h-[18px] appearance-none bg-transparent pointer-events-none " +
         "[&::-webkit-slider-thumb]:pointer-events-auto [&::-webkit-slider-thumb]:appearance-none " +
-        "[&::-webkit-slider-thumb]:w-[14px] [&::-webkit-slider-thumb]:h-[14px] " +
+        "[&::-webkit-slider-thumb]:w-[18px] [&::-webkit-slider-thumb]:h-[18px] " +
         "[&::-webkit-slider-thumb]:bg-foreground [&::-webkit-slider-thumb]:border-2 " +
         "[&::-webkit-slider-thumb]:border-background [&::-webkit-slider-thumb]:cursor-pointer [&::-webkit-slider-thumb]:[border-radius:0px] " +
-        "[&::-moz-range-thumb]:pointer-events-auto [&::-moz-range-thumb]:w-[13px] [&::-moz-range-thumb]:h-[13px] " +
+        "[&::-moz-range-thumb]:pointer-events-auto [&::-moz-range-thumb]:w-[17px] [&::-moz-range-thumb]:h-[17px] " +
         "[&::-moz-range-thumb]:bg-foreground [&::-moz-range-thumb]:border-2 " +
         "[&::-moz-range-thumb]:border-background [&::-moz-range-thumb]:cursor-pointer " +
         "[&::-moz-range-thumb]:appearance-none [&::-moz-range-thumb]:[border-radius:0px] [&::-moz-range-thumb]:[box-sizing:border-box]";
@@ -89,10 +89,7 @@ export function YearRangeSlider({
             <div className="bg-border relative h-0.5">
                 <div
                     className="bg-foreground absolute h-full"
-                    style={{
-                        left: `${frac(value[0])}%`,
-                        right: `${100 - frac(value[1])}%`,
-                    }}
+                    style={{ left: `${frac(value[0])}%`, right: `${100 - frac(value[1])}%` }}
                 />
             </div>
             <input
@@ -120,7 +117,7 @@ export function YearRangeSlider({
                 className={thumbCls}
             />
             <div
-                className={`absolute inset-x-0 -top-[6px] h-[14px] cursor-pointer ${overlayActive ? "" : "pointer-events-none"}`}
+                className={`absolute inset-x-0 -top-[9px] h-[18px] cursor-pointer ${overlayActive ? "" : "pointer-events-none"}`}
                 onPointerDown={onOverlayPointerDown}
                 onPointerMove={onOverlayPointerMove}
                 onPointerUp={onOverlayPointerUp}

--- a/frontend/src/components/searchpage/results-bar/ResultsBar.tsx
+++ b/frontend/src/components/searchpage/results-bar/ResultsBar.tsx
@@ -11,12 +11,12 @@ interface ResultsBarProps {
     showSearch: boolean;
 }
 
-const SORT_OPTIONS = ["recent", "oldest", "az"] as const;
+const SORT_OPTIONS = ["relevant", "recent", "oldest"] as const;
 
 export function ResultsBar({ query, onQueryChange, onSearch, showSearch }: ResultsBarProps) {
     const t = useTranslations("ResultsBar");
     const tSearch = useTranslations("Search");
-    const [activeSort, setActiveSort] = useState<string>("recent");
+    const [activeSort, setActiveSort] = useState<string>("relevant");
 
     const handleSort = useCallback((option: string) => {
         setActiveSort(option);

--- a/frontend/src/components/searchpage/search-hero/SearchHero.tsx
+++ b/frontend/src/components/searchpage/search-hero/SearchHero.tsx
@@ -4,8 +4,6 @@ import { forwardRef } from "react";
 import { Search } from "lucide-react";
 import { useTranslations } from "next-intl";
 
-const QUICK_TAGS = ["dance", "theater", "concert", "nightlife", "performance"] as const;
-
 interface SearchHeroProps {
     query: string;
     onQueryChange: (query: string) => void;
@@ -52,25 +50,6 @@ export const SearchHero = forwardRef<HTMLDivElement, SearchHeroProps>(function S
                 </span>
 
                 <div className="bg-primary absolute -bottom-[2px] left-0 h-[2.5px] w-0 transition-all duration-500 group-focus-within:w-full group-focus-within:shadow-[0_4px_16px_rgba(var(--primary-rgb),0.6)]" />
-            </div>
-
-            <div className="flex flex-wrap items-center justify-center gap-2">
-                <span className="text-muted-foreground mr-1 font-mono text-[9px] tracking-[1.2px] uppercase">
-                    {t("quickSearch")}
-                </span>
-                {QUICK_TAGS.map((tag) => (
-                    <button
-                        key={tag}
-                        onClick={() => {
-                            const value = t(`tags.${tag}`);
-                            onQueryChange(value);
-                            onSearch?.(value);
-                        }}
-                        className="border-border text-muted-foreground hover:border-foreground hover:text-foreground cursor-pointer border px-2.5 py-1 font-mono text-[9px] tracking-[1.1px] uppercase transition-all"
-                    >
-                        {t(`tags.${tag}`)}
-                    </button>
-                ))}
             </div>
         </div>
     );

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -63,6 +63,7 @@
     },
     "ResultsBar": {
         "sortBy": "Sort by:",
+        "relevant": "Most relevant",
         "recent": "Most recent",
         "oldest": "Oldest first",
         "az": "A–Z"

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -139,7 +139,9 @@
             ],
             "weekdays": ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"]
         },
-        "clearAll": "Clear all"
+        "clearAll": "Clear all",
+        "showMore": "Show more",
+        "showLess": "Show less"
     },
     "Home": {
         "loading": "Loading archive...",

--- a/frontend/src/messages/nl.json
+++ b/frontend/src/messages/nl.json
@@ -63,6 +63,7 @@
     },
     "ResultsBar": {
         "sortBy": "Sorteren:",
+        "relevant": "Meest relevant",
         "recent": "Meest recent",
         "oldest": "Oudste eerst",
         "az": "A–Z"

--- a/frontend/src/messages/nl.json
+++ b/frontend/src/messages/nl.json
@@ -139,7 +139,9 @@
             ],
             "weekdays": ["Ma", "Di", "Wo", "Do", "Vr", "Za", "Zo"]
         },
-        "clearAll": "Wis alles"
+        "clearAll": "Wis alles",
+        "showMore": "Meer tonen",
+        "showLess": "Minder tonen"
     },
     "Home": {
         "loading": "Archief laden...",

--- a/frontend/test/unit/components/searchpage/ResultsBar.test.tsx
+++ b/frontend/test/unit/components/searchpage/ResultsBar.test.tsx
@@ -7,9 +7,9 @@ import { NextIntlClientProvider } from "next-intl";
 const messages = {
     ResultsBar: {
         sortBy: "Sort by",
+        relevant: "Relevant",
         recent: "Most Recent",
         oldest: "Oldest First",
-        az: "A-Z",
     },
     Search: {
         heroPlaceholder: "Search the archive",
@@ -35,9 +35,9 @@ describe("ResultsBar component", () => {
         );
 
         expect(screen.getByText("Sort by")).toBeInTheDocument();
+        expect(screen.getByText("Relevant")).toBeInTheDocument();
         expect(screen.getByText("Most Recent")).toBeInTheDocument();
         expect(screen.getByText("Oldest First")).toBeInTheDocument();
-        expect(screen.getByText("A-Z")).toBeInTheDocument();
     });
 
     it("updates active sort option on click", async () => {
@@ -46,18 +46,18 @@ describe("ResultsBar component", () => {
             <ResultsBar query="" onQueryChange={() => {}} onSearch={() => {}} showSearch={false} />
         );
 
-        const recentBtn = screen.getByText("Most Recent");
-        const azBtn = screen.getByText("A-Z");
+        const relevantBtn = screen.getByText("Relevant");
+        const oldestBtn = screen.getByText("Oldest First");
 
         // Initial state
-        expect(recentBtn).toHaveClass("border-foreground");
-        expect(azBtn).not.toHaveClass("border-foreground");
+        expect(relevantBtn).toHaveClass("border-foreground");
+        expect(oldestBtn).not.toHaveClass("border-foreground");
 
-        // Click A-Z
-        await user.click(azBtn);
+        // Click Oldest First
+        await user.click(oldestBtn);
 
         // Updated state
-        expect(recentBtn).not.toHaveClass("border-foreground");
-        expect(azBtn).toHaveClass("border-foreground");
+        expect(relevantBtn).not.toHaveClass("border-foreground");
+        expect(oldestBtn).toHaveClass("border-foreground");
     });
 });

--- a/frontend/test/unit/components/searchpage/SearchHero.test.tsx
+++ b/frontend/test/unit/components/searchpage/SearchHero.test.tsx
@@ -10,14 +10,6 @@ const messages = {
         heroTitleItalic: "the archive",
         heroPlaceholder: "What are you looking for?",
         enter: "Press enter",
-        quickSearch: "Quick search",
-        tags: {
-            dance: "Dance",
-            theater: "Theater",
-            concert: "Concert",
-            nightlife: "Nightlife",
-            performance: "Performance",
-        },
     },
 };
 
@@ -34,7 +26,7 @@ describe("SearchHero component", () => {
         cleanup();
     });
 
-    it("renders title, placeholder, and quick tags based on translations", () => {
+    it("renders title and placeholder based on translations", () => {
         renderWithIntl(<SearchHero query="" onQueryChange={vi.fn()} />);
 
         expect(screen.getByText("Search")).toBeInTheDocument();
@@ -42,10 +34,6 @@ describe("SearchHero component", () => {
 
         const input = screen.getByPlaceholderText("What are you looking for?");
         expect(input).toBeInTheDocument();
-
-        expect(screen.getByText("Quick search")).toBeInTheDocument();
-        expect(screen.getByText("Dance")).toBeInTheDocument();
-        expect(screen.getByText("Theater")).toBeInTheDocument();
     });
 
     it("displays the correct query value", () => {
@@ -65,17 +53,5 @@ describe("SearchHero component", () => {
         await user.type(input, "a");
 
         expect(onQueryChange).toHaveBeenCalledWith("a");
-    });
-
-    it("calls onQueryChange when a quick tag is clicked", async () => {
-        const user = userEvent.setup();
-        const onQueryChange = vi.fn();
-
-        renderWithIntl(<SearchHero query="" onQueryChange={onQueryChange} />);
-
-        const tagButton = screen.getByText("Dance");
-        await user.click(tagButton);
-
-        expect(onQueryChange).toHaveBeenCalledWith("Dance");
     });
 });


### PR DESCRIPTION
Several UX improvements to the search page and filter sidebar:

- Removed the quick-search tag pills below the search bar
- Moved the "Clear all" button into the sidebar header so it's always visible without scrolling
- Year range slider moved to the top of the sidebar so it's visible on load; its label is hidden to save space
- Slider thumbs enlarged (14px to 18px)
- Filter groups (facets, locations) now show 4 tags by default with a +/- inline toggle to reveal the rest
- Sort options: replaced A-Z with "Most relevant" as the new default
- Added `overscroll-contain` to the sidebar to prevent scroll chaining into the results list

<img width="1745" height="1333" alt="image" src="https://github.com/user-attachments/assets/f44efab5-8895-4a18-9152-e308cfb6fbca" />