### PR TITLE
fix(cicd): do lfs pull and decrypt

### DIFF
--- a/.github/workflows/build-push-deploy.yml
+++ b/.github/workflows/build-push-deploy.yml
@@ -34,6 +34,14 @@ jobs:
         with:
           lfs: true
 
+      - name: Pull LFS files
+        run: git lfs pull
+
+      - name: Unlock git-crypt
+        run: echo "$GIT_CRYPT_KEY" | base64 -d | git-crypt unlock -
+        env:
+          GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
+
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
The `build-push` job was checking out the repo but the Docker image ended up with LFS pointer files instead of real JSON, and encrypted blobs instead of the normalization patch files. This caused the backend to silently skip the seed import on first boot and fall back to a full live API fetch from epoch.

Adds a `git lfs pull` step to materialise the raw seed files, and a `git-crypt unlock` step (using a `GIT_CRYPT_KEY` repo secret) to decrypt the normalisation patches before the Docker build runs.

**Related Issue**
Fixes #

**How Has This Been Tested?**
- [ ] Local manual testing
- [ ] Added/updated unit or integration tests
- [ ] Tested in the staging environment

**Developer Checklist:**
- [ ] I have performed a self-review of my own code.
- [ ] I have left comments in hard-to-understand areas of my code.
- [ ] My changes generate no new warnings or console errors.
- [ ] I have updated the documentation (if applicable).

**Screenshots / Video (if UI/UX changed):**