### PR TITLE
feat(search): skeleton loading in searchpage

### DIFF
--- a/frontend/src/app/[locale]/(app)/search/page.tsx
+++ b/frontend/src/app/[locale]/(app)/search/page.tsx
@@ -137,7 +137,6 @@ export default function SearchPage() {
             ...(currentCursor ? { cursor: currentCursor } : {}),
         },
     });
-
     const nextCursor = productionsResult?.nextCursor;
 
     // Accumulate all fetched pages from TanStack Query cache

--- a/frontend/src/components/searchpage/archive-sidebar/ArchiveSidebar.tsx
+++ b/frontend/src/components/searchpage/archive-sidebar/ArchiveSidebar.tsx
@@ -47,7 +47,12 @@ export function ArchiveSidebar({ minYear: minYearProp, initialTag }: ArchiveSide
     const searchParams = useSearchParams();
 
     const { data: stats, isPending: statsLoading } = useGetStats();
-    const { data: locationsPages, fetchNextPage, hasNextPage } = useGetInfiniteLocations();
+    const {
+        data: locationsPages,
+        fetchNextPage,
+        hasNextPage,
+        isPending: locationsLoading,
+    } = useGetInfiniteLocations();
     const { data: facetsData, isPending: facetsLoading } = useGetFacets({
         entityType: "production",
     });
@@ -57,6 +62,8 @@ export function ArchiveSidebar({ minYear: minYearProp, initialTag }: ArchiveSide
         [locationsPages]
     );
     const facetList = useMemo<Facet[]>(() => facetsData ?? [], [facetsData]);
+
+    const sidebarLoading = statsLoading || facetsLoading || locationsLoading;
 
     const bounds = useMemo(
         () => yearBoundsFromStats(stats, { minYear: minYearProp }),
@@ -357,7 +364,7 @@ export function ArchiveSidebar({ minYear: minYearProp, initialTag }: ArchiveSide
                 {dateMode === "year" && (
                     <>
                         <div className="text-foreground mb-3.5 flex justify-between font-mono text-[13px] select-text">
-                            {statsLoading ? (
+                            {sidebarLoading ? (
                                 <>
                                     <Skeleton className="bg-muted/20 h-4 w-10" />
                                     <Skeleton className="bg-muted/20 h-4 w-10" />
@@ -370,7 +377,7 @@ export function ArchiveSidebar({ minYear: minYearProp, initialTag }: ArchiveSide
                                 </>
                             )}
                         </div>
-                        {statsLoading ? (
+                        {sidebarLoading ? (
                             <Skeleton className="bg-muted/20 h-2 w-full" />
                         ) : (
                             <YearRangeSlider
@@ -398,7 +405,7 @@ export function ArchiveSidebar({ minYear: minYearProp, initialTag }: ArchiveSide
                 )}
             </div>
 
-            {facetsLoading ? (
+            {sidebarLoading ? (
                 <FilterGroupSkeleton />
             ) : (
                 <FilterGroup label={t("categories.label")}>
@@ -422,7 +429,7 @@ export function ArchiveSidebar({ minYear: minYearProp, initialTag }: ArchiveSide
                 </FilterGroup>
             )}
 
-            {facetsLoading
+            {sidebarLoading
                 ? [0, 1, 2, 3, 4, 5].map((i) => <FilterGroupSkeleton key={i} />)
                 : facetList.map((facet) => (
                       <FacetFilterGroup
@@ -437,7 +444,7 @@ export function ArchiveSidebar({ minYear: minYearProp, initialTag }: ArchiveSide
                       />
                   ))}
 
-            {facetsLoading ? (
+            {sidebarLoading ? (
                 <FilterGroupSkeleton />
             ) : (
                 <LocationFilterGroup

--- a/frontend/src/components/searchpage/archive-sidebar/ArchiveSidebar.tsx
+++ b/frontend/src/components/searchpage/archive-sidebar/ArchiveSidebar.tsx
@@ -13,6 +13,7 @@ import { useGetInfiniteLocations } from "@/hooks/api/useLocations";
 import { useGetFacets } from "@/hooks/api/useTaxonomy";
 import { useRouter, usePathname } from "@/i18n/routing";
 
+import { Skeleton } from "@/components/ui/skeleton";
 import { YearRangeSlider } from "./YearRangeSlider";
 import { DateRangePicker } from "./DateRangePicker";
 import { yearBoundsFromStats } from "./statsYearBounds";
@@ -45,15 +46,17 @@ export function ArchiveSidebar({ minYear: minYearProp, initialTag }: ArchiveSide
     const pathname = usePathname();
     const searchParams = useSearchParams();
 
-    const { data: stats } = useGetStats();
+    const { data: stats, isPending: statsLoading } = useGetStats();
     const { data: locationsPages, fetchNextPage, hasNextPage } = useGetInfiniteLocations();
-    const { data: facets } = useGetFacets({ entityType: "production" });
+    const { data: facetsData, isPending: facetsLoading } = useGetFacets({
+        entityType: "production",
+    });
 
     const locations = useMemo(
         () => locationsPages?.pages.flatMap((p) => p.data) ?? [],
         [locationsPages]
     );
-    const facetList = useMemo<Facet[]>(() => facets ?? [], [facets]);
+    const facetList = useMemo<Facet[]>(() => facetsData ?? [], [facetsData]);
 
     const bounds = useMemo(
         () => yearBoundsFromStats(stats, { minYear: minYearProp }),
@@ -354,18 +357,31 @@ export function ArchiveSidebar({ minYear: minYearProp, initialTag }: ArchiveSide
                 {dateMode === "year" && (
                     <>
                         <div className="text-foreground mb-3.5 flex justify-between font-mono text-[13px] select-text">
-                            <span>{displayedYearRange[0]}</span>
-                            <span className="text-muted-foreground text-[11px]">—</span>
-                            <span>{displayedYearRange[1]}</span>
+                            {statsLoading ? (
+                                <>
+                                    <Skeleton className="bg-muted/20 h-4 w-10" />
+                                    <Skeleton className="bg-muted/20 h-4 w-10" />
+                                </>
+                            ) : (
+                                <>
+                                    <span>{displayedYearRange[0]}</span>
+                                    <span className="text-muted-foreground text-[11px]">—</span>
+                                    <span>{displayedYearRange[1]}</span>
+                                </>
+                            )}
                         </div>
-                        <YearRangeSlider
-                            min={bounds.minYear}
-                            max={bounds.maxYear}
-                            value={displayedYearRange}
-                            onChange={handleYearRangeChange}
-                            ariaLabelStart={t("year.rangeFrom")}
-                            ariaLabelEnd={t("year.rangeTo")}
-                        />
+                        {statsLoading ? (
+                            <Skeleton className="bg-muted/20 h-2 w-full" />
+                        ) : (
+                            <YearRangeSlider
+                                min={bounds.minYear}
+                                max={bounds.maxYear}
+                                value={displayedYearRange}
+                                onChange={handleYearRangeChange}
+                                ariaLabelStart={t("year.rangeFrom")}
+                                ariaLabelEnd={t("year.rangeTo")}
+                            />
+                        )}
                     </>
                 )}
 
@@ -382,49 +398,59 @@ export function ArchiveSidebar({ minYear: minYearProp, initialTag }: ArchiveSide
                 )}
             </div>
 
-            <FilterGroup label={t("categories.label")}>
-                <div className="flex flex-wrap gap-2 pb-2.5">
-                    {CATEGORIES.map((cat) => (
-                        <button
-                            key={cat}
-                            type="button"
-                            aria-pressed={checkedCategories.has(cat)}
-                            onClick={() => toggleCategory(cat)}
-                            className={`cursor-pointer border px-2 py-1 font-mono text-[10px] tracking-[1.1px] uppercase transition-all ${
-                                checkedCategories.has(cat)
-                                    ? "bg-foreground text-background border-foreground"
-                                    : "border-border text-muted-foreground hover:border-foreground hover:text-foreground"
-                            }`}
-                        >
-                            {t(`categories.${cat}`)}
-                        </button>
-                    ))}
-                </div>
-            </FilterGroup>
+            {facetsLoading ? (
+                <FilterGroupSkeleton />
+            ) : (
+                <FilterGroup label={t("categories.label")}>
+                    <div className="flex flex-wrap gap-2 pb-2.5">
+                        {CATEGORIES.map((cat) => (
+                            <button
+                                key={cat}
+                                type="button"
+                                aria-pressed={checkedCategories.has(cat)}
+                                onClick={() => toggleCategory(cat)}
+                                className={`cursor-pointer border px-2 py-1 font-mono text-[10px] tracking-[1.1px] uppercase transition-all ${
+                                    checkedCategories.has(cat)
+                                        ? "bg-foreground text-background border-foreground"
+                                        : "border-border text-muted-foreground hover:border-foreground hover:text-foreground"
+                                }`}
+                            >
+                                {t(`categories.${cat}`)}
+                            </button>
+                        ))}
+                    </div>
+                </FilterGroup>
+            )}
 
-            {facetList.map((facet) => (
-                <FacetFilterGroup
-                    key={facet.slug}
-                    label={getLabel(facet.translations, locale)}
-                    facet={facet}
-                    activeTags={activeFacets[facet.slug] ?? new Set()}
-                    toggleTag={(tagSlug) => toggleTag(facet.slug, tagSlug)}
-                    locale={locale}
+            {facetsLoading
+                ? [0, 1, 2, 3, 4, 5].map((i) => <FilterGroupSkeleton key={i} />)
+                : facetList.map((facet) => (
+                      <FacetFilterGroup
+                          key={facet.slug}
+                          label={getLabel(facet.translations, locale)}
+                          facet={facet}
+                          activeTags={activeFacets[facet.slug] ?? new Set()}
+                          toggleTag={(tagSlug) => toggleTag(facet.slug, tagSlug)}
+                          locale={locale}
+                          showMoreLabel={t("showMore")}
+                          showLessLabel={t("showLess")}
+                      />
+                  ))}
+
+            {facetsLoading ? (
+                <FilterGroupSkeleton />
+            ) : (
+                <LocationFilterGroup
+                    label={t("locations.label")}
+                    locations={locations}
+                    checkedLocations={checkedLocations}
+                    toggleLocation={toggleLocation}
                     showMoreLabel={t("showMore")}
                     showLessLabel={t("showLess")}
+                    fetchNextPage={fetchNextPage}
+                    hasNextPage={!!hasNextPage}
                 />
-            ))}
-
-            <LocationFilterGroup
-                label={t("locations.label")}
-                locations={locations}
-                checkedLocations={checkedLocations}
-                toggleLocation={toggleLocation}
-                showMoreLabel={t("showMore")}
-                showLessLabel={t("showLess")}
-                fetchNextPage={fetchNextPage}
-                hasNextPage={!!hasNextPage}
-            />
+            )}
         </>
     );
 
@@ -482,6 +508,19 @@ function ModeTab({
 }
 
 const TAGS_INITIAL_COUNT = 4;
+
+function FilterGroupSkeleton() {
+    return (
+        <div className="border-border border-t px-4 py-2.5">
+            <Skeleton className="bg-muted/20 mb-3 h-3 w-20" />
+            <div className="flex flex-wrap gap-2 pb-1">
+                {[0, 1, 2, 3].map((i) => (
+                    <Skeleton key={i} className="bg-muted/20 h-6 w-28" />
+                ))}
+            </div>
+        </div>
+    );
+}
 
 function FilterGroup({ label, children }: { label: string; children: React.ReactNode }) {
     return (

--- a/frontend/src/components/searchpage/production-list/ProductionList.tsx
+++ b/frontend/src/components/searchpage/production-list/ProductionList.tsx
@@ -3,14 +3,14 @@
 import { useState, useCallback } from "react";
 import Image from "next/image";
 import { useTranslations } from "next-intl";
-import { ChevronDown, Loader2 } from "lucide-react";
+import { ChevronDown } from "lucide-react";
 import { Link } from "@/i18n/routing";
 
 import type { Production } from "@/types/models/production.types";
 import type { Event } from "@/types/models/event.types";
 import { getLocalizedField } from "@/lib/locale";
 import { useGetEventsByProduction } from "@/hooks/api/useEvents";
-import { LoadingState } from "@/components/shared/loading-state";
+import { Skeleton } from "@/components/ui/skeleton";
 import { EntityTagStrip } from "@/components/shared/entity-tag-strip";
 
 interface ProductionItemProps {
@@ -60,8 +60,12 @@ function EventList({ productionId, locale }: { productionId: string; locale: str
 
     if (isLoading) {
         return (
-            <div className="border-muted/35 flex items-center justify-center border-t px-4 py-4 sm:px-0">
-                <Loader2 className="text-muted-foreground h-4 w-4 animate-spin" />
+            <div className="border-muted/35 border-t">
+                <div className="border-muted/25 flex items-center border-b px-4 py-2 sm:px-0">
+                    <Skeleton className="bg-muted/20 h-3 w-28" />
+                    <Skeleton className="bg-muted/20 ml-4 h-3 w-10" />
+                    <Skeleton className="bg-muted/20 mr-2 ml-auto h-4 w-16" />
+                </div>
             </div>
         );
     }
@@ -168,22 +172,26 @@ interface ProductionListProps {
 }
 
 export function ProductionList({ productions, locale, isLoading }: ProductionListProps) {
-    const t = useTranslations("Home");
-
     return (
-        <div
-            className={`relative overflow-hidden ${
-                isLoading && productions.length === 0 ? "flex-1" : ""
-            }`}
-        >
-            {isLoading && productions.length === 0 && (
-                <div className="absolute inset-0 flex flex-col items-center justify-center">
-                    <LoadingState message={t("loading")} className="min-h-0" />
-                </div>
-            )}
-            {productions.map((production) => (
-                <ProductionItem key={production.id} production={production} locale={locale} />
-            ))}
+        <div className="relative overflow-hidden">
+            {isLoading && productions.length === 0
+                ? [0, 1, 2, 3, 4, 5, 6].map((i) => (
+                      <div
+                          key={i}
+                          className="border-muted/35 flex items-start gap-3 border-b px-4 py-3.5 sm:gap-[18px] sm:px-7"
+                      >
+                          <Skeleton className="bg-muted/20 h-[108px] w-[144px] shrink-0 sm:h-[136px] sm:w-[180px]" />
+                          <div className="min-w-0 flex-1 space-y-2 pt-1">
+                              <Skeleton className="bg-muted/20 h-5 w-3/4" />
+                              <Skeleton className="bg-muted/20 h-4 w-1/2" />
+                              <Skeleton className="bg-muted/20 h-3 w-full" />
+                              <Skeleton className="bg-muted/20 h-3 w-2/3" />
+                          </div>
+                      </div>
+                  ))
+                : productions.map((production) => (
+                      <ProductionItem key={production.id} production={production} locale={locale} />
+                  ))}
         </div>
     );
 }

--- a/frontend/test/unit/components/searchpage/ArchiveSidebar.test.tsx
+++ b/frontend/test/unit/components/searchpage/ArchiveSidebar.test.tsx
@@ -12,11 +12,13 @@ const mockSearchParams = new URLSearchParams();
 const { useGetStatsMock, useGetFacetsMock, useGetInfiniteLocationsMock } = vi.hoisted(() => ({
     useGetStatsMock: vi.fn(() => ({
         data: undefined as StatsPayload | undefined,
+        isPending: false,
         isLoading: false,
         isError: false,
     })),
     useGetFacetsMock: vi.fn(() => ({
         data: undefined as Facet[] | undefined,
+        isPending: false,
     })),
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     useGetInfiniteLocationsMock: vi.fn((): any => ({
@@ -162,10 +164,11 @@ describe("ArchiveSidebar component", () => {
         window.HTMLElement.prototype.scrollIntoView = vi.fn();
         useGetStatsMock.mockReturnValue({
             data: undefined,
+            isPending: false,
             isLoading: false,
             isError: false,
         });
-        useGetFacetsMock.mockReturnValue({ data: undefined });
+        useGetFacetsMock.mockReturnValue({ data: undefined, isPending: false });
         useGetInfiniteLocationsMock.mockReturnValue({
             data: undefined,
             fetchNextPage: vi.fn(),
@@ -196,7 +199,7 @@ describe("ArchiveSidebar component", () => {
     });
 
     it("renders tags (facets) from API hook", () => {
-        useGetFacetsMock.mockReturnValue({ data: mockFacets });
+        useGetFacetsMock.mockReturnValue({ data: mockFacets, isPending: false });
         renderWithIntl(<ArchiveSidebar />);
 
         expect(screen.getByText("Facet 1")).toBeInTheDocument();
@@ -230,7 +233,7 @@ describe("ArchiveSidebar component", () => {
     });
 
     it("tag starts unchecked when not in URL", () => {
-        useGetFacetsMock.mockReturnValue({ data: mockFacets });
+        useGetFacetsMock.mockReturnValue({ data: mockFacets, isPending: false });
         renderWithIntl(<ArchiveSidebar />);
 
         const tag1 = screen.getByRole("button", { name: "Tag 1" });
@@ -238,7 +241,7 @@ describe("ArchiveSidebar component", () => {
     });
 
     it("tag appears checked when its slug is in URL params", () => {
-        useGetFacetsMock.mockReturnValue({ data: mockFacets });
+        useGetFacetsMock.mockReturnValue({ data: mockFacets, isPending: false });
         mockSearchParams.set("discipline", "t1");
         renderWithIntl(<ArchiveSidebar />);
 
@@ -248,7 +251,7 @@ describe("ArchiveSidebar component", () => {
 
     it("clicking a tag calls router.replace with updated URL param", async () => {
         const user = userEvent.setup();
-        useGetFacetsMock.mockReturnValue({ data: mockFacets });
+        useGetFacetsMock.mockReturnValue({ data: mockFacets, isPending: false });
         renderWithIntl(<ArchiveSidebar />);
 
         await user.click(screen.getByRole("button", { name: "Tag 1" }));
@@ -260,7 +263,7 @@ describe("ArchiveSidebar component", () => {
 
     it("clicking an active tag removes it from the URL param", async () => {
         const user = userEvent.setup();
-        useGetFacetsMock.mockReturnValue({ data: mockFacets });
+        useGetFacetsMock.mockReturnValue({ data: mockFacets, isPending: false });
         mockSearchParams.set("discipline", "t1");
         window.history.pushState({}, "", "?discipline=t1");
         renderWithIntl(<ArchiveSidebar />);
@@ -490,7 +493,7 @@ describe("ArchiveSidebar component", () => {
 
     it("clearAll strips filter params from URL and resets category state", async () => {
         const user = userEvent.setup();
-        useGetFacetsMock.mockReturnValue({ data: mockFacets });
+        useGetFacetsMock.mockReturnValue({ data: mockFacets, isPending: false });
         mockSearchParams.set("discipline", "t1");
         renderWithIntl(<ArchiveSidebar />);
 
@@ -536,6 +539,7 @@ describe("ArchiveSidebar component", () => {
 
         useGetStatsMock.mockReturnValue({
             data: undefined,
+            isPending: false,
             isLoading: false,
             isError: false,
         });
@@ -559,6 +563,7 @@ describe("ArchiveSidebar component", () => {
 
         useGetStatsMock.mockReturnValue({
             data: statsPayload,
+            isPending: false,
             isLoading: false,
             isError: false,
         });
@@ -606,6 +611,26 @@ describe("ArchiveSidebar component", () => {
         await user.click(closeBtn!);
 
         expect(document.body.style.overflow).toBe("");
+    });
+
+    it("shows skeleton year range while stats are loading", () => {
+        useGetStatsMock.mockReturnValue({
+            data: undefined,
+            isPending: true,
+            isLoading: true,
+            isError: false,
+        });
+        renderWithIntl(<ArchiveSidebar minYear={2000} />);
+
+        expect(screen.queryAllByRole("slider")).toHaveLength(0);
+    });
+
+    it("shows skeleton filter groups while facets are loading", () => {
+        useGetFacetsMock.mockReturnValue({ data: undefined, isPending: true });
+        renderWithIntl(<ArchiveSidebar />);
+
+        expect(screen.queryByText("Categories")).not.toBeInTheDocument();
+        expect(screen.queryByText("Locations")).not.toBeInTheDocument();
     });
 
     it("closes mobile sidebar when clicking the backdrop overlay", async () => {


### PR DESCRIPTION
**Description**
Adds skeleton loading states across the search page (production list, event rows, year bounds, and facet filters).

**Related Issue**
Fixes #

**How Has This Been Tested?**
- [x] Local manual testing
- [x] Added/updated unit or integration tests
- [ ] Tested in the staging environment

**Developer Checklist:**
- [x] I have performed a self-review of my own code.
- [x] I have left comments in hard-to-understand areas of my code.
- [x] My changes generate no new warnings or console errors.
- [x] I have updated the documentation (if applicable).

**Screenshots / Video (if UI/UX changed):**
[Screencast from 2026-05-11 22-43-17.webm](https://github.com/user-attachments/assets/18168cb1-9856-4847-ad95-641baa58e7b6)
[Screencast from 2026-05-07 14-46-46.webm](https://github.com/user-attachments/assets/871d96a6-ac8a-4fbb-8542-0ffc4fbc40d5)
<img width="4096" height="2224" alt="image" src="https://github.com/user-attachments/assets/a189ffb7-f866-4e0b-a069-4a6e6f4077c9" />
<img width="4096" height="2224" alt="image" src="https://github.com/user-attachments/assets/812a6155-8020-4ecd-8ddd-84d7943ec82c" />
<img width="2013" height="422" alt="image" src="https://github.com/user-attachments/assets/5b75cb0f-f8ae-4408-9854-f244f1aa0ee3" />
