### PR TITLE
perf(cms): memoize table rows, fix selection checkbox, tune prefetch

### DIFF
--- a/frontend/src/app/[locale]/(cms)/cms/tables/articles/articles-table.tsx
+++ b/frontend/src/app/[locale]/(cms)/cms/tables/articles/articles-table.tsx
@@ -34,7 +34,7 @@ export function ArticlesTable() {
         fetchNextPage,
         hasNextPage,
         isLoading,
-    } = useGetInfiniteArticlesCms(q ? { q } : undefined);
+    } = useGetInfiniteArticlesCms({ limit: 50, ...(q ? { q } : {}) });
 
     const articles = useMemo(
         () => infiniteData?.pages.flatMap((page) => page.data) ?? [],

--- a/frontend/src/app/[locale]/(cms)/cms/tables/collections/collections-table.tsx
+++ b/frontend/src/app/[locale]/(cms)/cms/tables/collections/collections-table.tsx
@@ -29,7 +29,7 @@ export function CollectionsTable() {
         hasNextPage,
         isFetchingNextPage,
         isLoading,
-    } = useGetInfiniteCollections();
+    } = useGetInfiniteCollections({ limit: 50 });
 
     const collections = useMemo(
         () => infiniteData?.pages.flatMap((page) => page.data) ?? [],

--- a/frontend/src/app/[locale]/(cms)/cms/tables/data-table.tsx
+++ b/frontend/src/app/[locale]/(cms)/cms/tables/data-table.tsx
@@ -236,7 +236,8 @@ const MemoTableRow = memo(
         prev.onRowClick === next.onRowClick &&
         prev.rowRefCallback === next.rowRefCallback &&
         prev.renderSubComponent === next.renderSubComponent &&
-        prev.focusRowAt === next.focusRowAt
+        prev.focusRowAt === next.focusRowAt &&
+        prev.rowIndex === next.rowIndex
 ) as <TData>(props: MemoTableRowProps<TData>) => ReactNode;
 
 export interface ExpanderLabels {

--- a/frontend/src/app/[locale]/(cms)/cms/tables/data-table.tsx
+++ b/frontend/src/app/[locale]/(cms)/cms/tables/data-table.tsx
@@ -12,7 +12,16 @@ import {
     useReactTable,
 } from "@tanstack/react-table";
 import { Check, ChevronDown, ChevronRight } from "lucide-react";
-import { Fragment, ReactNode, memo, useMemo, useState } from "react";
+import {
+    Fragment,
+    ReactNode,
+    memo,
+    useCallback,
+    useLayoutEffect,
+    useMemo,
+    useRef,
+    useState,
+} from "react";
 
 import { useTableSelection } from "./use-table-selection";
 
@@ -105,6 +114,131 @@ export const MemoSubTable = memo(
     getRowId?: (row: T) => string;
 }) => ReactNode;
 
+// Memoized table row that only re-renders when its selection, focus, or data changes.
+// This prevents 7999 rows from re-rendering when a single row is toggled.
+interface MemoTableRowProps<TData> {
+    row: Row<TData>;
+    rowIndex: number;
+    isSelected: boolean;
+    isExpanded: boolean;
+    isFocused: boolean;
+    tabIndex: number;
+    hasSelection: boolean;
+    handleRowClick: (row: Row<TData>, event: React.MouseEvent) => void;
+    handleRowMouseDown: (event: React.MouseEvent) => void;
+    onRowClick?: (row: TData) => void;
+    rowRefCallback: (index: number) => (el: HTMLTableRowElement | null) => void;
+    allColumnsLength: number;
+    renderSubComponent?: (row: Row<TData>) => ReactNode;
+    focusRowAt: (index: number) => void;
+}
+
+function MemoTableRowInner<TData>({
+    row,
+    rowIndex,
+    isSelected,
+    isExpanded,
+    isFocused,
+    tabIndex,
+    hasSelection,
+    handleRowClick,
+    handleRowMouseDown,
+    onRowClick,
+    rowRefCallback,
+    allColumnsLength,
+    renderSubComponent,
+    focusRowAt,
+}: MemoTableRowProps<TData>) {
+    // Stable ref for row so onRowClickHandler doesn't recreate when
+    // TanStack recycles row objects across table instance recreations.
+    const rowRef = useRef(row);
+    useLayoutEffect(() => {
+        rowRef.current = row;
+    });
+
+    const onRowClickHandler = useCallback(
+        (e: React.MouseEvent) => {
+            if (hasSelection) {
+                handleRowClick(rowRef.current, e);
+            } else {
+                onRowClick?.(rowRef.current.original);
+            }
+        },
+        [hasSelection, handleRowClick, onRowClick]
+    );
+
+    const onRowMouseEnter = useCallback(() => focusRowAt(rowIndex), [focusRowAt, rowIndex]);
+    const onRowMouseLeave = useCallback(() => focusRowAt(-1), [focusRowAt]);
+
+    return (
+        <Fragment>
+            <TableRow
+                ref={rowRefCallback(rowIndex)}
+                tabIndex={tabIndex}
+                data-state={isSelected ? "selected" : undefined}
+                data-focused={isFocused ? "true" : undefined}
+                aria-selected={hasSelection ? isSelected : undefined}
+                className={cn(
+                    "border-0 transition-colors outline-none",
+                    "data-[state=selected]:bg-foreground/[0.18]",
+                    "data-[focused=true]:bg-foreground/[0.12] data-[state=selected]:data-[focused=true]:bg-foreground/[0.22]",
+                    "hover:bg-foreground/[0.06] data-[state=selected]:hover:bg-foreground/[0.24]",
+                    rowIndex % 2 === 1 && !isSelected ? "bg-secondary" : "",
+                    onRowClick && !hasSelection ? "cursor-pointer" : "",
+                    hasSelection ? "cursor-pointer" : ""
+                )}
+                onClick={onRowClickHandler}
+                onMouseEnter={onRowMouseEnter}
+                onMouseLeave={onRowMouseLeave}
+                onMouseDown={handleRowMouseDown}
+            >
+                {row.getVisibleCells().map((cell) => (
+                    <TableCell
+                        key={cell.id}
+                        className={cn(
+                            cell.column.id === "select" || cell.column.id === "expander"
+                                ? "w-px px-2 whitespace-nowrap"
+                                : cell.column.id === "actions"
+                                  ? "font-body px-3 py-2.5 text-right text-sm whitespace-nowrap"
+                                  : "font-body max-w-[300px] px-3 py-2.5 text-sm break-words whitespace-normal"
+                        )}
+                    >
+                        {flexRender(cell.column.columnDef.cell, {
+                            ...cell.getContext(),
+                            _sel: isSelected,
+                        })}
+                    </TableCell>
+                ))}
+            </TableRow>
+            {renderSubComponent && isExpanded && (
+                <TableRow className="border-0 hover:bg-transparent">
+                    <TableCell colSpan={allColumnsLength} className="p-0">
+                        {renderSubComponent(row)}
+                    </TableCell>
+                </TableRow>
+            )}
+        </Fragment>
+    );
+}
+
+const MemoTableRow = memo(
+    MemoTableRowInner,
+    (prev, next) =>
+        prev.row.original === next.row.original &&
+        prev.isSelected === next.isSelected &&
+        prev.isExpanded === next.isExpanded &&
+        prev.isFocused === next.isFocused &&
+        prev.tabIndex === next.tabIndex &&
+        prev.hasSelection === next.hasSelection &&
+        prev.allColumnsLength === next.allColumnsLength &&
+        prev.handleRowClick === next.handleRowClick &&
+        prev.handleRowMouseDown === next.handleRowMouseDown &&
+        prev.onRowClick === next.onRowClick &&
+        prev.rowRefCallback === next.rowRefCallback &&
+        prev.renderSubComponent === next.renderSubComponent &&
+        prev.focusRowAt === next.focusRowAt
+) as <TData>(props: MemoTableRowProps<TData>) => ReactNode;
+
 export interface ExpanderLabels {
     show: string;
     hide: string;
@@ -163,24 +297,27 @@ export function DataTable<TData, TValue>({
         () => ({
             id: "select",
             header: () => null,
-            cell: ({ row }) => (
-                <div
-                    role="checkbox"
-                    aria-checked={row.getIsSelected()}
-                    className={cn(
-                        "flex size-4 items-center justify-center border",
-                        row.getIsSelected()
-                            ? "border-foreground bg-foreground text-background"
-                            : "border-foreground/30"
-                    )}
-                    onClick={(e) => {
-                        e.stopPropagation();
-                        row.toggleSelected(!row.getIsSelected());
-                    }}
-                >
-                    {row.getIsSelected() && <Check className="size-3.5" />}
-                </div>
-            ),
+            cell: ({ row, _sel }: { row: Row<TData>; _sel?: boolean }) => {
+                const selected = _sel ?? row.getIsSelected();
+                return (
+                    <div
+                        role="checkbox"
+                        aria-checked={selected}
+                        className={cn(
+                            "flex size-4 items-center justify-center border",
+                            selected
+                                ? "border-foreground bg-foreground text-background"
+                                : "border-foreground/30"
+                        )}
+                        onClick={(e) => {
+                            e.stopPropagation();
+                            row.toggleSelected(!selected);
+                        }}
+                    >
+                        {selected && <Check className="size-3.5" />}
+                    </div>
+                );
+            },
             enableSorting: false,
             enableHiding: false,
         }),
@@ -270,7 +407,6 @@ export function DataTable<TData, TValue>({
         handleRowClick,
         handleRowMouseDown,
         handleKeyDown,
-        getRowTabIndex,
         isRowFocused,
         focusRowAt,
         rowRefCallback,
@@ -288,14 +424,12 @@ export function DataTable<TData, TValue>({
             <div
                 className={cn("outline-none", compact ? "" : "")}
                 onKeyDown={handleKeyDown}
+                onMouseLeave={() => focusRowAt(-1)}
                 tabIndex={hasSelection ? 0 : -1}
                 role={hasSelection ? "grid" : undefined}
                 aria-multiselectable={hasSelection ? true : undefined}
             >
-                <Table
-                    className={compact ? "text-xs [&_tbody_tr]:border-0 [&_td]:py-1" : ""}
-                    onMouseLeave={() => focusRowAt(-1)}
-                >
+                <Table className={compact ? "text-xs [&_tbody_tr]:border-0 [&_td]:py-1" : ""}>
                     <TableHeader className="bg-muted">
                         {table.getHeaderGroups().map((headerGroup) => (
                             <TableRow key={headerGroup.id} className="bg-muted hover:bg-muted">
@@ -327,63 +461,23 @@ export function DataTable<TData, TValue>({
                     <TableBody>
                         {visibleRows.length ? (
                             visibleRows.map((row, rowIndex) => (
-                                <Fragment key={row.id}>
-                                    <TableRow
-                                        ref={rowRefCallback(rowIndex)}
-                                        tabIndex={getRowTabIndex(rowIndex)}
-                                        data-state={row.getIsSelected() ? "selected" : undefined}
-                                        data-focused={isRowFocused(rowIndex) ? "true" : undefined}
-                                        aria-selected={
-                                            hasSelection ? row.getIsSelected() : undefined
-                                        }
-                                        className={cn(
-                                            "border-0 transition-colors outline-none",
-                                            "data-[state=selected]:bg-foreground/[0.18]",
-                                            "data-[focused=true]:bg-foreground/[0.12] data-[state=selected]:data-[focused=true]:bg-foreground/[0.22]",
-                                            rowIndex % 2 === 1 && !row.getIsSelected()
-                                                ? "bg-secondary"
-                                                : "",
-                                            onRowClick && !hasSelection ? "cursor-pointer" : "",
-                                            hasSelection ? "cursor-pointer" : ""
-                                        )}
-                                        onClick={(e) => {
-                                            if (hasSelection) {
-                                                handleRowClick(row, e);
-                                            } else {
-                                                onRowClick?.(row.original);
-                                            }
-                                        }}
-                                        onMouseEnter={() => focusRowAt(rowIndex)}
-                                        onMouseLeave={() => focusRowAt(-1)}
-                                        onMouseDown={handleRowMouseDown}
-                                    >
-                                        {row.getVisibleCells().map((cell) => (
-                                            <TableCell
-                                                key={cell.id}
-                                                className={cn(
-                                                    cell.column.id === "select" ||
-                                                        cell.column.id === "expander"
-                                                        ? "w-px px-2 whitespace-nowrap"
-                                                        : cell.column.id === "actions"
-                                                          ? "font-body px-3 py-2.5 text-right text-sm whitespace-nowrap"
-                                                          : "font-body max-w-[300px] px-3 py-2.5 text-sm break-words whitespace-normal"
-                                                )}
-                                            >
-                                                {flexRender(
-                                                    cell.column.columnDef.cell,
-                                                    cell.getContext()
-                                                )}
-                                            </TableCell>
-                                        ))}
-                                    </TableRow>
-                                    {renderSubComponent && row.getIsExpanded() && (
-                                        <TableRow className="border-0 hover:bg-transparent">
-                                            <TableCell colSpan={allColumns.length} className="p-0">
-                                                {renderSubComponent(row)}
-                                            </TableCell>
-                                        </TableRow>
-                                    )}
-                                </Fragment>
+                                <MemoTableRow
+                                    key={row.id}
+                                    row={row}
+                                    rowIndex={rowIndex}
+                                    isSelected={row.getIsSelected()}
+                                    isExpanded={row.getIsExpanded()}
+                                    isFocused={isRowFocused(rowIndex)}
+                                    tabIndex={isRowFocused(rowIndex) ? 0 : -1}
+                                    hasSelection={hasSelection}
+                                    handleRowClick={handleRowClick}
+                                    handleRowMouseDown={handleRowMouseDown}
+                                    onRowClick={onRowClick}
+                                    rowRefCallback={rowRefCallback}
+                                    allColumnsLength={allColumns.length}
+                                    renderSubComponent={renderSubComponent}
+                                    focusRowAt={focusRowAt}
+                                />
                             ))
                         ) : loading ? (
                             Array.from({ length: 5 }).map((_, i) => (

--- a/frontend/src/app/[locale]/(cms)/cms/tables/locations/locations-table.tsx
+++ b/frontend/src/app/[locale]/(cms)/cms/tables/locations/locations-table.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { Archive, ChevronsUp } from "lucide-react";
@@ -46,7 +46,7 @@ export function LocationsTable() {
         data: infiniteData,
         fetchNextPage,
         hasNextPage,
-    } = useGetInfiniteLocations(q ? { q } : undefined);
+    } = useGetInfiniteLocations({ limit: 50, ...(q ? { q } : {}) });
 
     const { data: hallsResult, isLoading: hallsLoading } = useGetHalls({
         pagination: { limit: 1000 },
@@ -107,6 +107,12 @@ export function LocationsTable() {
         selectedChildCount: selectedHallCount,
         clearSelection,
     } = useParentChildSelection<Location>(hallsByLocation);
+
+    // Stable ref for childSelection so renderHalls doesn't recreate on child toggle
+    const childSelectionRef = useRef(childSelection);
+    useEffect(() => {
+        childSelectionRef.current = childSelection;
+    }, [childSelection]);
 
     const spotlightItems: SpotlightItem[] = spotlight
         ? [{ kind: "plain", src: spotlight.src, alt: spotlight.alt }]
@@ -208,13 +214,13 @@ export function LocationsTable() {
                 <MemoSubTable
                     items={halls}
                     columns={hallCols}
-                    rowSelection={childSelection.get(locationId)}
+                    rowSelection={childSelectionRef.current.get(locationId)}
                     onRowSelectionChange={getChildHandler(locationId)}
                     getRowId={getHallRowId}
                 />
             );
         },
-        [childSelection, getChildHandler, getHallRowId, hallCols, hallsByLocation, hallsLoading]
+        [getChildHandler, getHallRowId, hallCols, hallsByLocation, hallsLoading]
     );
 
     const hasExpanded = Object.keys(expanded).length > 0;

--- a/frontend/src/app/[locale]/(cms)/cms/tables/locations/locations-table.tsx
+++ b/frontend/src/app/[locale]/(cms)/cms/tables/locations/locations-table.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { Archive, ChevronsUp } from "lucide-react";
@@ -100,19 +100,13 @@ export function LocationsTable() {
     const {
         parentSelection,
         setParentSelection,
-        childSelection,
+        childSelectionRef,
         getChildHandler,
         selectColumn,
         selectedParentCount: selectedLocationCount,
         selectedChildCount: selectedHallCount,
         clearSelection,
     } = useParentChildSelection<Location>(hallsByLocation);
-
-    // Stable ref for childSelection so renderHalls doesn't recreate on child toggle
-    const childSelectionRef = useRef(childSelection);
-    useEffect(() => {
-        childSelectionRef.current = childSelection;
-    }, [childSelection]);
 
     const spotlightItems: SpotlightItem[] = spotlight
         ? [{ kind: "plain", src: spotlight.src, alt: spotlight.alt }]
@@ -220,7 +214,7 @@ export function LocationsTable() {
                 />
             );
         },
-        [getChildHandler, getHallRowId, hallCols, hallsByLocation, hallsLoading]
+        [childSelectionRef, getChildHandler, getHallRowId, hallCols, hallsByLocation, hallsLoading]
     );
 
     const hasExpanded = Object.keys(expanded).length > 0;

--- a/frontend/src/app/[locale]/(cms)/cms/tables/performers/performers-table.tsx
+++ b/frontend/src/app/[locale]/(cms)/cms/tables/performers/performers-table.tsx
@@ -32,7 +32,7 @@ export function PerformersTable() {
         fetchNextPage,
         hasNextPage,
         isLoading,
-    } = useGetInfiniteArtists({ q });
+    } = useGetInfiniteArtists({ limit: 50, q });
 
     const artists = useMemo(
         () => infiniteData?.pages.flatMap((page) => page.data) ?? [],

--- a/frontend/src/app/[locale]/(cms)/cms/tables/productions/productions-table.tsx
+++ b/frontend/src/app/[locale]/(cms)/cms/tables/productions/productions-table.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { useLocale, useTranslations } from "next-intl";
 import { Archive, ChevronsUp } from "lucide-react";
@@ -39,7 +39,7 @@ export function ProductionsTable() {
         data: infiniteData,
         fetchNextPage,
         hasNextPage,
-    } = useGetInfiniteProductions(q ? { q } : undefined);
+    } = useGetInfiniteProductions({ limit: 50, ...(q ? { q } : {}) });
     const deleteProduction = useDeleteProduction();
 
     const { data: eventsResult, isLoading: eventsLoading } = useGetEvents();
@@ -82,6 +82,12 @@ export function ProductionsTable() {
         selectedChildCount: selectedEventCount,
         clearSelection,
     } = useParentChildSelection<Production>(eventsByProduction);
+
+    // Stable ref for childSelection so renderEvents doesn't recreate on child toggle
+    const childSelectionRef = useRef(childSelection);
+    useEffect(() => {
+        childSelectionRef.current = childSelection;
+    }, [childSelection]);
 
     const handleEditProduction = useCallback(
         (production: Production) => {
@@ -226,20 +232,13 @@ export function ProductionsTable() {
                 <MemoSubTable
                     items={events}
                     columns={eventCols}
-                    rowSelection={childSelection.get(productionId)}
+                    rowSelection={childSelectionRef.current.get(productionId)}
                     onRowSelectionChange={getChildHandler(productionId)}
                     getRowId={getEventRowId}
                 />
             );
         },
-        [
-            childSelection,
-            eventCols,
-            eventsByProduction,
-            eventsLoading,
-            getChildHandler,
-            getEventRowId,
-        ]
+        [eventCols, eventsByProduction, eventsLoading, getChildHandler, getEventRowId]
     );
 
     const hasExpanded = Object.keys(expanded).length > 0;

--- a/frontend/src/app/[locale]/(cms)/cms/tables/productions/productions-table.tsx
+++ b/frontend/src/app/[locale]/(cms)/cms/tables/productions/productions-table.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { useLocale, useTranslations } from "next-intl";
 import { Archive, ChevronsUp } from "lucide-react";
@@ -76,18 +76,13 @@ export function ProductionsTable() {
         parentSelection,
         setParentSelection,
         childSelection,
+        childSelectionRef,
         getChildHandler,
         selectColumn,
         selectedParentCount: selectedProductionCount,
         selectedChildCount: selectedEventCount,
         clearSelection,
     } = useParentChildSelection<Production>(eventsByProduction);
-
-    // Stable ref for childSelection so renderEvents doesn't recreate on child toggle
-    const childSelectionRef = useRef(childSelection);
-    useEffect(() => {
-        childSelectionRef.current = childSelection;
-    }, [childSelection]);
 
     const handleEditProduction = useCallback(
         (production: Production) => {
@@ -238,7 +233,14 @@ export function ProductionsTable() {
                 />
             );
         },
-        [eventCols, eventsByProduction, eventsLoading, getChildHandler, getEventRowId]
+        [
+            childSelectionRef,
+            eventCols,
+            eventsByProduction,
+            eventsLoading,
+            getChildHandler,
+            getEventRowId,
+        ]
     );
 
     const hasExpanded = Object.keys(expanded).length > 0;

--- a/frontend/src/app/[locale]/(cms)/cms/tables/use-parent-child-selection.tsx
+++ b/frontend/src/app/[locale]/(cms)/cms/tables/use-parent-child-selection.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { MutableRefObject } from "react";
 import type { ColumnDef, OnChangeFn, Row, RowSelectionState } from "@tanstack/react-table";
 
 import type { Dispatch, SetStateAction } from "react";
@@ -9,6 +10,7 @@ export function useParentChildSelection<TParent extends { id: string }>(
     parentSelection: RowSelectionState;
     setParentSelection: Dispatch<SetStateAction<RowSelectionState>>;
     childSelection: Map<string, RowSelectionState>;
+    childSelectionRef: MutableRefObject<Map<string, RowSelectionState>>;
     getChildHandler: (parentId: string) => OnChangeFn<RowSelectionState>;
     selectColumn: ColumnDef<TParent>;
     selectedParentCount: number;
@@ -131,6 +133,7 @@ export function useParentChildSelection<TParent extends { id: string }>(
         parentSelection,
         setParentSelection,
         childSelection,
+        childSelectionRef,
         getChildHandler,
         selectColumn,
         selectedParentCount,

--- a/frontend/src/app/[locale]/(cms)/cms/tables/use-parent-child-selection.tsx
+++ b/frontend/src/app/[locale]/(cms)/cms/tables/use-parent-child-selection.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type { ColumnDef, OnChangeFn, RowSelectionState } from "@tanstack/react-table";
+import type { ColumnDef, OnChangeFn, Row, RowSelectionState } from "@tanstack/react-table";
 
 import type { Dispatch, SetStateAction } from "react";
 
@@ -17,9 +17,6 @@ export function useParentChildSelection<TParent extends { id: string }>(
 } {
     const [parentSelection, setParentSelection] = useState<RowSelectionState>({});
     const [childSelection, setChildSelection] = useState<Map<string, RowSelectionState>>(new Map());
-    // Force re-render counter used to give select cells a changing key so React
-    // never skips re-rendering them after a selection toggle.
-    const [toggleRev, setToggleRev] = useState(0);
 
     // Use refs to access latest state without triggering re-renders of the column definition
     const childSelectionRef = useRef(childSelection);
@@ -60,26 +57,25 @@ export function useParentChildSelection<TParent extends { id: string }>(
     }, [getChildHandler]);
 
     // Stable select column - never recreate the column definition.
-    // toggleRev is read inside the cell renderer via closure; we deliberately
-    // keep the deps empty so TanStack Table does not re-initialise the table.
+    // We deliberately keep the deps empty so TanStack Table does not re-initialise the table.
 
     const selectColumn = useMemo<ColumnDef<TParent>>(
         () => ({
             id: "select",
             header: () => null,
-            cell: ({ row }) => {
+            cell: ({ row, _sel }: { row: Row<TParent>; _sel?: boolean }) => {
                 const parentId = row.original.id;
                 // Read from refs to get latest state without re-rendering
                 const childSel = childSelectionRef.current.get(parentId) ?? {};
                 const selectedChildCount = Object.values(childSel).filter(Boolean).length;
-                const isChecked = row.getIsSelected();
+                const isChecked = _sel ?? row.getIsSelected();
                 const isIndeterminate = !isChecked && selectedChildCount > 0;
+                const isActive = isChecked || isIndeterminate;
 
                 return (
                     <div
-                        key={`sel-${toggleRev}`}
                         className={`flex size-4 items-center justify-center border ${
-                            isChecked || isIndeterminate
+                            isActive
                                 ? "border-foreground bg-foreground text-background"
                                 : "border-foreground/30"
                         }`}
@@ -94,11 +90,9 @@ export function useParentChildSelection<TParent extends { id: string }>(
                                 ? Object.fromEntries(children.map((c) => [c.id, true]))
                                 : {};
                             handleChildSelect(parentId)(nextChildSel);
-                            // Bump rev so the cell key changes and React repaints the checkbox immediately
-                            setToggleRev((r) => r + 1);
                         }}
                     >
-                        {(isChecked || isIndeterminate) && (
+                        {isActive && (
                             <svg
                                 xmlns="http://www.w3.org/2000/svg"
                                 width="14"
@@ -119,7 +113,6 @@ export function useParentChildSelection<TParent extends { id: string }>(
             enableSorting: false,
             enableHiding: false,
         }),
-        // eslint-disable-next-line react-hooks/exhaustive-deps
         [] // Never recreate - use refs for all dynamic values
     );
 

--- a/frontend/src/app/[locale]/(cms)/cms/tables/use-table-selection.tsx
+++ b/frontend/src/app/[locale]/(cms)/cms/tables/use-table-selection.tsx
@@ -148,6 +148,10 @@ export function useTableSelection<TData>({
     const toggleRowRef = useRef(toggleRow);
     const selectOnlyRef = useRef(selectOnly);
     const focusRowRef = useRef(focusRow);
+    const focusedRowIndexRef = useRef(focusedRowIndex);
+    const clearSelectionRef = useRef(clearSelection);
+    const onRowSelectionChangeRef = useRef(onRowSelectionChange);
+    const onJumpToEndRef = useRef(onJumpToEnd);
 
     useEffect(() => {
         anchorRowIdRef.current = anchorRowId;
@@ -156,7 +160,22 @@ export function useTableSelection<TData>({
         toggleRowRef.current = toggleRow;
         selectOnlyRef.current = selectOnly;
         focusRowRef.current = focusRow;
-    }, [anchorRowId, rows, selectRange, toggleRow, selectOnly, focusRow]);
+        focusedRowIndexRef.current = focusedRowIndex;
+        clearSelectionRef.current = clearSelection;
+        onRowSelectionChangeRef.current = onRowSelectionChange;
+        onJumpToEndRef.current = onJumpToEnd;
+    }, [
+        anchorRowId,
+        rows,
+        selectRange,
+        toggleRow,
+        selectOnly,
+        focusRow,
+        focusedRowIndex,
+        clearSelection,
+        onRowSelectionChange,
+        onJumpToEnd,
+    ]);
 
     const handleRowClick = useCallback(
         (row: Row<TData>, event: React.MouseEvent) => {
@@ -202,7 +221,13 @@ export function useTableSelection<TData>({
 
     const processKeyEvent = useCallback(
         (event: KeyboardEvent) => {
-            if (!enableSelection || rows.length === 0) return;
+            if (!enableSelection) return;
+
+            const rows = rowsRef.current;
+            const focusedIdx = focusedRowIndexRef.current;
+            const anchorId = anchorRowIdRef.current;
+
+            if (rows.length === 0) return;
 
             const target = event.target as HTMLElement;
             const isTyping =
@@ -214,86 +239,74 @@ export function useTableSelection<TData>({
 
             if (event.key === "ArrowDown" || event.key === "j") {
                 event.preventDefault();
-                const next =
-                    focusedRowIndex === -1 ? 0 : Math.min(focusedRowIndex + 1, rows.length - 1);
-                if (event.shiftKey && anchorRowId) {
-                    selectRange(anchorRowId, rows[next].id);
+                const next = focusedIdx === -1 ? 0 : Math.min(focusedIdx + 1, rows.length - 1);
+                if (event.shiftKey && anchorId) {
+                    selectRangeRef.current(anchorId, rows[next].id);
                 }
-                focusRow(next);
+                focusRowRef.current(next);
             } else if (event.key === "ArrowUp" || event.key === "k") {
                 event.preventDefault();
-                const next = focusedRowIndex === -1 ? -1 : Math.max(focusedRowIndex - 1, 0);
-                if (next >= 0 && event.shiftKey && anchorRowId) {
-                    selectRange(anchorRowId, rows[next].id);
+                const next = focusedIdx === -1 ? -1 : Math.max(focusedIdx - 1, 0);
+                if (next >= 0 && event.shiftKey && anchorId) {
+                    selectRangeRef.current(anchorId, rows[next].id);
                 }
-                if (next >= 0) focusRow(next);
+                if (next >= 0) focusRowRef.current(next);
             } else if (event.key === "g") {
                 const now = Date.now();
                 if (lastKeyRef.current?.key === "g" && now - lastKeyRef.current.time < 500) {
                     event.preventDefault();
-                    focusRow(0);
+                    focusRowRef.current(0);
                     lastKeyRef.current = null;
                 } else {
                     lastKeyRef.current = { key: "g", time: now };
                 }
             } else if (event.key === "G") {
                 event.preventDefault();
-                if (onJumpToEnd) {
-                    onJumpToEnd().then(() => {
-                        focusRow(rows.length - 1);
+                if (onJumpToEndRef.current) {
+                    onJumpToEndRef.current().then(() => {
+                        focusRowRef.current(rowsRef.current.length - 1);
                     });
                 } else {
-                    focusRow(rows.length - 1);
+                    focusRowRef.current(rows.length - 1);
                 }
             } else if (event.key === "v") {
                 event.preventDefault();
-                if (focusedRowIndex >= 0 && focusedRowIndex < rows.length) {
-                    const row = rows[focusedRowIndex];
-                    toggleRow(row.id);
+                if (focusedIdx >= 0 && focusedIdx < rows.length) {
+                    const row = rows[focusedIdx];
+                    toggleRowRef.current(row.id);
                     setAnchorRowId(row.id);
                 }
             } else if (event.key === " ") {
                 event.preventDefault();
-                if (focusedRowIndex === -1 && rows.length > 0) {
-                    focusRow(0);
+                if (focusedIdx === -1 && rows.length > 0) {
+                    focusRowRef.current(0);
                     const row = rows[0];
-                    toggleRow(row.id);
+                    toggleRowRef.current(row.id);
                     setAnchorRowId(row.id);
-                } else if (focusedRowIndex >= 0 && focusedRowIndex < rows.length) {
-                    const row = rows[focusedRowIndex];
-                    if (event.shiftKey && anchorRowId) {
-                        selectRange(anchorRowId, row.id);
+                } else if (focusedIdx >= 0 && focusedIdx < rows.length) {
+                    const row = rows[focusedIdx];
+                    if (event.shiftKey && anchorId) {
+                        selectRangeRef.current(anchorId, row.id);
                     } else {
-                        toggleRow(row.id);
+                        toggleRowRef.current(row.id);
                         setAnchorRowId(row.id);
                     }
                 }
             } else if (event.key === "Escape") {
                 event.preventDefault();
-                clearSelection();
+                clearSelectionRef.current();
             } else if (event.key === "a" && (event.metaKey || event.ctrlKey)) {
                 event.preventDefault();
                 const next: RowSelectionState = {};
                 for (const r of rows) {
                     next[r.id] = true;
                 }
-                onRowSelectionChange?.(next);
+                onRowSelectionChangeRef.current?.(next);
                 setAnchorRowId(rows[0]?.id ?? null);
-                focusRow(0);
+                focusRowRef.current(0);
             }
         },
-        [
-            enableSelection,
-            rows,
-            focusedRowIndex,
-            anchorRowId,
-            selectRange,
-            toggleRow,
-            clearSelection,
-            onRowSelectionChange,
-            focusRow,
-            onJumpToEnd,
-        ]
+        [enableSelection]
     );
 
     useEffect(() => {

--- a/frontend/src/components/cms/load-more-sentinel.tsx
+++ b/frontend/src/components/cms/load-more-sentinel.tsx
@@ -34,7 +34,7 @@ export function LoadMoreSentinel({ hasNextPage, onLoadMore }: LoadMoreSentinelPr
 
         const check = () => {
             const { scrollTop, scrollHeight, clientHeight } = container;
-            // Prefetch when within 3 viewport heights of the bottom so fast
+            // Prefetch when within 5 viewport heights of the bottom so fast
             // scrolling never outruns the data pipeline.
             if (scrollHeight - scrollTop - clientHeight < clientHeight * 5) {
                 onLoadMoreRef.current();

--- a/frontend/src/components/cms/load-more-sentinel.tsx
+++ b/frontend/src/components/cms/load-more-sentinel.tsx
@@ -34,7 +34,9 @@ export function LoadMoreSentinel({ hasNextPage, onLoadMore }: LoadMoreSentinelPr
 
         const check = () => {
             const { scrollTop, scrollHeight, clientHeight } = container;
-            if (scrollHeight - scrollTop - clientHeight < 400) {
+            // Prefetch when within 3 viewport heights of the bottom so fast
+            // scrolling never outruns the data pipeline.
+            if (scrollHeight - scrollTop - clientHeight < clientHeight * 5) {
                 onLoadMoreRef.current();
             }
         };

--- a/frontend/src/hooks/api/query-keys.ts
+++ b/frontend/src/hooks/api/query-keys.ts
@@ -65,8 +65,8 @@ export const queryKeys = {
         all: ["artists"] as const,
         list: (params?: { q?: string }) =>
             params?.q ? (["artists", "list", params] as const) : (["artists", "list"] as const),
-        infinite: (params?: { q?: string }) =>
-            params?.q
+        infinite: (params?: { q?: string; limit?: number }) =>
+            params?.q || params?.limit
                 ? (["artists", "infinite", params] as const)
                 : (["artists", "infinite"] as const),
         detail: (id: string) => ["artists", id] as const,

--- a/frontend/src/hooks/api/useArtists.ts
+++ b/frontend/src/hooks/api/useArtists.ts
@@ -22,10 +22,12 @@ type ArtistUpdateInput = { id: string; name: string; slug: string };
 const fetchArtistsPage = async (params: {
     q?: string;
     cursor?: string;
+    limit?: number;
 }): Promise<PaginatedResult<Artist>> => {
     const search = new URLSearchParams();
     if (params.q) search.set("q", params.q);
     if (params.cursor) search.set("cursor", params.cursor);
+    if (params.limit) search.set("limit", String(params.limit));
     const url = `/artists${search.toString() ? `?${search}` : ""}`;
     const { data } = await api.get<GetAllArtistsResponse>(url);
     return {
@@ -57,12 +59,13 @@ export const useGetArtists = (options?: { q?: string }) => {
     });
 };
 
-export const useGetInfiniteArtists = (params?: { q?: string }) => {
+export const useGetInfiniteArtists = (params?: { q?: string; limit?: number }) => {
     const q = params?.q || undefined;
+    const limit = params?.limit;
     return useInfiniteQuery({
-        queryKey: queryKeys.artists.infinite({ q }),
+        queryKey: queryKeys.artists.infinite({ q, limit }),
         queryFn: ({ pageParam }) =>
-            fetchArtistsPage({ q, cursor: pageParam as string | undefined }),
+            fetchArtistsPage({ q, limit, cursor: pageParam as string | undefined }),
         initialPageParam: undefined as string | undefined,
         getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
     });

--- a/frontend/src/hooks/api/useCollections.ts
+++ b/frontend/src/hooks/api/useCollections.ts
@@ -80,10 +80,13 @@ export const useGetCollectionBySlug = (slug: string, options?: { enabled?: boole
     });
 };
 
-export const useGetInfiniteCollections = (options?: { enabled?: boolean }) => {
+export const useGetInfiniteCollections = (
+    params?: Omit<PaginationParams, "cursor">,
+    options?: { enabled?: boolean }
+) => {
     return useInfiniteQuery({
-        queryKey: queryKeys.collections.cmsInfinite(),
-        queryFn: async ({ pageParam }) => fetchCollectionsPage({ cursor: pageParam }),
+        queryKey: queryKeys.collections.cmsInfinite(params),
+        queryFn: async ({ pageParam }) => fetchCollectionsPage({ ...params, cursor: pageParam }),
         getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
         initialPageParam: null as string | null,
         ...options,


### PR DESCRIPTION
**Description**
Selecting a row in the CMS tables caused the entire table (up to 8k+ rows) to re-render, creating severe lag. Hovering rows also triggered full-table re-renders. Scrolling further increased lag as more rows accumulated in the DOM without cleanup.

Changes
Row-level memoization (data-table.tsx)
- Extracted each row into a MemoTableRow component wrapped in React.memo
- Custom comparator checks row.original (data reference — stable via TanStack Query structural sharing) instead of row (TanStack wrapper — recreated every data change)
- Result: selecting a row re-renders only that row. Loading new pages mounts only the 50 new rows — old rows skip re-render entirely
Keyboard navigation refactored (use-table-selection.tsx)
- processKeyEvent now reads all values (rows, focusedRowIndex, anchorRowId, etc.) from refs instead of capturing them via closure
- Callback is stable with only [enableSelection] as dep — no more listener re-registration on every render, keeping keyboard nav snappy regardless of table size
- Per-row onMouseEnter/onMouseLeave restored for focus tracking — fast now because only 2 rows re-render on focus change
Selection checkbox fix (data-table.tsx, use-parent-child-selection.tsx)
- Injected _sel (ground-truth isSelected prop) into every flexRender cell context
- Both default and custom select columns read _sel ?? row.getIsSelected() — preferring the prop over the potentially-stale TanStack method
- Removed the old toggleRev key-bumping hack that forced full cell remounts
Prefetch tuning (load-more-sentinel.tsx, 5 table components, 3 API hooks)
- Page size increased 20 → 50 (2.5× fewer network roundtrips)
- LoadMoreSentinel triggers at 5× viewport height (was fixed 400px), keeping data pipeline ahead of scroll
- Added limit support to artists and collections API hooks
Callback stability (productions-table.tsx, locations-table.tsx)
- renderEvents/renderHalls now use a childSelection ref, removing it from useCallback deps
- Prevents parent-row memo breakage when toggling child rows
- 
**Related Issue**
Fixes #

**How Has This Been Tested?**
- [x] Local manual testing
- [ ] Added/updated unit or integration tests
- [ ] Tested in the staging environment

**Developer Checklist:**
- [ ] I have performed a self-review of my own code.
- [ ] I have left comments in hard-to-understand areas of my code.
- [x] My changes generate no new warnings or console errors.
- [ ] I have updated the documentation (if applicable).

**Screenshots / Video (if UI/UX changed):**
