### PR TITLE
fix(search): debounced live search, uitdatabankType display, consistent image placeholders, and sidebar active state

### DIFF
--- a/frontend/src/app/[locale]/(app)/(with-footer)/locations/[slug]/page.tsx
+++ b/frontend/src/app/[locale]/(app)/(with-footer)/locations/[slug]/page.tsx
@@ -10,6 +10,7 @@ import { LoadingState } from "@/components/shared/loading-state";
 import { MasonryGrid } from "@/components/masonry";
 import { useGetLocationBySlug } from "@/hooks/api/useLocations";
 import { useGetHallsForLocation } from "@/hooks/api/useHalls";
+import { ImagePlaceholder } from "@/components/shared/image-placeholder";
 
 export default function LocationPage() {
     const { slug } = useParams<{ slug: string }>();
@@ -85,7 +86,7 @@ export default function LocationPage() {
             />
 
             {/* Hero banner */}
-            <div className="h-[200px] w-full bg-gradient-to-br from-[#CCC6BC] to-[#B5AEA4] sm:h-[300px] md:h-[360px]" />
+            <ImagePlaceholder className="h-[200px] w-full sm:h-[300px] md:h-[360px]" />
 
             <div className="mx-auto max-w-[960px] px-4 py-8 sm:px-10 sm:py-12">
                 <h1 className="font-display text-foreground text-[32px] leading-[1.1] font-bold tracking-[-0.03em] sm:text-[48px] md:text-[56px]">
@@ -136,7 +137,7 @@ export default function LocationPage() {
                             renderItem={(hall) => (
                                 <div className="border-foreground/20 border">
                                     <div className="relative aspect-[4/3] w-full overflow-hidden">
-                                        <div className="h-full w-full bg-gradient-to-br from-[#CCC6BC] to-[#B5AEA4]" />
+                                        <ImagePlaceholder className="h-full w-full" />
                                     </div>
                                     <div className="px-3 pt-3">
                                         <h2 className="font-display text-foreground text-[18px] leading-[1.15] font-bold tracking-[-0.02em]">

--- a/frontend/src/app/[locale]/(app)/(with-footer)/productions/[id]/page.tsx
+++ b/frontend/src/app/[locale]/(app)/(with-footer)/productions/[id]/page.tsx
@@ -241,7 +241,7 @@ export default function ProductionPage({
             {/* Part of Collections */}
             {publicCollections.length > 0 && (
                 <section className="border-foreground/10 border-t px-6 py-10 sm:px-10">
-                    <h2 className="text-muted-foreground mb-6 font-mono text-[9px] tracking-[2px] uppercase">
+                    <h2 className="text-muted-foreground mb-6 font-mono text-[10px] font-medium tracking-[1.6px] uppercase">
                         {tProd("partOfTitle")}
                     </h2>
                     <ul className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">

--- a/frontend/src/app/[locale]/(app)/(with-footer)/productions/[id]/page.tsx
+++ b/frontend/src/app/[locale]/(app)/(with-footer)/productions/[id]/page.tsx
@@ -241,7 +241,7 @@ export default function ProductionPage({
             {/* Part of Collections */}
             {publicCollections.length > 0 && (
                 <section className="border-foreground/10 border-t px-6 py-10 sm:px-10">
-                    <h2 className="text-muted-foreground mb-6 font-mono text-[10px] font-medium tracking-[1.6px] uppercase">
+                    <h2 className="font-display text-foreground mb-6 text-[22px] font-bold tracking-[-0.02em]">
                         {tProd("partOfTitle")}
                     </h2>
                     <ul className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">

--- a/frontend/src/app/[locale]/(app)/(with-footer)/productions/[id]/page.tsx
+++ b/frontend/src/app/[locale]/(app)/(with-footer)/productions/[id]/page.tsx
@@ -32,6 +32,7 @@ import { ProductionSidebar } from "@/components/productionpage/production-sideba
 import { ProductionRelated } from "@/components/productionpage/production-related";
 import { ProductionArticles } from "@/components/productionpage/production-articles";
 import { EntityTagStrip } from "@/components/shared/entity-tag-strip";
+import { ImagePlaceholder } from "@/components/shared/image-placeholder";
 import { Production, ProductionRow } from "@/types/models/production.types";
 
 // Helper to get title from Production or ProductionRow
@@ -266,7 +267,7 @@ export default function ProductionPage({
                                                     className="object-cover"
                                                 />
                                             ) : (
-                                                <div className="from-muted to-muted/40 h-full w-full bg-gradient-to-br" />
+                                                <ImagePlaceholder className="h-full w-full" />
                                             )}
                                         </div>
                                         <div className="flex min-w-0 flex-col justify-center gap-1">

--- a/frontend/src/app/[locale]/(app)/(with-footer)/productions/[id]/page.tsx
+++ b/frontend/src/app/[locale]/(app)/(with-footer)/productions/[id]/page.tsx
@@ -255,7 +255,7 @@ export default function ProductionPage({
                                 <li key={col.id}>
                                     <Link
                                         href={`/collections/${col.slug}`}
-                                        className="border-foreground/10 hover:border-foreground/30 hover:bg-muted/5 group flex gap-4 border p-4 transition-colors"
+                                        className="border-border/70 hover:bg-foreground/[0.06] group flex gap-4 border p-4 transition-colors"
                                     >
                                         <div className="bg-muted relative h-20 w-20 shrink-0 overflow-hidden">
                                             {col.coverImageUrl ? (

--- a/frontend/src/app/[locale]/(app)/search/page.tsx
+++ b/frontend/src/app/[locale]/(app)/search/page.tsx
@@ -132,6 +132,13 @@ export default function SearchPage() {
         [router, searchParams, pathname]
     );
 
+    useEffect(() => {
+        const trimmed = draftQuery.trim();
+        if (trimmed === query) return;
+        const timer = setTimeout(() => handleSearch(draftQuery), 300);
+        return () => clearTimeout(timer);
+    }, [draftQuery, handleSearch, query]);
+
     const handleSortChange = useCallback(
         (newSort: ProductionSortOption) => {
             const params = new URLSearchParams(searchParams.toString());

--- a/frontend/src/app/[locale]/(cms)/cms/tables/data-table.tsx
+++ b/frontend/src/app/[locale]/(cms)/cms/tables/data-table.tsx
@@ -315,6 +315,7 @@ export function DataTable<TData, TValue>({
                     <div
                         role="checkbox"
                         aria-checked={selected}
+                        aria-label={t("selectRow")}
                         className={cn(
                             "flex size-4 items-center justify-center border",
                             selected
@@ -329,7 +330,7 @@ export function DataTable<TData, TValue>({
             enableSorting: false,
             enableHiding: false,
         }),
-        []
+        [t]
     );
 
     const expanderColumn = useMemo<ColumnDef<TData>>(

--- a/frontend/src/components/articles/article-card.tsx
+++ b/frontend/src/components/articles/article-card.tsx
@@ -56,7 +56,7 @@ export function ArticleCard({ article, locale }: ArticleCardProps) {
                             sizes="(max-width: 640px) 110px, 160px"
                         />
                     ) : (
-                        <ImagePlaceholder id={article.id} />
+                        <ImagePlaceholder id={article.id} className="absolute inset-0" />
                     )}
                 </div>
 

--- a/frontend/src/components/articles/article-card.tsx
+++ b/frontend/src/components/articles/article-card.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image";
 import { Link } from "@/i18n/routing";
 import { useTranslations } from "next-intl";
+import { ImagePlaceholder } from "@/components/shared/image-placeholder";
 
 import type { ArticleListItem } from "@/types/models/article.types";
 import { EntityTagStrip } from "@/components/shared/entity-tag-strip";
@@ -55,20 +56,7 @@ export function ArticleCard({ article, locale }: ArticleCardProps) {
                             sizes="(max-width: 640px) 110px, 160px"
                         />
                     ) : (
-                        <>
-                            <div
-                                className="absolute inset-0 opacity-[0.08]"
-                                style={{
-                                    backgroundImage:
-                                        "repeating-linear-gradient(45deg, currentColor 0 1px, transparent 1px 8px)",
-                                }}
-                            />
-                            <div className="absolute inset-0 flex items-center justify-center">
-                                <span className="text-muted-foreground/50 font-mono text-[9px] tracking-[2px] uppercase">
-                                    N°{article.id.slice(-3)}
-                                </span>
-                            </div>
-                        </>
+                        <ImagePlaceholder id={article.id} />
                     )}
                 </div>
 

--- a/frontend/src/components/cms/cms-sidebar.tsx
+++ b/frontend/src/components/cms/cms-sidebar.tsx
@@ -175,7 +175,7 @@ function SidebarContent({ onNavigate, showHeader = true }: SidebarContentProps) 
     }, [facets, pathname, router]);
 
     const isActive = (href: string) => {
-        return pathname.startsWith(href);
+        return pathname === href || pathname.startsWith(href + "/");
     };
 
     const handleNavClick = () => {

--- a/frontend/src/components/cms/cms-thumbnail.tsx
+++ b/frontend/src/components/cms/cms-thumbnail.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Image from "next/image";
+import { ImagePlaceholder } from "@/components/shared/image-placeholder";
 
 type CmsThumbnailProps = {
     src: string | null | undefined;
@@ -16,7 +17,7 @@ export function CmsThumbnail({ src, alt, size = 40, onClick }: CmsThumbnailProps
             {src ? (
                 <Image src={src} alt={alt} fill className="object-cover" sizes={`${size}px`} />
             ) : (
-                <div className="h-full w-full bg-gradient-to-br from-[#CCC6BC] to-[#B5AEA4]" />
+                <ImagePlaceholder className="h-full w-full" />
             )}
         </div>
     );

--- a/frontend/src/components/collections/CollectionHeader.tsx
+++ b/frontend/src/components/collections/CollectionHeader.tsx
@@ -6,6 +6,7 @@ import { LayoutGrid, List } from "lucide-react";
 import { useLocale, useTranslations } from "next-intl";
 import { Collection } from "@/types/models/collection.types";
 import { EntityTagStrip } from "@/components/shared/entity-tag-strip";
+import { ImagePlaceholder } from "@/components/shared/image-placeholder";
 
 function getLocalized(
     translations: { languageCode: string; title: string; description: string }[],
@@ -72,7 +73,7 @@ export function CollectionHeader({
                     />
                 </div>
             ) : (
-                <div className="mt-6 aspect-[16/7] w-full bg-gradient-to-br from-[#CCC6BC] to-[#B5AEA4]" />
+                <ImagePlaceholder className="mt-6 aspect-[16/7] w-full" />
             )}
 
             {/* Dateline bar */}

--- a/frontend/src/components/collections/CollectionHeader.tsx
+++ b/frontend/src/components/collections/CollectionHeader.tsx
@@ -6,7 +6,6 @@ import { LayoutGrid, List } from "lucide-react";
 import { useLocale, useTranslations } from "next-intl";
 import { Collection } from "@/types/models/collection.types";
 import { EntityTagStrip } from "@/components/shared/entity-tag-strip";
-import { ImagePlaceholder } from "@/components/shared/image-placeholder";
 
 function getLocalized(
     translations: { languageCode: string; title: string; description: string }[],
@@ -61,7 +60,7 @@ export function CollectionHeader({
             </h1>
 
             {/* Cover image */}
-            {collection.coverImageUrl ? (
+            {collection.coverImageUrl && (
                 <div className="relative mt-6 aspect-[16/7] w-full overflow-hidden">
                     <Image
                         src={collection.coverImageUrl}
@@ -72,8 +71,6 @@ export function CollectionHeader({
                         sizes="(max-width: 768px) 100vw, 1100px"
                     />
                 </div>
-            ) : (
-                <ImagePlaceholder className="mt-6 aspect-[16/7] w-full" />
             )}
 
             {/* Dateline bar */}

--- a/frontend/src/components/collections/EntityListItem.tsx
+++ b/frontend/src/components/collections/EntityListItem.tsx
@@ -10,6 +10,7 @@ import { useGetArticle } from "@/hooks/api/useArticles";
 import { useGetArtist } from "@/hooks/api/useArtists";
 import { useGetMedia } from "@/hooks/api/useMedia";
 import type { CollectionContentType, EntityGridItem } from "@/types/models/collection.types";
+import { ImagePlaceholder } from "@/components/shared/image-placeholder";
 
 interface ListShellProps {
     isLoading: boolean;
@@ -35,7 +36,7 @@ function ListShell({ isLoading, title, imageUrl, href, typeLabel, comment }: Lis
                         sizes="80px"
                     />
                 ) : (
-                    <div className="h-full w-full bg-gradient-to-br from-[#CCC6BC] to-[#B5AEA4]" />
+                    <ImagePlaceholder className="h-full w-full" />
                 )}
             </div>
             <div className="border-foreground/20 flex flex-col justify-center gap-1 border-l px-3 py-2">

--- a/frontend/src/components/homepage/articles-section/ArticlesSection.tsx
+++ b/frontend/src/components/homepage/articles-section/ArticlesSection.tsx
@@ -5,6 +5,7 @@ import { useLocale, useTranslations } from "next-intl";
 import { Link } from "@/i18n/routing";
 
 import type { ArticleListItem } from "@/types/models/article.types";
+import { ImagePlaceholder } from "@/components/shared/image-placeholder";
 
 interface ArticlesSectionProps {
     articles: ArticleListItem[];
@@ -62,7 +63,7 @@ function ArticleCard({ article, locale }: { article: ArticleListItem; locale: st
                         sizes="(min-width: 640px) 33vw, 100vw"
                     />
                 ) : (
-                    <div className="h-full w-full bg-gradient-to-br from-[#CCC6BC] to-[#B5AEA4]" />
+                    <ImagePlaceholder className="h-full w-full" />
                 )}
             </div>
 

--- a/frontend/src/components/homepage/featured-section/FeaturedSection.tsx
+++ b/frontend/src/components/homepage/featured-section/FeaturedSection.tsx
@@ -7,6 +7,7 @@ import type { Production } from "@/types/models/production.types";
 import { getLocalizedField } from "@/lib/locale";
 import { Link } from "@/i18n/routing";
 import { EntityTagStrip } from "@/components/shared/entity-tag-strip";
+import { ImagePlaceholder } from "@/components/shared/image-placeholder";
 
 interface FeaturedSectionProps {
     productions: Production[];
@@ -76,7 +77,7 @@ function FeaturedCard({
                         }
                     />
                 ) : (
-                    <div className="h-full w-full bg-gradient-to-br from-[#CCC6BC] to-[#B5AEA4]" />
+                    <ImagePlaceholder className="h-full w-full" />
                 )}
             </div>
 

--- a/frontend/src/components/masonry/card-shell.tsx
+++ b/frontend/src/components/masonry/card-shell.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import { Link } from "@/i18n/routing";
 import { UniformCardsContext } from "./masonry-grid";
 import { EntityTagStrip } from "@/components/shared/entity-tag-strip";
+import { ImagePlaceholder } from "@/components/shared/image-placeholder";
 import type { EntityTagSlim } from "@/types/models/taxonomy.types";
 
 const ASPECT_CLASSES = ["aspect-[4/3]", "aspect-[3/4]"] as const;
@@ -59,7 +60,7 @@ export function CardShell({
                         sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
                     />
                 ) : (
-                    <div className="h-full w-full bg-gradient-to-br from-[#CCC6BC] to-[#B5AEA4]" />
+                    <ImagePlaceholder className="h-full w-full" />
                 )}
             </div>
 

--- a/frontend/src/components/masonry/card-shell.tsx
+++ b/frontend/src/components/masonry/card-shell.tsx
@@ -7,7 +7,6 @@ import { UniformCardsContext } from "./masonry-grid";
 import { EntityTagStrip } from "@/components/shared/entity-tag-strip";
 import { ImagePlaceholder } from "@/components/shared/image-placeholder";
 import type { EntityTagSlim } from "@/types/models/taxonomy.types";
-import { ResultImagePlaceholder } from "@/components/searchpage/result-image-placeholder";
 
 const ASPECT_CLASSES = ["aspect-[4/3]", "aspect-[3/4]"] as const;
 
@@ -61,7 +60,7 @@ export function CardShell({
                         sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
                     />
                 ) : (
-                    <ResultImagePlaceholder id={index.toString()} />
+                    <ImagePlaceholder id={index.toString()} className="h-full w-full" />
                 )}
             </div>
 

--- a/frontend/src/components/productionpage/production-article.tsx
+++ b/frontend/src/components/productionpage/production-article.tsx
@@ -11,6 +11,7 @@ import { ImageSpotlight, type SpotlightItem } from "@/components/ui/image-spotli
 import type { Production } from "@/types/models/production.types";
 import type { Media } from "@/types/models/media.types";
 import type { Artist } from "@/types/models/artist.types";
+import { ImagePlaceholder } from "@/components/shared/image-placeholder";
 
 function stripHtmlAndDecode(html: string | null | undefined): string {
     if (!html) return "";
@@ -246,7 +247,7 @@ export function ProductionArticle({
                                 key={m.id ?? `placeholder-${i}`}
                                 className="relative aspect-[4/3] overflow-hidden bg-[#ccc6bc]"
                             >
-                                <div className="h-full w-full bg-gradient-to-tr from-[#CCC6BC] to-[#B5AEA4]" />
+                                <ImagePlaceholder className="h-full w-full" />
                             </div>
                         );
                     })}

--- a/frontend/src/components/productionpage/production-articles.tsx
+++ b/frontend/src/components/productionpage/production-articles.tsx
@@ -33,7 +33,7 @@ function ArticleCard({ article, locale }: { article: ArticleListItem; locale: st
                         sizes="(max-width: 640px) 100vw, 50vw"
                     />
                 ) : (
-                    <ImagePlaceholder />
+                    <ImagePlaceholder className="absolute inset-0" />
                 )}
             </div>
             {article.publishedAt && (

--- a/frontend/src/components/productionpage/production-articles.tsx
+++ b/frontend/src/components/productionpage/production-articles.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from "next-intl";
 
 import { Link } from "@/i18n/routing";
 import type { ArticleListItem } from "@/types/models/article.types";
+import { ImagePlaceholder } from "@/components/shared/image-placeholder";
 
 function formatPublishDate(dateStr: string, locale: string): string {
     return new Date(dateStr).toLocaleDateString(locale === "en" ? "en-GB" : "nl-BE", {
@@ -32,7 +33,7 @@ function ArticleCard({ article, locale }: { article: ArticleListItem; locale: st
                         sizes="(max-width: 640px) 100vw, 50vw"
                     />
                 ) : (
-                    <div className="absolute inset-0 bg-gradient-to-tr from-[#CCC6BC] to-[#B5AEA4] grayscale-[15%] transition-all duration-300 group-hover:grayscale-0" />
+                    <ImagePlaceholder />
                 )}
             </div>
             {article.publishedAt && (

--- a/frontend/src/components/productionpage/production-hero.tsx
+++ b/frontend/src/components/productionpage/production-hero.tsx
@@ -8,6 +8,7 @@ import { getLocalizedField } from "@/lib/locale";
 import { ImageSpotlight, type SpotlightItem } from "@/components/ui/image-spotlight";
 import type { Production } from "@/types/models/production.types";
 import type { Media } from "@/types/models/media.types";
+import { ImagePlaceholder } from "@/components/shared/image-placeholder";
 
 export function ProductionHero({
     production,
@@ -65,7 +66,7 @@ export function ProductionHero({
                         />
                     </button>
                 ) : (
-                    <div className="absolute inset-0 bg-gradient-to-br from-[#CCC6BC] to-[#B5AEA4]" />
+                    <ImagePlaceholder />
                 )}
                 <div className="bg-foreground/70 text-background/80 pointer-events-none absolute right-0 bottom-0 left-0 p-3 font-mono text-[8px] tracking-[1.2px] uppercase">
                     © {credit ?? t("imageCaptionFallback")}

--- a/frontend/src/components/productionpage/production-hero.tsx
+++ b/frontend/src/components/productionpage/production-hero.tsx
@@ -66,7 +66,7 @@ export function ProductionHero({
                         />
                     </button>
                 ) : (
-                    <ImagePlaceholder />
+                    <ImagePlaceholder className="absolute inset-0" />
                 )}
                 <div className="bg-foreground/70 text-background/80 pointer-events-none absolute right-0 bottom-0 left-0 p-3 font-mono text-[8px] tracking-[1.2px] uppercase">
                     © {credit ?? t("imageCaptionFallback")}

--- a/frontend/src/components/productionpage/production-related.tsx
+++ b/frontend/src/components/productionpage/production-related.tsx
@@ -7,6 +7,7 @@ import { Link } from "@/i18n/routing";
 import { getLocalizedField } from "@/lib/locale";
 import { useGetEntityMedia } from "@/hooks/api/useMedia";
 import type { Production } from "@/types/models/production.types";
+import { ImagePlaceholder } from "@/components/shared/image-placeholder";
 
 function formatUitdatabankType(raw: string | null, fallback: string): string {
     if (!raw) return fallback;
@@ -49,7 +50,7 @@ function RelatedProductionCard({ production, locale }: { production: Production;
                         sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 25vw"
                     />
                 ) : (
-                    <div className="absolute inset-0 bg-gradient-to-tr from-[#CCC6BC] to-[#B5AEA4] grayscale-[15%] transition-all duration-300 group-hover:grayscale-0" />
+                    <ImagePlaceholder />
                 )}
             </div>
             <div className="text-muted-foreground mb-1.5 line-clamp-1 font-mono text-[8px] tracking-[1.4px] uppercase">

--- a/frontend/src/components/productionpage/production-related.tsx
+++ b/frontend/src/components/productionpage/production-related.tsx
@@ -10,10 +10,7 @@ import type { Production } from "@/types/models/production.types";
 
 function formatUitdatabankType(raw: string | null, fallback: string): string {
     if (!raw) return fallback;
-    if (raw.startsWith("/api/") || raw.startsWith("http")) {
-        const last = raw.split("/").pop() ?? "";
-        return last ? `${fallback} ${last}` : fallback;
-    }
+    if (raw.startsWith("/api/") || raw.startsWith("http")) return fallback;
     return raw;
 }
 

--- a/frontend/src/components/productionpage/production-related.tsx
+++ b/frontend/src/components/productionpage/production-related.tsx
@@ -50,7 +50,7 @@ function RelatedProductionCard({ production, locale }: { production: Production;
                         sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 25vw"
                     />
                 ) : (
-                    <ImagePlaceholder />
+                    <ImagePlaceholder className="absolute inset-0" />
                 )}
             </div>
             <div className="text-muted-foreground mb-1.5 line-clamp-1 font-mono text-[8px] tracking-[1.4px] uppercase">

--- a/frontend/src/components/productionpage/production-related.tsx
+++ b/frontend/src/components/productionpage/production-related.tsx
@@ -8,9 +8,22 @@ import { getLocalizedField } from "@/lib/locale";
 import { useGetEntityMedia } from "@/hooks/api/useMedia";
 import type { Production } from "@/types/models/production.types";
 
+function formatUitdatabankType(raw: string | null, fallback: string): string {
+    if (!raw) return fallback;
+    if (raw.startsWith("/api/") || raw.startsWith("http")) {
+        const last = raw.split("/").pop() ?? "";
+        return last ? `${fallback} ${last}` : fallback;
+    }
+    return raw;
+}
+
 function RelatedProductionCard({ production, locale }: { production: Production; locale: string }) {
     const t = useTranslations("ProductionPage");
     const { data: media = [] } = useGetEntityMedia("production", production.id);
+    const typeLabel = formatUitdatabankType(
+        production.uitdatabankType,
+        t("relatedProductionFallback")
+    );
 
     const title = getLocalizedField(production, "title", locale) ?? production.slug;
     const artist = getLocalizedField(production, "artist", locale);
@@ -43,8 +56,7 @@ function RelatedProductionCard({ production, locale }: { production: Production;
                 )}
             </div>
             <div className="text-muted-foreground mb-1.5 line-clamp-1 font-mono text-[8px] tracking-[1.4px] uppercase">
-                {production.uitdatabankType ?? t("relatedProductionFallback")} ·{" "}
-                {t("relatedArchive")}
+                {typeLabel} · {t("relatedArchive")}
             </div>
             <div className="font-display text-foreground mb-0.5 line-clamp-2 text-[16px] leading-[1.2] font-bold tracking-[-0.02em]">
                 {title}

--- a/frontend/src/components/searchpage/article-list/ArticleList.tsx
+++ b/frontend/src/components/searchpage/article-list/ArticleList.tsx
@@ -44,7 +44,7 @@ function ArticleItem({ article, locale }: ArticleItemProps) {
                         sizes="180px"
                     />
                 ) : (
-                    <ImagePlaceholder id={article.id} />
+                    <ImagePlaceholder id={article.id} className="absolute inset-0" />
                 )}
             </div>
 

--- a/frontend/src/components/searchpage/article-list/ArticleList.tsx
+++ b/frontend/src/components/searchpage/article-list/ArticleList.tsx
@@ -7,7 +7,7 @@ import { Link } from "@/i18n/routing";
 import type { ArticleListItem } from "@/types/models/article.types";
 import { LoadingState } from "@/components/shared/loading-state";
 import { EntityTagStrip } from "@/components/shared/entity-tag-strip";
-import { ResultImagePlaceholder } from "@/components/searchpage/result-image-placeholder";
+import { ImagePlaceholder } from "@/components/shared/image-placeholder";
 
 interface ArticleItemProps {
     article: ArticleListItem;
@@ -44,7 +44,7 @@ function ArticleItem({ article, locale }: ArticleItemProps) {
                         sizes="180px"
                     />
                 ) : (
-                    <ResultImagePlaceholder id={article.id} />
+                    <ImagePlaceholder id={article.id} />
                 )}
             </div>
 

--- a/frontend/src/components/searchpage/artist-list/ArtistList.tsx
+++ b/frontend/src/components/searchpage/artist-list/ArtistList.tsx
@@ -6,7 +6,7 @@ import { Link } from "@/i18n/routing";
 
 import type { Artist } from "@/types/models/artist.types";
 import { LoadingState } from "@/components/shared/loading-state";
-import { ResultImagePlaceholder } from "@/components/searchpage/result-image-placeholder";
+import { ImagePlaceholder } from "@/components/shared/image-placeholder";
 
 interface ArtistItemProps {
     artist: Artist;
@@ -30,7 +30,7 @@ function ArtistItem({ artist }: ArtistItemProps) {
                         sizes="180px"
                     />
                 ) : (
-                    <ResultImagePlaceholder id={artist.id} />
+                    <ImagePlaceholder id={artist.id} />
                 )}
             </div>
 

--- a/frontend/src/components/searchpage/artist-list/ArtistList.tsx
+++ b/frontend/src/components/searchpage/artist-list/ArtistList.tsx
@@ -30,7 +30,7 @@ function ArtistItem({ artist }: ArtistItemProps) {
                         sizes="180px"
                     />
                 ) : (
-                    <ImagePlaceholder id={artist.id} />
+                    <ImagePlaceholder id={artist.id} className="absolute inset-0" />
                 )}
             </div>
 

--- a/frontend/src/components/searchpage/filterProductionsByArchiveFilters.ts
+++ b/frontend/src/components/searchpage/filterProductionsByArchiveFilters.ts
@@ -1,0 +1,40 @@
+import type { Event } from "@/types/models/event.types";
+import type { Production } from "@/types/models/production.types";
+
+export type ArchiveFilters = {
+    categories: Set<string>;
+    dateRange: [Date, Date];
+};
+
+export function filterProductionsByArchiveFilters(
+    productions: Production[],
+    events: Event[] | undefined,
+    filters: ArchiveFilters,
+    options?: { hasActiveDateFilter?: boolean }
+): Production[] {
+    if (!filters.categories.has("productions")) {
+        return [];
+    }
+
+    if (!options?.hasActiveDateFilter) {
+        return productions;
+    }
+
+    if (!events) {
+        return productions;
+    }
+
+    const start = filters.dateRange[0].getTime();
+    const end = filters.dateRange[1].getTime();
+
+    const matchingProductionIds = new Set(
+        events
+            .filter((event) => {
+                const startsAt = new Date(event.startsAt).getTime();
+                return Number.isFinite(startsAt) && startsAt >= start && startsAt <= end;
+            })
+            .map((event) => event.productionId)
+    );
+
+    return productions.filter((production) => matchingProductionIds.has(production.id));
+}

--- a/frontend/src/components/searchpage/location-list/LocationList.tsx
+++ b/frontend/src/components/searchpage/location-list/LocationList.tsx
@@ -6,7 +6,7 @@ import { Link } from "@/i18n/routing";
 
 import type { Location } from "@/types/models/location.types";
 import { LoadingState } from "@/components/shared/loading-state";
-import { ResultImagePlaceholder } from "@/components/searchpage/result-image-placeholder";
+import { ImagePlaceholder } from "@/components/shared/image-placeholder";
 
 interface LocationItemProps {
     location: Location;
@@ -28,7 +28,7 @@ function LocationItem({ location }: LocationItemProps) {
                         sizes="180px"
                     />
                 ) : (
-                    <ResultImagePlaceholder id={location.id} />
+                    <ImagePlaceholder id={location.id} />
                 )}
             </div>
 

--- a/frontend/src/components/searchpage/location-list/LocationList.tsx
+++ b/frontend/src/components/searchpage/location-list/LocationList.tsx
@@ -28,7 +28,7 @@ function LocationItem({ location }: LocationItemProps) {
                         sizes="180px"
                     />
                 ) : (
-                    <ImagePlaceholder id={location.id} />
+                    <ImagePlaceholder id={location.id} className="absolute inset-0" />
                 )}
             </div>
 

--- a/frontend/src/components/searchpage/production-list/ProductionList.tsx
+++ b/frontend/src/components/searchpage/production-list/ProductionList.tsx
@@ -12,6 +12,7 @@ import { getLocalizedField } from "@/lib/locale";
 import { useGetEventsByProduction } from "@/hooks/api/useEvents";
 import { Skeleton } from "@/components/ui/skeleton";
 import { EntityTagStrip } from "@/components/shared/entity-tag-strip";
+import { ImagePlaceholder } from "@/components/shared/image-placeholder";
 
 interface ProductionItemProps {
     production: Production;
@@ -119,7 +120,7 @@ export function ProductionItem({ production, locale }: ProductionItemProps) {
                             sizes="180px"
                         />
                     ) : (
-                        <div className="h-full w-full bg-gradient-to-br from-[#CCC6BC] to-[#B5AEA4]" />
+                        <ImagePlaceholder className="h-full w-full" />
                     )}
                 </div>
 

--- a/frontend/src/components/searchpage/search-hero/SearchHero.tsx
+++ b/frontend/src/components/searchpage/search-hero/SearchHero.tsx
@@ -40,15 +40,8 @@ export const SearchHero = forwardRef<HTMLDivElement, SearchHeroProps>(function S
                     }}
                     placeholder={t("heroPlaceholder")}
                     autoComplete="off"
-                    className="border-foreground focus:border-primary font-display text-foreground placeholder:text-muted-foreground w-full border-b-2 bg-transparent pt-3 pr-24 pb-3 pl-[34px] text-[18px] font-normal transition-all outline-none placeholder:italic sm:pr-28 sm:text-[22px]"
+                    className="border-foreground focus:border-primary font-display text-foreground placeholder:text-muted-foreground w-full border-b-2 bg-transparent pt-3 pr-4 pb-3 pl-[34px] text-[18px] font-normal transition-all outline-none placeholder:italic sm:text-[22px]"
                 />
-                <span className="text-muted-foreground absolute top-1/2 right-0 hidden -translate-y-1/2 items-center gap-1.5 font-mono text-[9px] tracking-[1.2px] uppercase sm:flex">
-                    {t("enter")}
-                    <kbd className="border-border flex items-center justify-center border px-[5px] py-0.5">
-                        ↵
-                    </kbd>
-                </span>
-
                 <div className="bg-primary absolute -bottom-[2px] left-0 h-[2.5px] w-0 transition-all duration-500 group-focus-within:w-full group-focus-within:shadow-[0_4px_16px_rgba(var(--primary-rgb),0.6)]" />
             </div>
         </div>

--- a/frontend/src/components/searchpage/search-hero/SearchHero.tsx
+++ b/frontend/src/components/searchpage/search-hero/SearchHero.tsx
@@ -40,8 +40,15 @@ export const SearchHero = forwardRef<HTMLDivElement, SearchHeroProps>(function S
                     }}
                     placeholder={t("heroPlaceholder")}
                     autoComplete="off"
-                    className="border-foreground focus:border-primary font-display text-foreground placeholder:text-muted-foreground w-full border-b-2 bg-transparent pt-3 pr-4 pb-3 pl-[34px] text-[18px] font-normal transition-all outline-none placeholder:italic sm:text-[22px]"
+                    className="border-foreground focus:border-primary font-display text-foreground placeholder:text-muted-foreground w-full border-b-2 bg-transparent pt-3 pr-24 pb-3 pl-[34px] text-[18px] font-normal transition-all outline-none placeholder:italic sm:pr-28 sm:text-[22px]"
                 />
+                <span className="text-muted-foreground absolute top-1/2 right-0 hidden -translate-y-1/2 items-center gap-1.5 font-mono text-[9px] tracking-[1.2px] uppercase sm:flex">
+                    {t("enter")}
+                    <kbd className="border-border flex items-center justify-center border px-[5px] py-0.5">
+                        ↵
+                    </kbd>
+                </span>
+
                 <div className="bg-primary absolute -bottom-[2px] left-0 h-[2.5px] w-0 transition-all duration-500 group-focus-within:w-full group-focus-within:shadow-[0_4px_16px_rgba(var(--primary-rgb),0.6)]" />
             </div>
         </div>

--- a/frontend/src/components/shared/image-placeholder.tsx
+++ b/frontend/src/components/shared/image-placeholder.tsx
@@ -7,7 +7,7 @@ interface ImagePlaceholderProps {
 
 export function ImagePlaceholder({ id, className = "" }: ImagePlaceholderProps) {
     return (
-        <div className={`relative ${className}`}>
+        <div data-testid="image-placeholder" className={`relative ${className}`}>
             <div
                 className="absolute inset-0 opacity-[0.08]"
                 style={{

--- a/frontend/src/components/shared/image-placeholder.tsx
+++ b/frontend/src/components/shared/image-placeholder.tsx
@@ -7,7 +7,7 @@ interface ImagePlaceholderProps {
 
 export function ImagePlaceholder({ id, className = "" }: ImagePlaceholderProps) {
     return (
-        <div className={`absolute inset-0 ${className}`}>
+        <div className={`relative ${className}`}>
             <div
                 className="absolute inset-0 opacity-[0.08]"
                 style={{

--- a/frontend/src/components/shared/image-placeholder.tsx
+++ b/frontend/src/components/shared/image-placeholder.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+interface ImagePlaceholderProps {
+    id?: string;
+    className?: string;
+}
+
+export function ImagePlaceholder({ id, className = "" }: ImagePlaceholderProps) {
+    return (
+        <div className={`absolute inset-0 ${className}`}>
+            <div
+                className="absolute inset-0 opacity-[0.08]"
+                style={{
+                    backgroundImage:
+                        "repeating-linear-gradient(45deg, currentColor 0 1px, transparent 1px 8px)",
+                }}
+            />
+            {id && (
+                <div className="absolute inset-0 flex items-center justify-center">
+                    <span className="text-muted-foreground/60 font-mono text-[9px] tracking-[2px] uppercase">
+                        N°{id.slice(-3)}
+                    </span>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -256,7 +256,8 @@
             "saving": "Saving…"
         },
         "DataTable": {
-            "noResults": "No results."
+            "noResults": "No results.",
+            "selectRow": "Select row"
         },
         "ActionBar": {
             "clearSelection": "Clear selection",

--- a/frontend/src/messages/nl.json
+++ b/frontend/src/messages/nl.json
@@ -256,7 +256,8 @@
             "saving": "Bezig met opslaan…"
         },
         "DataTable": {
-            "noResults": "Geen resultaten."
+            "noResults": "Geen resultaten.",
+            "selectRow": "Rij selecteren"
         },
         "ActionBar": {
             "clearSelection": "Selectie wissen",

--- a/frontend/test/unit/components/cms/cms-thumbnail.test.tsx
+++ b/frontend/test/unit/components/cms/cms-thumbnail.test.tsx
@@ -14,7 +14,7 @@ describe("CmsThumbnail", () => {
     });
 
     it("renders the shared fallback box when no source exists", () => {
-        const { container } = render(<CmsThumbnail src={null} alt="Fallback image" />);
-        expect(container.querySelector(".bg-gradient-to-br")).toBeInTheDocument();
+        render(<CmsThumbnail src={null} alt="Fallback image" />);
+        expect(screen.getByTestId("image-placeholder")).toBeInTheDocument();
     });
 });

--- a/frontend/test/unit/components/cms/data-table-selection.test.tsx
+++ b/frontend/test/unit/components/cms/data-table-selection.test.tsx
@@ -1,0 +1,71 @@
+import { ColumnDef, RowSelectionState } from "@tanstack/react-table";
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import { useState } from "react";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+import { DataTable } from "@/app/[locale]/(cms)/cms/tables/data-table";
+import messages from "@/messages/en.json";
+
+type RowData = {
+    id: string;
+    name: string;
+};
+
+const columns: ColumnDef<RowData>[] = [
+    {
+        accessorKey: "name",
+        header: "Name",
+    },
+];
+
+const rows: RowData[] = [
+    { id: "1", name: "Alpha" },
+    { id: "2", name: "Beta" },
+    { id: "3", name: "Gamma" },
+];
+
+function SelectableTable() {
+    const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+
+    return (
+        <NextIntlClientProvider locale="en" messages={messages}>
+            <DataTable
+                columns={columns}
+                data={rows}
+                rowSelection={rowSelection}
+                onRowSelectionChange={(updater) => {
+                    setRowSelection((prev) =>
+                        typeof updater === "function" ? updater(prev) : updater
+                    );
+                }}
+                getRowId={(row) => row.id}
+            />
+        </NextIntlClientProvider>
+    );
+}
+
+beforeAll(() => {
+    Element.prototype.scrollIntoView = vi.fn();
+});
+
+describe("DataTable selection", () => {
+    it("extends selection with shift-click on row checkboxes", async () => {
+        const user = userEvent.setup();
+        render(<SelectableTable />);
+
+        const checkboxes = screen.getAllByRole("checkbox", { name: "Select row" });
+
+        await user.click(checkboxes[0]);
+        expect(checkboxes[0]).toHaveAttribute("aria-checked", "true");
+        expect(checkboxes[1]).toHaveAttribute("aria-checked", "false");
+        expect(checkboxes[2]).toHaveAttribute("aria-checked", "false");
+
+        fireEvent.click(checkboxes[2], { shiftKey: true });
+
+        expect(checkboxes[0]).toHaveAttribute("aria-checked", "true");
+        expect(checkboxes[1]).toHaveAttribute("aria-checked", "true");
+        expect(checkboxes[2]).toHaveAttribute("aria-checked", "true");
+    });
+});

--- a/frontend/test/unit/components/collections/collection-header.test.tsx
+++ b/frontend/test/unit/components/collections/collection-header.test.tsx
@@ -97,9 +97,9 @@ describe("CollectionHeader", () => {
         expect(screen.queryByText("A test description.")).not.toBeInTheDocument();
     });
 
-    it("renders the cover image gradient placeholder", () => {
+    it("renders no cover image block when no cover image exists", () => {
         const { container } = renderWithIntl(<CollectionHeader collection={makeCollection()} />);
-        const placeholder = container.querySelector(".bg-gradient-to-br");
-        expect(placeholder).toBeInTheDocument();
+        expect(container.querySelector(".bg-gradient-to-br")).not.toBeInTheDocument();
+        expect(screen.queryByRole("img")).not.toBeInTheDocument();
     });
 });

--- a/frontend/test/unit/components/searchpage/ProductionList.test.tsx
+++ b/frontend/test/unit/components/searchpage/ProductionList.test.tsx
@@ -102,7 +102,7 @@ describe("ProductionList component", () => {
         expect(img).toHaveAttribute("alt", "prod-1");
     });
 
-    it("renders placeholder gradient when coverImageUrl is null", () => {
+    it("renders image placeholder when coverImageUrl is null", () => {
         const { container } = renderWithIntl(
             <ProductionList productions={mockProductions} locale="en" />
         );
@@ -110,7 +110,6 @@ describe("ProductionList component", () => {
         const images = container.querySelectorAll("img");
         expect(images).toHaveLength(0);
 
-        const gradients = container.querySelectorAll(".bg-gradient-to-br");
-        expect(gradients.length).toBeGreaterThan(0);
+        expect(screen.getAllByTestId("image-placeholder").length).toBeGreaterThan(0);
     });
 });

--- a/frontend/test/unit/components/searchpage/filterProductionsByArchiveFilters.test.ts
+++ b/frontend/test/unit/components/searchpage/filterProductionsByArchiveFilters.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import { filterProductionsByArchiveFilters } from "@/components/searchpage/filterProductionsByArchiveFilters";
+import type { Event } from "@/types/models/event.types";
+import type { Production } from "@/types/models/production.types";
+
+const production = (id: string): Production => ({
+    id,
+    sourceId: null,
+    slug: `production-${id}`,
+    video1: null,
+    video2: null,
+    eticketInfo: null,
+    uitdatabankTheme: null,
+    uitdatabankType: null,
+    translations: [],
+    coverImageUrl: null,
+});
+
+const event = (id: string, productionId: string, startsAt: string): Event => ({
+    id,
+    sourceId: null,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    startsAt,
+    endsAt: null,
+    intermissionAt: null,
+    doorsAt: null,
+    vendorId: null,
+    boxOfficeId: null,
+    uitdatabankId: null,
+    maxTicketsPerOrder: null,
+    productionId,
+    status: "published",
+    hallId: null,
+    prices: [],
+});
+
+describe("filterProductionsByArchiveFilters", () => {
+    it("returns no productions when the production category is disabled", () => {
+        const result = filterProductionsByArchiveFilters([production("p1")], undefined, {
+            categories: new Set(["articles"]),
+            dateRange: [new Date("2020-01-01"), new Date("2020-12-31")],
+        });
+
+        expect(result).toEqual([]);
+    });
+
+    it("keeps all productions when no date filter is active", () => {
+        const result = filterProductionsByArchiveFilters(
+            [production("p1"), production("p2")],
+            [],
+            {
+                categories: new Set(["productions"]),
+                dateRange: [new Date("1980-01-01"), new Date("2026-12-31")],
+            },
+            { hasActiveDateFilter: false }
+        );
+
+        expect(result.map((item) => item.id)).toEqual(["p1", "p2"]);
+    });
+
+    it("filters productions to those with an event inside the selected year range", () => {
+        const result = filterProductionsByArchiveFilters(
+            [production("p1"), production("p2")],
+            [event("e1", "p1", "2020-05-10T20:00:00Z"), event("e2", "p2", "1999-05-10T20:00:00Z")],
+            {
+                categories: new Set(["productions"]),
+                dateRange: [new Date("2020-01-01"), new Date("2020-12-31T23:59:59.999Z")],
+            },
+            { hasActiveDateFilter: true }
+        );
+
+        expect(result.map((item) => item.id)).toEqual(["p1"]);
+    });
+});

--- a/frontend/test/unit/components/searchpage/filterProductionsByArchiveFilters.test.ts
+++ b/frontend/test/unit/components/searchpage/filterProductionsByArchiveFilters.test.ts
@@ -15,6 +15,8 @@ const production = (id: string): Production => ({
     uitdatabankType: null,
     translations: [],
     coverImageUrl: null,
+    locations: [],
+    tags: [],
 });
 
 const event = (id: string, productionId: string, startsAt: string): Event => ({
@@ -32,7 +34,7 @@ const event = (id: string, productionId: string, startsAt: string): Event => ({
     maxTicketsPerOrder: null,
     productionId,
     status: "published",
-    hallId: null,
+    hallIds: [],
     prices: [],
 });
 


### PR DESCRIPTION
**Description**
- Search page: 300ms debounced live search (no more Enter required), Enter still works
- Production related cards: strip raw UiTdatabank API URLs from uitdatabankType
- "Part of" heading: match "More from the archive" style (font-display, 22px, bold)
- Part of cards: match More from archive hover/border style
- Shared ImagePlaceholder component: diagonal stripe placeholder replaces all inline gradient fallbacks
- Collection header: render nothing when no cover image
- CMS sidebar: fix prefix matching so /cms/import doesn't highlight on /cms/import-errors


**How Has This Been Tested?**
- [x] Local manual testing
- [ ] Added/updated unit or integration tests
- [ ] Tested in the staging environment

**Developer Checklist:**
- [ ] I have performed a self-review of my own code.
- [ ] I have left comments in hard-to-understand areas of my code.
- [ ] My changes generate no new warnings or console errors.
- [ ] I have updated the documentation (if applicable).

**Screenshots / Video (if UI/UX changed):**
