### PR TITLE
fix(cms): keyboard selection

### DIFF
--- a/frontend/src/app/[locale]/(cms)/cms/tables/use-table-selection.tsx
+++ b/frontend/src/app/[locale]/(cms)/cms/tables/use-table-selection.tsx
@@ -227,6 +227,9 @@ export function useTableSelection<TData>({
                 const next = focusedIdx === -1 ? 0 : Math.min(focusedIdx + 1, rows.length - 1);
                 if (event.shiftKey && anchorId) {
                     selectRangeRef.current(anchorId, rows[next].id);
+                } else {
+                    onRowSelectionChangeRef.current?.({ [rows[next].id]: true });
+                    setAnchorRowId(rows[next].id);
                 }
                 focusRowRef.current(next);
             } else if (event.key === "ArrowUp" || event.key === "k") {
@@ -234,6 +237,9 @@ export function useTableSelection<TData>({
                 const next = focusedIdx === -1 ? -1 : Math.max(focusedIdx - 1, 0);
                 if (next >= 0 && event.shiftKey && anchorId) {
                     selectRangeRef.current(anchorId, rows[next].id);
+                } else if (next >= 0) {
+                    onRowSelectionChangeRef.current?.({ [rows[next].id]: true });
+                    setAnchorRowId(rows[next].id);
                 }
                 if (next >= 0) focusRowRef.current(next);
             } else if (event.key === "g") {

--- a/frontend/src/app/[locale]/(cms)/cms/tables/use-table-selection.tsx
+++ b/frontend/src/app/[locale]/(cms)/cms/tables/use-table-selection.tsx
@@ -196,7 +196,7 @@ export function useTableSelection<TData>({
                 setAnchorRowId(rowId);
                 focusRowRef.current(rowIndex);
             } else {
-                toggleRowRef.current(rowId);
+                onRowSelectionChangeRef.current?.({ [rowId]: true });
                 setAnchorRowId(rowId);
                 focusRowRef.current(rowIndex);
             }

--- a/frontend/src/app/[locale]/(cms)/cms/tables/use-table-selection.tsx
+++ b/frontend/src/app/[locale]/(cms)/cms/tables/use-table-selection.tsx
@@ -227,9 +227,6 @@ export function useTableSelection<TData>({
                 const next = focusedIdx === -1 ? 0 : Math.min(focusedIdx + 1, rows.length - 1);
                 if (event.shiftKey && anchorId) {
                     selectRangeRef.current(anchorId, rows[next].id);
-                } else {
-                    onRowSelectionChangeRef.current?.({ [rows[next].id]: true });
-                    setAnchorRowId(rows[next].id);
                 }
                 focusRowRef.current(next);
             } else if (event.key === "ArrowUp" || event.key === "k") {
@@ -237,9 +234,6 @@ export function useTableSelection<TData>({
                 const next = focusedIdx === -1 ? -1 : Math.max(focusedIdx - 1, 0);
                 if (next >= 0 && event.shiftKey && anchorId) {
                     selectRangeRef.current(anchorId, rows[next].id);
-                } else if (next >= 0) {
-                    onRowSelectionChangeRef.current?.({ [rows[next].id]: true });
-                    setAnchorRowId(rows[next].id);
                 }
                 if (next >= 0) focusRowRef.current(next);
             } else if (event.key === "g") {

--- a/frontend/test/unit/components/cms/parent-child-selection.test.tsx
+++ b/frontend/test/unit/components/cms/parent-child-selection.test.tsx
@@ -160,7 +160,7 @@ describe("useParentChildSelection", () => {
         expect(screen.getByRole("columnheader", { name: "Label" })).toHaveClass("text-foreground");
     });
 
-    it("deselects the clicked row when multiple plain table rows are selected", () => {
+    it("replaces selection on plain row click when multiple rows are selected", () => {
         render(
             <NextIntlClientProvider locale="en" messages={messages}>
                 <PlainSelectionHarness />
@@ -170,16 +170,14 @@ describe("useParentChildSelection", () => {
         const checkboxes = screen.getAllByRole("checkbox");
 
         fireEvent.click(checkboxes[0]);
-        fireEvent.click(checkboxes[1]);
-        fireEvent.click(checkboxes[2]);
+        fireEvent.click(checkboxes[1], { ctrlKey: true });
+        fireEvent.click(checkboxes[2], { ctrlKey: true });
         expect(screen.getByTestId("plain-selected")).toHaveTextContent("p1,p2,p3");
 
-        fireEvent.click(checkboxes[1]);
+        // Plain click on row text should replace selection, not toggle
+        fireEvent.click(screen.getByText("Production 1"));
 
-        expect(screen.getByTestId("plain-selected")).toHaveTextContent("p1,p3");
-        expect(checkboxes[0]).toHaveAttribute("aria-checked", "true");
-        expect(checkboxes[1]).toHaveAttribute("aria-checked", "false");
-        expect(checkboxes[2]).toHaveAttribute("aria-checked", "true");
+        expect(screen.getByTestId("plain-selected")).toHaveTextContent("p1");
     });
 
     it("deselects the ctrl-clicked row when multiple plain table rows are selected", () => {
@@ -199,20 +197,28 @@ describe("useParentChildSelection", () => {
         expect(screen.getByTestId("plain-selected")).toHaveTextContent("p1,p3");
     });
 
-    it("toggles plain table rows so multiple rows can be selected without modifiers", () => {
+    it("replaces selection on plain click and toggles with ctrl+click", () => {
         render(
             <NextIntlClientProvider locale="en" messages={messages}>
                 <PlainSelectionHarness />
             </NextIntlClientProvider>
         );
 
+        // Plain click selects only that row
         fireEvent.click(screen.getByText("Production 1"));
+        expect(screen.getByTestId("plain-selected")).toHaveTextContent("p1");
+
+        // Another plain click replaces
         fireEvent.click(screen.getByText("Production 2"));
-        fireEvent.click(screen.getByText("Production 3"));
+        expect(screen.getByTestId("plain-selected")).toHaveTextContent("p2");
+
+        // Ctrl+click toggles (adds row to selection)
+        fireEvent.click(screen.getByText("Production 1"), { ctrlKey: true });
+        fireEvent.click(screen.getByText("Production 3"), { ctrlKey: true });
         expect(screen.getByTestId("plain-selected")).toHaveTextContent("p1,p2,p3");
 
-        fireEvent.click(screen.getByText("Production 2"));
-
+        // Ctrl+click toggles (removes row from selection)
+        fireEvent.click(screen.getByText("Production 2"), { ctrlKey: true });
         expect(screen.getByTestId("plain-selected")).toHaveTextContent("p1,p3");
     });
 
@@ -221,25 +227,25 @@ describe("useParentChildSelection", () => {
 
         const [parentCheckbox] = screen.getAllByRole("checkbox");
 
-        fireEvent.click(parentCheckbox);
-        fireEvent.click(parentCheckbox);
+        fireEvent.click(parentCheckbox, { ctrlKey: true });
+        fireEvent.click(parentCheckbox, { ctrlKey: true });
 
         expect(screen.getByTestId("counts")).toHaveTextContent("0:0:1");
         expect(parentCheckbox).toHaveAttribute("aria-checked", "false");
     });
 
-    it("deselects the clicked parent row without changing the last selected parent", () => {
+    it("toggles the ctrl-clicked parent row without changing other selected parents", () => {
         renderSelectionHarness();
 
         let checkboxes = screen.getAllByRole("checkbox");
 
-        fireEvent.click(checkboxes[0]);
-        fireEvent.click(checkboxes[2]);
-        fireEvent.click(checkboxes[4]);
+        fireEvent.click(checkboxes[0], { ctrlKey: true });
+        fireEvent.click(checkboxes[2], { ctrlKey: true });
+        fireEvent.click(checkboxes[4], { ctrlKey: true });
         expect(screen.getByTestId("counts")).toHaveTextContent("3:3:3");
 
         checkboxes = screen.getAllByRole("checkbox");
-        fireEvent.click(checkboxes[2]);
+        fireEvent.click(checkboxes[2], { ctrlKey: true });
 
         checkboxes = screen.getAllByRole("checkbox");
         expect(screen.getByTestId("counts")).toHaveTextContent("2:2:3");

--- a/frontend/test/unit/components/cms/use-table-selection.test.tsx
+++ b/frontend/test/unit/components/cms/use-table-selection.test.tsx
@@ -89,9 +89,27 @@ describe("useTableSelection", () => {
             });
 
             expect(onRowSelectionChange).toHaveBeenCalled();
-            const updater = onRowSelectionChange.mock.calls[0][0];
-            expect(typeof updater).toBe("function");
-            expect(updater({})).toEqual({ "row-1": true });
+            const callArg = onRowSelectionChange.mock.calls[0][0];
+            expect(callArg).toEqual({ "row-1": true });
+        });
+
+        it("replaces existing selection on plain click", () => {
+            const existingSelection = { "row-0": true, "row-2": true };
+            const { result } = setup({ rowSelection: existingSelection });
+
+            act(() => {
+                result.current.handleRowClick(rows[1], {
+                    target: document.createElement("div"),
+                    stopPropagation: vi.fn(),
+                    preventDefault: vi.fn(),
+                } as unknown as React.MouseEvent);
+            });
+
+            expect(onRowSelectionChange).toHaveBeenCalled();
+            // plain click should call onRowSelectionChange with { row-1: true },
+            // replacing the old selection, not toggling
+            const callArg = onRowSelectionChange.mock.calls[0][0];
+            expect(callArg).toEqual({ "row-1": true });
         });
 
         it("toggles a row on ctrl+click", () => {


### PR DESCRIPTION
**Description**
Fixes keyboard select with vim key binds no longer working properly and fixes the mouse select to select a single row unless cmd/ctrl is hold... (shift+click etc still works)

**How Has This Been Tested?**
- [x] Local manual testing
- [ ] Added/updated unit or integration tests
- [ ] Tested in the staging environment