### PR TITLE
Fix(searchpage): cover fallback to entity media

### DIFF
--- a/frontend/src/components/searchpage/production-list/ProductionList.tsx
+++ b/frontend/src/components/searchpage/production-list/ProductionList.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import Image from "next/image";
+import { ResultCoverImage } from "@/components/shared/result-cover-image";
 import { useTranslations } from "next-intl";
 import { ChevronDown } from "lucide-react";
 import { Link } from "@/i18n/routing";
@@ -12,7 +12,6 @@ import { getLocalizedField } from "@/lib/locale";
 import { useGetEventsByProduction } from "@/hooks/api/useEvents";
 import { Skeleton } from "@/components/ui/skeleton";
 import { EntityTagStrip } from "@/components/shared/entity-tag-strip";
-import { ImagePlaceholder } from "@/components/shared/image-placeholder";
 
 interface ProductionItemProps {
     production: Production;
@@ -110,19 +109,15 @@ export function ProductionItem({ production, locale }: ProductionItemProps) {
                 }`}
                 style={{ animation: "fadein 0.3s ease both" }}
             >
-                <div className="bg-muted relative h-[108px] w-[144px] shrink-0 overflow-hidden sm:h-[136px] sm:w-[180px]">
-                    {production.coverImageUrl ? (
-                        <Image
-                            src={production.coverImageUrl}
-                            alt={title}
-                            fill
-                            className="object-cover"
-                            sizes="180px"
-                        />
-                    ) : (
-                        <ImagePlaceholder className="h-full w-full" />
-                    )}
-                </div>
+                <ResultCoverImage
+                    entityType="production"
+                    entityId={production.id}
+                    coverImageUrl={production.coverImageUrl}
+                    alt={title}
+                    sizes="180px"
+                    wrapperClassName="bg-muted relative h-[108px] w-[144px] shrink-0 overflow-hidden sm:h-[136px] sm:w-[180px]"
+                    placeholderClassName="h-full w-full"
+                />
 
                 <div className="min-w-0 flex-1">
                     <Link

--- a/frontend/src/components/shared/index.ts
+++ b/frontend/src/components/shared/index.ts
@@ -3,3 +3,4 @@ export * from "./theme-switcher/ThemeSwitcher";
 export * from "./loading-state";
 export * from "./page-header";
 export * from "./dashboard-card";
+export * from "./result-cover-image";

--- a/frontend/src/components/shared/result-cover-image.tsx
+++ b/frontend/src/components/shared/result-cover-image.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import { useGetEntityMedia } from "@/hooks/api/useMedia";
+import { ImagePlaceholder } from "@/components/shared/image-placeholder";
+
+type EntityType = "production" | "article" | "artist" | "location" | "collection";
+
+interface ResultCoverImageProps {
+    entityType: EntityType;
+    entityId: string;
+    coverImageUrl: string | null | undefined;
+    alt: string;
+    sizes: string;
+    wrapperClassName: string;
+    imageClassName?: string;
+    placeholderId?: string;
+    placeholderClassName?: string;
+}
+
+export function ResultCoverImage({
+    entityType,
+    entityId,
+    coverImageUrl,
+    alt,
+    sizes,
+    wrapperClassName,
+    imageClassName = "object-cover",
+    placeholderId,
+    placeholderClassName = "absolute inset-0",
+}: ResultCoverImageProps) {
+    const [coverFailed, setCoverFailed] = useState(false);
+    const useFallback = !coverImageUrl || coverFailed;
+
+    const { data: media } = useGetEntityMedia(entityType, entityId, {
+        enabled: useFallback,
+    });
+
+    const fallbackUrl = useFallback
+        ? (media?.find((m) => m.url && m.url !== coverImageUrl)?.url ?? null)
+        : null;
+
+    const src = useFallback ? fallbackUrl : coverImageUrl;
+
+    return (
+        <div className={wrapperClassName}>
+            {src ? (
+                <Image
+                    key={src}
+                    src={src}
+                    alt={alt}
+                    fill
+                    className={imageClassName}
+                    sizes={sizes}
+                    onError={() => {
+                        if (!coverFailed) setCoverFailed(true);
+                    }}
+                />
+            ) : (
+                <ImagePlaceholder id={placeholderId} className={placeholderClassName} />
+            )}
+        </div>
+    );
+}

--- a/frontend/src/components/shared/result-cover-image.tsx
+++ b/frontend/src/components/shared/result-cover-image.tsx
@@ -30,7 +30,8 @@ export function ResultCoverImage({
     placeholderId,
     placeholderClassName = "absolute inset-0",
 }: ResultCoverImageProps) {
-    const [coverFailed, setCoverFailed] = useState(false);
+    const [failedUrls, setFailedUrls] = useState<Set<string>>(() => new Set());
+    const coverFailed = !!coverImageUrl && failedUrls.has(coverImageUrl);
     const useFallback = !coverImageUrl || coverFailed;
 
     const { data: media } = useGetEntityMedia(entityType, entityId, {
@@ -38,10 +39,20 @@ export function ResultCoverImage({
     });
 
     const fallbackUrl = useFallback
-        ? (media?.find((m) => m.url && m.url !== coverImageUrl)?.url ?? null)
+        ? (media?.find((m) => m.url && m.url !== coverImageUrl && !failedUrls.has(m.url))?.url ??
+          null)
         : null;
 
     const src = useFallback ? fallbackUrl : coverImageUrl;
+
+    const handleError = (failedSrc: string) => {
+        setFailedUrls((prev) => {
+            if (prev.has(failedSrc)) return prev;
+            const next = new Set(prev);
+            next.add(failedSrc);
+            return next;
+        });
+    };
 
     return (
         <div className={wrapperClassName}>
@@ -53,9 +64,7 @@ export function ResultCoverImage({
                     fill
                     className={imageClassName}
                     sizes={sizes}
-                    onError={() => {
-                        if (!coverFailed) setCoverFailed(true);
-                    }}
+                    onError={() => handleError(src)}
                 />
             ) : (
                 <ImagePlaceholder id={placeholderId} className={placeholderClassName} />

--- a/frontend/test/unit/components/shared/result-cover-image.test.tsx
+++ b/frontend/test/unit/components/shared/result-cover-image.test.tsx
@@ -1,0 +1,121 @@
+import { describe, expect, it, afterEach, vi } from "vitest";
+import { fireEvent } from "@testing-library/react";
+import { render, screen, cleanup } from "../../../utils/test-utils";
+
+const useGetEntityMediaMock = vi.fn();
+
+vi.mock("@/hooks/api/useMedia", () => ({
+    useGetEntityMedia: (...args: unknown[]) => useGetEntityMediaMock(...args),
+}));
+
+vi.mock("next/image", () => ({
+    __esModule: true,
+    default: ({ src, alt, onError }: { src: string; alt: string; onError?: () => void }) => (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img data-testid="result-img" src={src} alt={alt} onError={onError} />
+    ),
+}));
+
+import { ResultCoverImage } from "@/components/shared/result-cover-image";
+
+const COVER = "https://cdn.example/cover.jpg";
+const FALLBACK = "https://cdn.example/fallback.jpg";
+
+const WRAPPER = "wrapper-class";
+
+describe("ResultCoverImage", () => {
+    afterEach(() => {
+        cleanup();
+        useGetEntityMediaMock.mockReset();
+    });
+
+    it("renders the cover image when coverImageUrl is provided and does not fetch fallback media", () => {
+        useGetEntityMediaMock.mockReturnValue({ data: undefined });
+
+        render(
+            <ResultCoverImage
+                entityType="production"
+                entityId="p1"
+                coverImageUrl={COVER}
+                alt="cover"
+                sizes="180px"
+                wrapperClassName={WRAPPER}
+            />
+        );
+
+        const img = screen.getByTestId("result-img");
+        expect(img).toHaveAttribute("src", COVER);
+        expect(useGetEntityMediaMock).toHaveBeenCalledWith(
+            "production",
+            "p1",
+            expect.objectContaining({ enabled: false })
+        );
+    });
+
+    it("falls back to first linked media when coverImageUrl is null", () => {
+        useGetEntityMediaMock.mockReturnValue({
+            data: [{ url: FALLBACK }, { url: "https://cdn.example/other.jpg" }],
+        });
+
+        render(
+            <ResultCoverImage
+                entityType="production"
+                entityId="p2"
+                coverImageUrl={null}
+                alt="cover"
+                sizes="180px"
+                wrapperClassName={WRAPPER}
+            />
+        );
+
+        expect(screen.getByTestId("result-img")).toHaveAttribute("src", FALLBACK);
+        expect(useGetEntityMediaMock).toHaveBeenCalledWith(
+            "production",
+            "p2",
+            expect.objectContaining({ enabled: true })
+        );
+    });
+
+    it("switches to fallback media when the cover image errors", () => {
+        useGetEntityMediaMock.mockReturnValue({
+            data: [{ url: COVER }, { url: FALLBACK }],
+        });
+
+        render(
+            <ResultCoverImage
+                entityType="production"
+                entityId="p3"
+                coverImageUrl={COVER}
+                alt="cover"
+                sizes="180px"
+                wrapperClassName={WRAPPER}
+            />
+        );
+
+        const img = screen.getByTestId("result-img");
+        expect(img).toHaveAttribute("src", COVER);
+
+        fireEvent.error(img);
+
+        expect(screen.getByTestId("result-img")).toHaveAttribute("src", FALLBACK);
+    });
+
+    it("renders the placeholder when no cover and no linked media exist", () => {
+        useGetEntityMediaMock.mockReturnValue({ data: [] });
+
+        render(
+            <ResultCoverImage
+                entityType="production"
+                entityId="p4"
+                coverImageUrl={null}
+                alt="cover"
+                sizes="180px"
+                wrapperClassName={WRAPPER}
+                placeholderId="p4"
+            />
+        );
+
+        expect(screen.queryByTestId("result-img")).toBeNull();
+        expect(screen.getByTestId("image-placeholder")).toBeInTheDocument();
+    });
+});

--- a/frontend/test/unit/components/shared/result-cover-image.test.tsx
+++ b/frontend/test/unit/components/shared/result-cover-image.test.tsx
@@ -100,6 +100,57 @@ describe("ResultCoverImage", () => {
         expect(screen.getByTestId("result-img")).toHaveAttribute("src", FALLBACK);
     });
 
+    it("advances to next media when the first fallback also errors", () => {
+        const SECOND_FALLBACK = "https://cdn.example/second.jpg";
+        useGetEntityMediaMock.mockReturnValue({
+            data: [{ url: FALLBACK }, { url: SECOND_FALLBACK }],
+        });
+
+        render(
+            <ResultCoverImage
+                entityType="production"
+                entityId="p5"
+                coverImageUrl={null}
+                alt="cover"
+                sizes="180px"
+                wrapperClassName={WRAPPER}
+            />
+        );
+
+        const first = screen.getByTestId("result-img");
+        expect(first).toHaveAttribute("src", FALLBACK);
+
+        fireEvent.error(first);
+
+        expect(screen.getByTestId("result-img")).toHaveAttribute("src", SECOND_FALLBACK);
+    });
+
+    it("renders the placeholder when the fallback media also errors and no more exist", () => {
+        useGetEntityMediaMock.mockReturnValue({
+            data: [{ url: FALLBACK }],
+        });
+
+        render(
+            <ResultCoverImage
+                entityType="production"
+                entityId="p6"
+                coverImageUrl={null}
+                alt="cover"
+                sizes="180px"
+                wrapperClassName={WRAPPER}
+                placeholderId="p6"
+            />
+        );
+
+        const img = screen.getByTestId("result-img");
+        expect(img).toHaveAttribute("src", FALLBACK);
+
+        fireEvent.error(img);
+
+        expect(screen.queryByTestId("result-img")).toBeNull();
+        expect(screen.getByTestId("image-placeholder")).toBeInTheDocument();
+    });
+
     it("renders the placeholder when no cover and no linked media exist", () => {
         useGetEntityMediaMock.mockReturnValue({ data: [] });
 


### PR DESCRIPTION
**Description**
  Production cover_image_url often NULL . Search results show blank.
  Fix: new ResultCoverImage component. Try cover_image_url first. Fallback to first linked media. Else ImagePlaceholder.

**Related Issue**
Fixes #

**How Has This Been Tested?**
- [ ] Local manual testing
- [ ] Added/updated unit or integration tests
- [ ] Tested in the staging environment

**Developer Checklist:**
- [ ] I have performed a self-review of my own code.
- [ ] I have left comments in hard-to-understand areas of my code.
- [ ] My changes generate no new warnings or console errors.
- [ ] I have updated the documentation (if applicable).

**Screenshots / Video (if UI/UX changed):**
